### PR TITLE
WIP fscache: blob gc feature for fscache with inuse and cull

### DIFF
--- a/src/bin/nydusd/fs_cache.rs
+++ b/src/bin/nydusd/fs_cache.rs
@@ -565,6 +565,7 @@ impl FsCacheHandler {
             let filetype = metadata.file_type();
             let filename = entry.file_name().to_str().unwrap().to_string();
             let objtype = FsCacheObjType::get_fscache_objtype(&filename);
+            // TODO skip chunk map and blob meta file
             // If objtype is not valid, skip this file.
             // If file is not dir but the objtype is Index or Intermediate, skip this file.
             // if neither directory nor regular file, skip this file.
@@ -589,6 +590,7 @@ impl FsCacheHandler {
                 entry,
             ));
         }
+
         Ok(file_atime_pq)
     }
 
@@ -633,12 +635,17 @@ impl FsCacheHandler {
                     }
                     FsCacheObjType::Data | FsCacheObjType::Special => {
                         inuse = self.check_if_in_use(&entry.filepath);
+                        if !inuse {
+                            // TODO extract the blobid from the blob file path.
+                            // TODO mark corresponding chunk map file as deleted and delete it.
+                        }
                     }
                     _ => {
                         // TODO this should be an error
                     }
                 }
                 if !inuse {
+                    // self.remove_blob_entry();
                     self.cull_file(entry.filepath.as_path());
                 }
             }

--- a/storage/src/cache/state/blob_state_map.rs
+++ b/storage/src/cache/state/blob_state_map.rs
@@ -164,6 +164,10 @@ where
         any.downcast_ref::<BlobStateMap<IndexedChunkMap, u32>>()
             .map(|v| v as &dyn RangeMap<I = u32>)
     }
+
+    fn is_deleted(&self) -> bool {
+        self.c.is_deleted()
+    }
 }
 
 impl RangeMap for BlobStateMap<IndexedChunkMap, u32> {

--- a/storage/src/cache/state/mod.rs
+++ b/storage/src/cache/state/mod.rs
@@ -86,6 +86,11 @@ pub trait ChunkMap: Any + Send + Sync {
     fn as_range_map(&self) -> Option<&dyn RangeMap<I = u32>> {
         None
     }
+
+    /// Check whether the on-disk file is deleted.
+    fn is_deleted(&self) -> bool {
+        false
+    }
 }
 
 /// Trait to track chunk or data readiness state.


### PR DESCRIPTION
This patch is still working in progress, hasn't been tested at all, very likely to have bugs or even errors.
Does anyone have suggestions on how can I test it?

Add blob gc for fscache by using `inuse` and `cull`,
this implementation reference the implementation of the `cachefilesd`,
but since we use ondemand mode, so it's sightly different.

The gc watermark for now is 95% used blocks or 95% used files,
in the future, we need to change it configurable.

#454

Signed-off-by: Qi Wang <wangqi@linux.alibaba.com>