### PR TITLE
refactor(nydus-core): rename NydusAccessor to NydusCore and clarify public API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,7 +2856,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-core"
-version = "0.1.2"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ UBLK_TIMEOUT ?= 300s
 UBLK_COUNT ?= 1
 UBLK_GO_TEST_ARGS ?=
 
-ACCESSOR_TIMEOUT ?= 900s
-ACCESSOR_COUNT ?= 1
-ACCESSOR_GO_TEST_ARGS ?=
+CORE_TIMEOUT ?= 900s
+CORE_COUNT ?= 1
+CORE_GO_TEST_ARGS ?=
 
 FANOTIFY_TIMEOUT ?= 600s
 FANOTIFY_COUNT ?= 1
@@ -75,7 +75,7 @@ TEST_SUPPORT_FILES = util.go optimize_util.go
 E2E_TEST_FILES = e2e_test.go $(TEST_SUPPORT_FILES)
 UFFD_TEST_FILES = uffd_test.go $(TEST_SUPPORT_FILES)
 UBLK_TEST_FILES = ublk_test.go $(TEST_SUPPORT_FILES)
-ACCESSOR_TEST_FILES = accessor_test.go $(TEST_SUPPORT_FILES)
+CORE_TEST_FILES = core_test.go $(TEST_SUPPORT_FILES)
 XFSTESTS_TEST_FILES = xfstests_test.go $(TEST_SUPPORT_FILES)
 PERF_TEST_FILES = perf_test.go $(TEST_SUPPORT_FILES)
 TOP_IMAGES_TEST_FILES = top_image_test.go $(TEST_SUPPORT_FILES)
@@ -89,7 +89,7 @@ FANOTIFY_PERF_TEST_PKG = .
 # fanotify_test.go, so the entire package must be compiled together.
 NBD_TEST_PKG = .
 
-.PHONY: build release nydusify test test-e2e test-uffd test-accessor test-fanotify test-nbd test-block-perf test-xfstests test-perf test-top-images crate clean
+.PHONY: build release nydusify test test-e2e test-uffd test-core test-fanotify test-nbd test-block-perf test-xfstests test-perf test-top-images crate clean
 
 build:
 	$(CARGO) build -p nydus --features "$(FEATURES)"
@@ -141,11 +141,11 @@ test-ublk: release
 # Run the cross-process blob cache tests. Requires root because they mount
 # several nydus FUSE instances against one shared --cache-dir and assert on the
 # cache directory plus each instance's /metrics endpoint.
-test-accessor: release
+test-core: release
 	@test -n "$(GO_BIN)" || { echo "go not found; set GO=/abs/path/to/go or GO_BIN=/abs/path/to/go"; exit 1; }
 	cd tests/integration && \
 		$(GO_TEST_ENV) \
-		$(GO_BIN) test -v -run '^TestAccessor' -count $(ACCESSOR_COUNT) -timeout $(ACCESSOR_TIMEOUT) $(ACCESSOR_GO_TEST_ARGS) $(ACCESSOR_TEST_FILES)
+		$(GO_BIN) test -v -run '^TestCore' -count $(CORE_COUNT) -timeout $(CORE_TIMEOUT) $(CORE_GO_TEST_ARGS) $(CORE_TEST_FILES)
 
 # Run the fanotify pre-content E2E test (requires root, Linux >= 6.15, docker
 # for the throwaway local registry). Builds nydus with the fanotify feature.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ redesign in Rust. Compared with Nydus v2 (RAFS), v3 brings:
   (`nydus fuse`), a read-only ublk block device (`nydus ublk`, Linux >= 6.0)
   that the kernel EROFS driver mounts directly, a device-level userfaultfd
   service (`nydus uffd`), a fanotify pre-content service (`nydus fanotify`,
-  Linux >= 6.15), and an embeddable accessor library (`NydusAccessor`) that
+  Linux >= 6.15), and an embeddable core library (`NydusCore`) that
   serve the image to microVM guests as EROFS over virtio-pmem — the target
   end-state for Kata image acceleration in agent sandbox image and snapshot
   scenarios.
@@ -143,7 +143,7 @@ O_DIRECT, 4K random costs 11.7 µs (ublk) vs 13.4 µs (FUSE) vs 24.0 µs (NBD),
 and sequential 128K direct goes 4,320 / 3,330 / 2,235 MiB/s — io_uring
 shared-memory SQE/CQE undercuts both the NBD kernel socket and FUSE's
 request/reply, so ublk now wins the cold per-request round trip too. The fill
-path is identical by construction (shared accessor and cache format): prewarm
+path is identical by construction (shared core and cache format): prewarm
 972 / 1,060 / 1,069 MiB/s, 71.1 MiB fetched for the block modes vs 64.0 for
 FUSE (readahead policy). FUSE's only remaining win is mount-ready latency:
 0.21 s vs ublk 6.42 s, because `nydus ublk` eagerly prepares every blob in
@@ -179,7 +179,7 @@ mount-ready, so the total cold-start cost is roughly constant across modes.
   ~6.2–6.4 s here because both prepare the blob lazily on first touch (meta
   download + cache-file sizing + digest verification); ublk pays 6.42 s in
   *mount-ready* instead, because `nydus ublk` calls
-  `accessor.blob.flat_layout()` in `UblkDevice::new` so EROFS `mount` never
+  `core.blobs.flat_layout()` in `UblkDevice::new` so EROFS `mount` never
   stalls. The total cold-start cost (mount-ready + first read) is roughly
   constant across modes.
 - Cold-page `direct=0` rows largely re-warm during each 20 s job (the target
@@ -192,7 +192,7 @@ mount-ready, so the total cold-start cost is roughly constant across modes.
 | ---------------- | ------------------------ | -------------------------------------------------------------------------------------------------------- |
 | `nydus`          | `nydus/src/bin/nydus/`         | CLI: `build`, `merge`, `check`, `optimize`, `fuse`, and optional `uffd` / `fanotify` / `nbd`              |
 | `nydusify`       | `nydusify/`              | Go orchestrator that converts, checks, and optimizes whole OCI images against a registry                 |
-| `nydus-core` | `nydus-core/` | Library crate (`NydusAccessor`) for embedding the image read path (e.g. hypervisor virtio-pmem wiring) without FUSE |
+| `nydus-core` | `nydus-core/` | Library crate (`NydusCore`) for embedding the image read path (e.g. hypervisor virtio-pmem wiring) without FUSE |
 
 ## Quick Start
 
@@ -235,7 +235,7 @@ nydus fuse --bootstrap image.boot --config config/registry.example.yaml --mountp
 
 | Document                       | Contents                                                                                                                                          |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [docs/nydus.md](docs/nydus.md) | Design document: CLI contract, artifact model, blob meta format, read path, prefetch, optimize pipeline, metrics, accessor API, and `nydusify`    |
+| [docs/nydus.md](docs/nydus.md) | Design document: CLI contract, artifact model, blob meta format, read path, prefetch, optimize pipeline, metrics, core API, and `nydusify`    |
 | [docs/uffd.md](docs/uffd.md)   | UFFD service design: flattened device layout, Unix-socket wire protocol, SCM_RIGHTS FD rules, and fault-handling policies for microVM virtio-pmem |
 | [docs/ublk.md](docs/ublk.md)   | ublk block device target: flattened device layout, device parameters, queue model, mmap-based read path, and comparison with the other mount paths |
 | [docs/erofs.md](docs/erofs.md) | EROFS internals: on-disk format, superblock, inode/NID system, chunk indexes, directory format, and the metadata build pipeline                   |
@@ -264,7 +264,7 @@ make nydusify
 
 Library embedders should depend on the `nydus-core` crate
 (`nydus-core/`, re-exported by the root `nydus` crate), which
-carries the accessor read path without FUSE, CLI, or server dependencies:
+carries the core read path without FUSE, CLI, or server dependencies:
 
 ```bash
 cargo build -p nydus-core --features backend-registry

--- a/docs/fanotify.md
+++ b/docs/fanotify.md
@@ -10,7 +10,7 @@ Requires Linux 6.15+.
 
 The daemon serves a **multi-device** EROFS image. The bootstrap is a real local
 EROFS file that is mounted directly; each data blob is a separate EROFS
-`device=` backed by the accessor's per-blob sparse cache file. The daemon marks
+`device=` backed by the core's per-blob sparse cache file. The daemon marks
 each blob cache file `FAN_PRE_ACCESS`. Mount, `ls`, and `stat` read the local
 bootstrap and never involve fanotify; only cold blob-**data** reads fault.
 
@@ -31,7 +31,7 @@ backing cache file (sparse hole; pages not present)
 nydus fanotify
       |
       | fstat(fd) -> (dev, ino) -> blob device
-      | BlobAccessor::fetch(id, offset, count):
+      | Blobs::fetch(id, offset, count):
       |   backend fetch + decode + CRC validate
       |   write decoded data to the blob's cache file
       v
@@ -50,7 +50,7 @@ answers them immediately with no backend I/O.
 ## Multi-Device Model
 
 The daemon enumerates blob devices from the bootstrap via
-`BlobAccessor::entries()`, which also creates and sizes each blob's sparse cache
+`Blobs::entries()`, which also creates and sizes each blob's sparse cache
 file so the device files exist before mount.
 
 Layout rules:
@@ -58,7 +58,7 @@ Layout rules:
 - The **bootstrap** is a local EROFS file, mounted directly as the mount source.
   It is never marked and never served through fanotify.
 - Each **blob** is one EROFS `device=` slot, in device-table order. Its backing
-  file is the accessor's decoded cache file (`BlobInfo::cache_path`), sized to
+  file is the core's decoded cache file (`BlobInfo::cache_path`), sized to
   the blob's decoded length.
 - Device slots keep their original 1-based index, including **redirect** slots,
   so the EROFS `device=` index is never renumbered. A read routed to a redirect
@@ -99,7 +99,7 @@ decides a response purely from the parsed event, then admits the fetch:
 2. **Resolve device.** `fstat` the event fd for `(dev, ino)` and look up the
    blob device. An unknown device, or a redirect slot, is denied.
 3. **Align.** The RANGE is aligned outward to 4 KiB EROFS blocks and clamped to
-   the device size (the accessor requires block-aligned arguments). The device
+   the device size (the core requires block-aligned arguments). The device
    size is the fetch bound; there is no per-event byte cap.
 4. **Fast path.** If the authoritative groupmap already covers the aligned range,
    the event is allowed immediately with no backend I/O.
@@ -109,7 +109,7 @@ decides a response purely from the parsed event, then admits the fetch:
    unbounded pending table. Admission never fails; concurrency is bounded by the
    fetch thread pool (`--fetch-concurrency`), which queues tasks (backpressure)
    rather than denying.
-6. **Fetch.** `BlobAccessor::fetch(id, offset, count)` runs on a fetch worker
+6. **Fetch.** `Blobs::fetch(id, offset, count)` runs on a fetch worker
    thread; it decodes, CRC-validates, dedups (idempotent, group-granular) and
    writes the blob's cache file in place. The work is wrapped in `catch_unwind`.
 7. **Respond.** On completion the event is answered `FAN_ALLOW` on success, or
@@ -122,7 +122,7 @@ decides a response purely from the parsed event, then admits the fetch:
 
 Duplicate work is removed at two layers. The event loop coalesces events sharing
 an identical `(blob, aligned range)` key, so a burst of readers faulting the same
-range dispatches a single fetch. Below that, the accessor de-duplicates at
+range dispatches a single fetch. Below that, the core de-duplicates at
 blob-meta-group granularity (single-flight), so faults for different ranges in
 the same group also join one fetch. Distinct groups fetch concurrently up to the
 fetch thread pool size (`max(ncpu, 64)`); a saturated pool queues tasks rather
@@ -177,7 +177,7 @@ backpressures readers rather than denying them.
 
 1. **Setup.** Raise the `RLIMIT_NOFILE` soft limit to the hard limit (each
    in-flight cold read pins a dup'd event fd and admission is unbounded). Build
-   the accessor, enumerate and prepare blob devices, create the
+   the core, enumerate and prepare blob devices, create the
    `FAN_CLASS_PRE_CONTENT` group, and `FAN_MARK_ADD` `FAN_PRE_ACCESS` on each
    blob cache file — skipping any blob already fully cached. The group fd is
    held unregistered.
@@ -255,7 +255,7 @@ prefetch:
 ```
 
 The fanotify feature is optional and does not affect default library or builtin
-accessor builds unless explicitly enabled.
+core builds unless explicitly enabled.
 
 ## Requirements
 

--- a/docs/nbd.md
+++ b/docs/nbd.md
@@ -49,7 +49,7 @@ kernels without `FAN_CLASS_PRE_CONTENT` (Linux < 6.15); it only needs the
 
 ## Flattened Device Layout
 
-The device content is the accessor's flattened view, identical to the UFFD
+The device content is the core's flattened view, identical to the UFFD
 service's layout (see [Nydus UFFD Service and Wire Protocol](uffd.md)):
 
 ```text

--- a/docs/nydus.md
+++ b/docs/nydus.md
@@ -207,7 +207,7 @@ Current implementation notes:
 - `--trace-file` is the offline alternative to `--apiserver` (the two are
 	mutually exclusive; one of them is required). It accepts the same versioned
 	trace document as produced by the `/trace` endpoint, so a trace captured
-	from a pmem/accessor mount can be replayed without a live apiserver.
+	from a pmem/core mount can be replayed without a live apiserver.
 - `--parent-bootstrap` is the merged bootstrap to optimize; it is read-only, so
 	optimize can be re-run against the same parent with new patterns.
 - `--bootstrap` is the rewritten bootstrap output: the parent's inode tree with
@@ -397,7 +397,7 @@ device as EROFS.
 
 The UFFD command is available only when Nydus is built with both the `cli` and
 `uffd` features. The `uffd` feature gates the service and its FD-passing
-dependency, so other Nydus library and builtin-accessor users do not include
+dependency, so other Nydus library and builtin-core users do not include
 the UFFD service path.
 
 ```bash
@@ -436,7 +436,7 @@ fault-handling responsibilities.
 The `nydus fanotify` command serves a Nydus image to the kernel EROFS driver as
 an on-demand, **multi-device** mount. The bootstrap is a real local EROFS image
 mounted directly, so mount and metadata reads (`ls`, `stat`) work off the local
-bootstrap; each blob is a separate EROFS device backed by the accessor's sparse
+bootstrap; each blob is a separate EROFS device backed by the core's sparse
 cache file, marked for fanotify `FAN_PRE_ACCESS`. A cold blob-data read faults;
 the daemon identifies the blob, fetches the range into its cache file, and
 answers the event. This is the native-EROFS counterpart to `nydus uffd` (which
@@ -1105,7 +1105,7 @@ A fully-zero chunk — a real filesystem hole reads back as zeros, and so does
 zero-filled data — is never stored: the builder emits the standard EROFS null
 chunk index (all 48 address bits set on disk) instead. Hole chunks occupy no
 bytes in the data region, get no blob meta chunk record, and never touch the
-blob cache at runtime: the accessor read paths satisfy them with zeros
+blob cache at runtime: the core read paths satisfy them with zeros
 directly, and native EROFS mounts decode the null address in-kernel the same
 way.
 
@@ -1442,7 +1442,7 @@ parallel ramped prefetch cut end-to-end start time from 32.6s to 25.0s.
 ### Cross-process cache sharing and prefetch dedup
 
 Many identical instances cold-starting on one node (for example, dozens of
-hypervisor-embedded accessors mounting the same optimized image) all target the
+hypervisor-embedded cores mounting the same optimized image) all target the
 same cache directory, the same blobs, and the same access-ordered hot set.
 Without coordination each instance would stream the whole ondemand blob and
 decode every group independently — N× the backend traffic, decode CPU, and
@@ -1482,13 +1482,13 @@ missing bit (tracked by the shared ready counter) latches the sticky
 faults, FUSE reads — consult it before any
 per-group bookkeeping (`ensure_range` and `ready_ranges` short-circuit on it),
 so a fully warmed blob costs one load per request instead of a bitmap walk.
-`all_ready()` falls back to scanning the shared bitmap (masking the partial
+`check_all_ready()` falls back to scanning the shared bitmap (masking the partial
 final byte) when the flag is not yet set, and latches the flag when the scan
 proves completion — this also heals the rare counter skew left by a process
 that died between setting the last bit and bumping the counter, as does the
 same reconciliation at every `open`. A successful `prefetch_all` additionally
 runs this authoritative scan before returning, so once a full prefetch
-completes, `fully_ready` is guaranteed to answer true even in the presence of
+completes, `is_fully_ready` is guaranteed to answer true even in the presence of
 historical counter skew.
 
 **Per-blob prefetch flock.** Blob-level prefetch — and only prefetch — is
@@ -1553,14 +1553,14 @@ cache grew to the same ≈900 MB a single instance produces and end-to-end
 application readiness stayed at the single-instance baseline (24–27s across
 all 50, vs ≈25s for one).
 
-## Accessor (virtio-pmem integration)
+## Core (virtio-pmem integration)
 
-`nydus_core::NydusAccessor` (re-exported as `nydus::NydusAccessor`) is
+`nydus_core::NydusCore` (re-exported as `nydus::NydusCore`) is
 the library entry point for hypervisors
 that mount the nydus image inside the guest as a plain EROFS
 filesystem over virtio-pmem, instead of using `nydus fuse` on the host. The
 `nydus uffd` service builds its flattened device and on-demand fetch path on
-the same accessor; see [Nydus UFFD Service and Wire Protocol](uffd.md). The
+the same core; see [Nydus UFFD Service and Wire Protocol](uffd.md). The
 `nydus nbd` service serves the same flattened view through the kernel NBD
 driver; see [Nydus NBD Service](nbd.md). The `nydus ublk` service serves it
 through `ublk_drv` over `io_uring`; see
@@ -1570,7 +1570,7 @@ through `ublk_drv` over `io_uring`; see
 	device backed by its host cache data file (`{cache_dir}/{hex}.blob.data`),
 	which mirrors the dense decoded block address space — a guest read of block
 	`N` lands at byte `N * 4096` of the backing file.
-- `NydusAccessor::new(bootstrap, Config)` parses the bootstrap and an already
+- `NydusCore::new(bootstrap, Config)` parses the bootstrap and an already
 	loaded `nydus::Config` (same structure as `nydus fuse --config`) lazily;
 	per-blob work (blob meta download/validation, sparse cache file creation)
 	happens on first touch through `blob.entries()` or `blob.fetch`.
@@ -1578,16 +1578,16 @@ through `ublk_drv` over `io_uring`; see
 	worker before returning — the same two-phase workflow as `nydus fuse`
 	(redirect blob first, then the rest only under `prefetch.full`). The worker
 	thread inherits the network namespace active at construction time, so
-	callers that construct the accessor for a guest-facing backend must do so
+	callers that construct the core for a guest-facing backend must do so
 	while the desired netns is active.
 - Access traces are recorded on actual backend fetches (not cache hits), and
 	`nydus::metrics::snapshot()` exposes runtime counters for embedding into
 	hypervisor stats endpoints; a saved trace JSON can be replayed offline via
 	`nydus optimize --trace-file`. See [Metrics](#metrics).
-- `BlobID` is the public blob digest type. It converts to/from 64-character
+- `BlobId` is the public blob digest type. It converts to/from 64-character
 	SHA256 hex strings and `[u8; 32]` bytes.
 - `blob.entries()` lists the device table in order as `BlobInfo` entries:
-	blob index, `BlobID`, block count, cache path, cache size, and whether the
+	blob index, `BlobId`, block count, cache path, cache size, and whether the
 	blob is an ondemand redirect blob. Calling it prepares the sparse cache data
 	files, so `BlobInfo.cache_path` is immediately suitable as a virtio-pmem
 	backing file and `BlobInfo.cache_size` is `blocks * 4096`.
@@ -1607,17 +1607,17 @@ Complete example:
 ```rust
 use std::path::Path;
 
-use nydus_core::{Config, NydusAccessor};
+use nydus_core::{Config, NydusCore};
 
 fn wire_nydus_image(bootstrap: &Path, config_path: &Path) -> anyhow::Result<()> {
 	// Load the same YAML schema accepted by `nydus fuse --config`.
 	let config = Config::from_file(config_path)?;
-	let accessor = NydusAccessor::new(bootstrap, config)?;
+	let core = NydusCore::new(bootstrap, config)?;
 
 	// Materialize every blob cache file before creating guest pmem devices.
 	// The vector is in bootstrap device-table order; `index` is the 1-based
 	// EROFS external-device index used by chunk indexes.
-	let blobs = accessor.blob.entries()?;
+	let blobs = core.blobs.entries()?;
 	for blob in &blobs {
 		println!(
 			"blob index={} id={} blocks={} cache={} bytes={} redirect={}",
@@ -1639,12 +1639,12 @@ fn wire_nydus_image(bootstrap: &Path, config_path: &Path) -> anyhow::Result<()> 
 	// aligned; fetch expands to whole blob-meta groups internally and is
 	// safe to call repeatedly or concurrently.
 	if let Some(blob) = blobs.iter().find(|blob| !blob.is_redirect) {
-		accessor.blob.fetch(&blob.id, 0, 4096 * 16)?;
+		core.blobs.fetch(&blob.id, 0, 4096 * 16)?;
 	}
 
 	// Static filesystem inspection without FUSE. Resolve a path once and
 	// reuse the FsEntry for hot loops.
-	let file = accessor.fs.open("path/to/file")?;
+	let file = core.fs.open("path/to/file")?;
 	let meta = file.metadata()?;
 	println!("ino={} size={} mode={:o}", meta.ino, meta.size, meta.mode);
 
@@ -1652,7 +1652,7 @@ fn wire_nydus_image(bootstrap: &Path, config_path: &Path) -> anyhow::Result<()> 
 	let n = file.read_at(0, &mut buf)?;
 	println!("read {n} bytes");
 
-	let root = accessor.fs.open("/")?;
+	let root = core.fs.open("/")?;
 	for entry in root.read_dir()? {
 		println!("{} {:?} ino={}", entry.name, entry.file_type, entry.ino);
 	}
@@ -1661,7 +1661,7 @@ fn wire_nydus_image(bootstrap: &Path, config_path: &Path) -> anyhow::Result<()> 
 }
 ```
 
-The accessor needs neither FUSE nor the CLI stack: it lives in the
+The core needs neither FUSE nor the CLI stack: it lives in the
 standalone `nydus-core` crate (`nydus-core/`), which the root
 `nydus` crate re-exports. Depending on `nydus-core` with the
 `backend-registry` feature produces a minimal library surface (no
@@ -1970,7 +1970,7 @@ Publishes an optimized copy of a nydus image from a recorded access pattern:
 mount's `GET /trace` endpoint
 (`{"version":1,"patterns":[{"blob_index":1,"group_index":4},...]}`). It can be
 saved from the `/trace` endpoint of a `nydusify mount` apiserver, or exported
-offline from a pmem/accessor mount trace (e.g. a rund sandbox extendedstats
+offline from a pmem/core mount trace (e.g. a rund sandbox extendedstats
 snapshot). Record the pattern from a mount **without** prefetch so it captures
 the pure on-demand access pattern, exercise the workload, then save the trace.
 Mount the optimized image **with** `--prefetch` to get the phase-0 redirect

--- a/docs/ublk.md
+++ b/docs/ublk.md
@@ -73,7 +73,7 @@ Layout rules:
   size.
 
 This is the same layout `nydus uffd` serves, so the two targets share the
-`NydusAccessor` range-resolution path.
+`NydusCore` range-resolution path.
 
 ## Device Parameters
 
@@ -110,7 +110,7 @@ readers, not from splitting one reader's stream.
 
 A block read is served in three steps:
 
-1. **Resolve.** `NydusAccessor::fetch_flat_ranges` maps the requested device
+1. **Resolve.** `NydusCore::fetch_flat_ranges` maps the requested device
    range onto a list of `(fd, offset, length)` ranges over the bootstrap file,
    the blob cache files, and `/dev/zero`. Ranges backed by a blob are fetched,
    decoded and CRC-validated before the descriptor is handed back, so a cache

--- a/docs/uffd.md
+++ b/docs/uffd.md
@@ -366,7 +366,7 @@ prefetch:
 ```
 
 The UFFD feature is optional and does not affect default library or builtin
-accessor builds unless explicitly enabled.
+core builds unless explicitly enabled.
 
 ## Protocol Constraints
 

--- a/nydus-core/Cargo.toml
+++ b/nydus-core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"
-description = "Runtime accessor APIs for EROFS-based Nydus images: metadata parsing, on-demand blob caching and storage backends."
+description = "Runtime core APIs for EROFS-based Nydus images: metadata parsing, on-demand blob caching and storage backends."
 repository = "https://github.com/dragonflyoss/nydus"
 readme = "README.md"
 # Integration tests need the `nydus` builder (a path-only cyclic

--- a/nydus-core/README.md
+++ b/nydus-core/README.md
@@ -1,6 +1,6 @@
 # nydus-core
 
-Runtime accessor APIs for EROFS-based Nydus images.
+Runtime core APIs for EROFS-based Nydus images.
 
 This crate provides the host-side building blocks used to serve Nydus images
 at runtime:
@@ -10,7 +10,7 @@ at runtime:
 - `storage`: on-demand blob cache, storage backends (`local`, and `registry`
   behind the `backend-registry` feature) and background prefetching.
 - `fs`: an EROFS image reader (`ErofsReader`).
-- `accessor`: the high-level `NydusAccessor` entry point exposing the device
+- `core`: the high-level `NydusCore` entry point exposing the device
   table and block-aligned `fetch` APIs for microVM virtio-pmem use cases.
 
 ## Features

--- a/nydus-core/src/config.rs
+++ b/nydus-core/src/config.rs
@@ -7,7 +7,7 @@ use crate::storage::prefetch::DEFAULT_PREFETCH_THREADS;
 
 /// Top-level nydus configuration, typically loaded from a YAML file passed to
 /// `nydus fuse --config` or constructed by an embedding application before
-/// creating a [`NydusAccessor`](crate::accessor::NydusAccessor).
+/// creating a [`NydusCore`](crate::core::NydusCore).
 ///
 /// ```yaml
 /// backend:

--- a/nydus-core/src/core.rs
+++ b/nydus-core/src/core.rs
@@ -1,15 +1,15 @@
-//! Host-side accessor for nydus images backing guest virtio-pmem devices.
+//! Host-side core for nydus images backing guest virtio-pmem devices.
 //!
 //! A guest kernel mounts the nydus bootstrap as an EROFS image whose external
 //! devices are virtio-pmem devices backed by the host-side cache data files
 //! (`{cache_dir}/{hex}.blob.data`). Each cache file mirrors the blob's dense
 //! decoded block address space, so a guest read of block `N` lands at byte
-//! `N * 4096` of the backing file. [`NydusAccessor`] exposes the device
-//! table needed to wire up those pmem devices and a [`blob.fetch`] entry point
+//! `N * 4096` of the backing file. [`NydusCore`] exposes the device
+//! table needed to wire up those pmem devices and a [`blobs.fetch`] entry point
 //! that guarantees a block-aligned range is decoded and resident before the
 //! guest touches it.
 //!
-//! [`blob.fetch`]: BlobAccessor::fetch
+//! [`blobs.fetch`]: Blobs::fetch
 
 use std::collections::HashMap;
 use std::fmt;
@@ -33,11 +33,11 @@ use crate::storage::backend::build_backend;
 use crate::storage::prefetch::BlobPrefetcher;
 use crate::utils::{hex_string, parse_sha256_hex};
 
-/// Blob digest used by public accessor APIs.
+/// Blob digest used by public core APIs.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct BlobID([u8; EROFS_BLOB_ID_SIZE]);
+pub struct BlobId([u8; EROFS_BLOB_ID_SIZE]);
 
-impl BlobID {
+impl BlobId {
     pub fn new(bytes: [u8; EROFS_BLOB_ID_SIZE]) -> Self {
         Self(bytes)
     }
@@ -55,19 +55,19 @@ impl BlobID {
     }
 }
 
-impl From<[u8; EROFS_BLOB_ID_SIZE]> for BlobID {
+impl From<[u8; EROFS_BLOB_ID_SIZE]> for BlobId {
     fn from(value: [u8; EROFS_BLOB_ID_SIZE]) -> Self {
         Self::new(value)
     }
 }
 
-impl From<BlobID> for [u8; EROFS_BLOB_ID_SIZE] {
-    fn from(value: BlobID) -> Self {
+impl From<BlobId> for [u8; EROFS_BLOB_ID_SIZE] {
+    fn from(value: BlobId) -> Self {
         value.into_bytes()
     }
 }
 
-impl FromStr for BlobID {
+impl FromStr for BlobId {
     type Err = anyhow::Error;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
@@ -75,7 +75,7 @@ impl FromStr for BlobID {
     }
 }
 
-impl fmt::Display for BlobID {
+impl fmt::Display for BlobId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&hex_string(&self.0))
     }
@@ -87,7 +87,7 @@ pub struct BlobInfo {
     /// 1-based blob index, matching the EROFS device table order.
     pub index: u16,
     /// Blob digest recorded in the device slot.
-    pub id: BlobID,
+    pub id: BlobId,
     /// Start block of this blob in the flattened single-device layout.
     pub mapped_blkaddr: u64,
     /// Start byte offset of this blob in the flattened single-device layout.
@@ -108,12 +108,12 @@ pub struct BlobInfo {
 /// Resolved mmap-ready byte range.
 ///
 /// `fd` is always a real file descriptor. Zero-filled ranges use the
-/// accessor-owned `/dev/zero` fd with `offset == 0`; callers can compare
-/// against [`NydusAccessor::zero_fd`] to recognize those ranges for optimized
+/// core-owned `/dev/zero` fd with `offset == 0`; callers can compare
+/// against [`NydusCore::zero_fd`] to recognize those ranges for optimized
 /// copy-mode handling.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FdRange {
-    /// Raw fd backing this range. The fd is owned by the accessor/cache and
+    /// Raw fd backing this range. The fd is owned by the core/cache and
     /// must not be closed by the caller.
     pub fd: RawFd,
     /// Byte offset within `fd`. For zero-filled ranges this is always `0`.
@@ -121,7 +121,7 @@ pub struct FdRange {
     /// Length in bytes.
     pub len: u64,
     /// Offset in the source view: flattened-device offset for
-    /// [`NydusAccessor`] ranges, file-relative offset for [`FsEntry`] ranges.
+    /// [`NydusCore`] ranges, file-relative offset for [`FsEntry`] ranges.
     pub source_offset: u64,
 }
 
@@ -136,7 +136,7 @@ impl FdRange {
     }
 }
 
-/// File type exposed by the static accessor API, independent of FUSE types.
+/// File type exposed by the static core API, independent of FUSE types.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FileType {
     RegularFile,
@@ -210,15 +210,15 @@ pub struct FsEntry {
 
 /// Read-side handle over a nydus image, split into blob data access and
 /// static filesystem metadata/data access.
-pub struct NydusAccessor {
+pub struct NydusCore {
     /// Size in bytes of the standalone bootstrap image passed to [`new`].
     ///
     /// [`new`]: Self::new
     pub bootstrap_size: u64,
     /// Blob table and decoded-cache preparation/fetch APIs.
-    pub blob: BlobAccessor,
+    pub blobs: Blobs,
     /// Static path-based filesystem APIs.
-    pub fs: FsAccessor,
+    pub fs: Fs,
     bootstrap: Arc<File>,
     zero_file: Arc<File>,
     flat_size: u64,
@@ -226,21 +226,21 @@ pub struct NydusAccessor {
 }
 
 /// Blob table and decoded-cache preparation/fetch APIs.
-pub struct BlobAccessor {
+pub struct Blobs {
     reader: Arc<ErofsReader>,
     blob_infos: Vec<ReaderBlobInfo>,
-    index_by_blob_id: HashMap<BlobID, u16>,
-    /// Memoised result of [`BlobAccessor::flat_layout`].
+    index_by_blob_id: HashMap<BlobId, u16>,
+    /// Memoised result of [`Blobs::flat_layout`].
     flat_layout: OnceLock<Vec<BlobInfo>>,
 }
 
 /// Static path-based filesystem APIs.
-pub struct FsAccessor {
+pub struct Fs {
     reader: Arc<ErofsReader>,
     zero_file: Arc<File>,
 }
 
-impl NydusAccessor {
+impl NydusCore {
     /// Parse the bootstrap and config and build the blob table,
     /// deferring all per-blob work: no blob meta is downloaded and no cache
     /// file is created until [`blobs`], [`fetch`], or [`prefetch`] first
@@ -255,7 +255,7 @@ impl NydusAccessor {
     /// "ondemand" redirect blob first (priority) to warm the source blobs'
     /// caches in recorded access order, then prefetches the remaining blobs.
     /// The worker borrows the shared reader, so callers that want network
-    /// access (e.g. the virtio-pmem backend) must construct the accessor while
+    /// access (e.g. the virtio-pmem backend) must construct the core while
     /// the desired network namespace is active so the spawned thread inherits
     /// it.
     ///
@@ -321,37 +321,37 @@ impl NydusAccessor {
         })?;
         let index_by_blob_id = blob_infos
             .iter()
-            .map(|info| (BlobID::from(info.blob_id), info.blob_index))
+            .map(|info| (BlobId::from(info.blob_id), info.blob_index))
             .collect();
         let reader = Arc::new(reader);
 
-        // Kick off background prefetch as soon as the accessor is built when the
+        // Kick off background prefetch as soon as the core is built when the
         // config opts in. The worker holds its own `Arc` clone of the reader,
         // so it keeps running (and keeps the reader alive) independently of the
-        // returned accessor. The handle is detached: prefetch is best-effort
-        // warmup and must never block accessor construction or teardown.
+        // returned core. The handle is detached: prefetch is best-effort
+        // warmup and must never block core construction or teardown.
         if prefetch_enable {
             match BlobPrefetcher::new(reader.clone(), prefetch_threads, prefetch_full).spawn() {
                 Ok(_handle) => {
                     tracing::info!(
-                        "nydus accessor: background prefetch started (full={prefetch_full})"
+                        "nydus core: background prefetch started (full={prefetch_full})"
                     );
                 }
                 Err(err) => {
-                    tracing::warn!("nydus accessor: failed to start prefetch worker: {err}");
+                    tracing::warn!("nydus core: failed to start prefetch worker: {err}");
                 }
             }
         }
 
         Ok(Self {
             bootstrap_size,
-            blob: BlobAccessor {
+            blobs: Blobs {
                 reader: reader.clone(),
                 blob_infos,
                 index_by_blob_id,
                 flat_layout: OnceLock::new(),
             },
-            fs: FsAccessor {
+            fs: Fs {
                 reader,
                 zero_file: zero_file.clone(),
             },
@@ -362,7 +362,7 @@ impl NydusAccessor {
         })
     }
 
-    /// Return the bootstrap file backing this accessor.
+    /// Return the bootstrap file backing this core.
     pub fn bootstrap(&self) -> &File {
         &self.bootstrap
     }
@@ -372,7 +372,7 @@ impl NydusAccessor {
         self.flat_size
     }
 
-    /// Return the accessor-owned `/dev/zero` fd used for zero-filled ranges.
+    /// Return the core-owned `/dev/zero` fd used for zero-filled ranges.
     pub fn zero_fd(&self) -> RawFd {
         self.zero_file.as_raw_fd()
     }
@@ -392,24 +392,24 @@ impl NydusAccessor {
         self.resolve_flat_ranges(offset, len, ResolveMode::Probe)
     }
 
-    /// Return a stable snapshot of this accessor's on-demand group trace.
+    /// Return a stable snapshot of this core's on-demand group trace.
     pub fn trace_snapshot(&self) -> TraceDocument {
         self.trace_recorder.snapshot()
     }
 
-    /// Serialize this accessor's on-demand group trace as optimize-compatible JSON.
+    /// Serialize this core's on-demand group trace as optimize-compatible JSON.
     pub fn trace_json(&self) -> String {
         self.trace_recorder.encode_json()
     }
 
-    /// Clear this accessor's on-demand group trace.
+    /// Clear this core's on-demand group trace.
     pub fn clear_trace(&self) {
         self.trace_recorder.clear();
     }
 
     /// Return a snapshot of the process-wide nydus metrics (counters and
     /// gauges). The metrics are global, so this reflects all blob activity in
-    /// the process, not just this accessor; callers typically inspect
+    /// the process, not just this core; callers typically inspect
     /// `backend_ondemand_read_count` to tell whether any group was fetched
     /// over the network rather than served from a warmed cache.
     pub fn metrics_snapshot(&self) -> crate::metrics::MetricsSnapshot {
@@ -446,7 +446,7 @@ impl NydusAccessor {
         }
 
         let blobs = self
-            .blob
+            .blobs
             .flat_layout()
             .context("failed to describe blob device layout")?;
 
@@ -464,7 +464,7 @@ impl NydusAccessor {
                 let seg_end = end.min(blob_end);
                 let blob_offset = pos - blob.mapped_offset;
                 push_blob_fd_ranges(
-                    &self.blob.reader,
+                    &self.blobs.reader,
                     self.zero_file.as_raw_fd(),
                     &mut ranges,
                     BlobRangeSpec {
@@ -500,7 +500,7 @@ impl NydusAccessor {
     }
 }
 
-impl BlobAccessor {
+impl Blobs {
     /// Describe every blob in device-table order, preparing each on first
     /// use: the blob meta is downloaded and validated, and the sparse cache
     /// data file is created and sized to the dense uncompressed address
@@ -527,7 +527,7 @@ impl BlobAccessor {
                     .context("blob cache size overflow")?;
                 Ok(BlobInfo {
                     index: info.blob_index,
-                    id: BlobID::from(info.blob_id),
+                    id: BlobId::from(info.blob_id),
                     mapped_blkaddr: info.mapped_blkaddr,
                     mapped_offset,
                     blocks: info.blocks,
@@ -542,11 +542,11 @@ impl BlobAccessor {
     /// Describe the blobs that back the flattened single-device address
     /// space, sorted by `mapped_offset` and with redirect blobs removed.
     ///
-    /// The layout is fixed for the lifetime of the accessor, so it is computed
+    /// The layout is fixed for the lifetime of the core, so it is computed
     /// once and memoised: block-device style workloads resolve ranges on every
     /// I/O and must not pay for re-enumerating (and re-sorting) the blob table
     /// each time. The first call prepares every blob, exactly as
-    /// [`BlobAccessor::entries`] does.
+    /// [`Blobs::entries`] does.
     pub fn flat_layout(&self) -> Result<&[BlobInfo]> {
         if let Some(layout) = self.flat_layout.get() {
             return Ok(layout);
@@ -568,7 +568,7 @@ impl BlobAccessor {
     /// file, fetching missing groups through the backend. Both `offset` and
     /// `len` must be 4 KiB block aligned; the fetch rounds outward to whole
     /// blob meta groups. Idempotent and safe to call concurrently.
-    pub fn fetch(&self, id: &BlobID, offset: u64, len: u64) -> Result<()> {
+    pub fn fetch(&self, id: &BlobId, offset: u64, len: u64) -> Result<()> {
         let block_size = EROFS_BLOCK_SIZE as u64;
         if offset % block_size != 0 || len % block_size != 0 {
             bail!("fetch range must be 4 KiB block aligned: offset={offset} len={len}");
@@ -594,7 +594,7 @@ impl BlobAccessor {
     /// without triggering a backend fetch. The groupmap remains authoritative.
     pub fn ready_ranges(
         &self,
-        id: &BlobID,
+        id: &BlobId,
         offset: u64,
         len: u64,
     ) -> Result<Vec<std::ops::Range<u64>>> {
@@ -619,7 +619,7 @@ impl BlobAccessor {
     /// scan). On-demand services (uffd, fanotify, FUSE) can consult this per
     /// event — or once per blob, since the answer is sticky — to bypass range
     /// readiness checks and fetch plumbing entirely for fully warmed blobs.
-    pub fn fully_ready(&self, id: &BlobID) -> Result<bool> {
+    pub fn is_fully_ready(&self, id: &BlobId) -> Result<bool> {
         let blob_index = *self
             .index_by_blob_id
             .get(id)
@@ -628,11 +628,11 @@ impl BlobAccessor {
             .reader
             .blob_cache(blob_index)
             .with_context(|| format!("failed to open blob {blob_index}"))?;
-        Ok(cache.fully_ready())
+        Ok(cache.is_fully_ready())
     }
 }
 
-impl FsAccessor {
+impl Fs {
     /// Resolve `path` once and return a reusable entry handle.
     pub fn open(&self, path: impl AsRef<Path>) -> Result<FsEntry> {
         let ino = self.resolve_path(path.as_ref())?;

--- a/nydus-core/src/fs/mod.rs
+++ b/nydus-core/src/fs/mod.rs
@@ -374,7 +374,7 @@ impl ErofsReader {
     /// Return whether the blob identified by `blob_index` is an "ondemand"
     /// redirect blob (produced by `nydus optimize`). Opens the blob cache,
     /// which reads the local blob meta but performs no data prefetch.
-    pub fn blob_is_redirect(&self, blob_index: u16) -> io::Result<bool> {
+    pub fn is_redirect_blob(&self, blob_index: u16) -> io::Result<bool> {
         let blob = self.blobs.get(&blob_index).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::NotFound,

--- a/nydus-core/src/lib.rs
+++ b/nydus-core/src/lib.rs
@@ -1,28 +1,27 @@
-//! Runtime accessor APIs for EROFS-based Nydus images.
+//! Runtime core APIs for EROFS-based Nydus images.
 //!
 //! This crate provides the host-side building blocks used to serve Nydus
 //! images at runtime: EROFS metadata parsing ([`metadata`]), an on-demand
 //! blob cache and storage backends ([`storage`]), an image reader ([`fs`]),
-//! and the high-level [`NydusAccessor`] entry point ([`accessor`]).
+//! and the high-level [`NydusCore`] entry point ([`core`]).
 //!
 //! Optional cargo features:
 //! - `backend-registry`: container image registry backend (OCI distribution).
 //! - `backend-dragonfly-proxy`: Dragonfly P2P SDK proxy for the registry
 //!   backend.
 
-pub mod accessor;
 pub mod config;
+pub mod core;
 pub mod fs;
 pub mod metadata;
 pub mod metrics;
 pub mod storage;
 pub mod utils;
 
-pub use accessor::{
-    BlobAccessor, BlobID, BlobInfo, DirEntry, FdRange, FileType, FsAccessor, FsEntry, Metadata,
-    NydusAccessor,
-};
 pub use config::Config;
+pub use core::{
+    BlobId, BlobInfo, Blobs, DirEntry, FdRange, FileType, Fs, FsEntry, Metadata, NydusCore,
+};
 pub use metadata::{
     is_rafs_v7_bootstrap, BlobMeta, BlobMetaChunk, BlobMetaGroup, BlobMetaHeader,
     BLOB_META_HEADER_SIZE, BLOB_META_MAGIC, EROFS_FEATURE_COMPAT_RAFS_V6,

--- a/nydus-core/src/metadata/chunk.rs
+++ b/nydus-core/src/metadata/chunk.rs
@@ -26,9 +26,9 @@ impl ErofsChunkIndex {
             v.device_id = [0xFF; 2];
             v.startblk_lo = [0xFF; 4];
         } else {
-            set_u16(&mut v.startblk_hi, (blkaddr >> 32) as u16);
-            set_u16(&mut v.device_id, device_id);
-            set_u32(&mut v.startblk_lo, blkaddr as u32);
+            write_u16(&mut v.startblk_hi, (blkaddr >> 32) as u16);
+            write_u16(&mut v.device_id, device_id);
+            write_u32(&mut v.startblk_lo, blkaddr as u32);
         }
         v
     }
@@ -38,8 +38,8 @@ impl ErofsChunkIndex {
     }
 
     pub fn blkaddr(&self) -> u64 {
-        let hi = get_u16(&self.startblk_hi) as u64;
-        let lo = get_u32(&self.startblk_lo) as u64;
+        let hi = read_u16(&self.startblk_hi) as u64;
+        let lo = read_u32(&self.startblk_lo) as u64;
         let addr = (hi << 32) | lo;
         // The on-disk null chunk (hole) has all 48 address bits set (written by
         // `new(EROFS_NULL_ADDR, ..)` above); normalize it back to the in-memory
@@ -52,7 +52,7 @@ impl ErofsChunkIndex {
     }
 
     pub fn device_id(&self) -> u16 {
-        get_u16(&self.device_id)
+        read_u16(&self.device_id)
     }
 }
 
@@ -83,8 +83,8 @@ impl ErofsDeviceSlot {
     pub fn new(blocks: u64) -> Self {
         let mut v: Self = unsafe { mem::zeroed() };
         debug_assert!(blocks < (1u64 << 48));
-        set_u32(&mut v.blocks_lo, blocks as u32);
-        set_u16(&mut v.blocks_hi, (blocks >> 32) as u16);
+        write_u32(&mut v.blocks_lo, blocks as u32);
+        write_u16(&mut v.blocks_hi, (blocks >> 32) as u16);
         v
     }
 
@@ -109,17 +109,17 @@ impl ErofsDeviceSlot {
     }
 
     pub fn blocks(&self) -> u64 {
-        ((get_u16(&self.blocks_hi) as u64) << 32) | get_u32(&self.blocks_lo) as u64
+        ((read_u16(&self.blocks_hi) as u64) << 32) | read_u32(&self.blocks_lo) as u64
     }
 
     pub fn mapped_blkaddr(&self) -> u64 {
-        ((get_u16(&self.uniaddr_hi) as u64) << 32) | get_u32(&self.uniaddr_lo) as u64
+        ((read_u16(&self.uniaddr_hi) as u64) << 32) | read_u32(&self.uniaddr_lo) as u64
     }
 
     pub fn set_mapped_blkaddr(&mut self, mapped_blkaddr: u64) {
         debug_assert!(mapped_blkaddr < (1u64 << 48));
-        set_u32(&mut self.uniaddr_lo, mapped_blkaddr as u32);
-        set_u16(&mut self.uniaddr_hi, (mapped_blkaddr >> 32) as u16);
+        write_u32(&mut self.uniaddr_lo, mapped_blkaddr as u32);
+        write_u16(&mut self.uniaddr_hi, (mapped_blkaddr >> 32) as u16);
     }
 
     pub fn set_blob_id(&mut self, blob_id: &[u8; EROFS_BLOB_ID_SIZE]) {

--- a/nydus-core/src/metadata/dir.rs
+++ b/nydus-core/src/metadata/dir.rs
@@ -16,8 +16,8 @@ const _: () = assert!(mem::size_of::<ErofsDirent>() == EROFS_DIRENT_SIZE);
 impl ErofsDirent {
     pub fn new(nid: u64, nameoff: u16, file_type: u8) -> Self {
         let mut v: Self = unsafe { mem::zeroed() };
-        set_u64(&mut v.nid, nid);
-        set_u16(&mut v.nameoff, nameoff);
+        write_u64(&mut v.nid, nid);
+        write_u16(&mut v.nameoff, nameoff);
         v.file_type = file_type;
         v
     }
@@ -27,11 +27,11 @@ impl ErofsDirent {
     }
 
     pub fn nid(&self) -> u64 {
-        get_u64(&self.nid)
+        read_u64(&self.nid)
     }
 
     pub fn nameoff(&self) -> u16 {
-        get_u16(&self.nameoff)
+        read_u16(&self.nameoff)
     }
 
     pub fn file_type(&self) -> u8 {

--- a/nydus-core/src/metadata/inode.rs
+++ b/nydus-core/src/metadata/inode.rs
@@ -36,15 +36,15 @@ impl ErofsInodeCompact {
         i_gid: u16,
     ) -> Self {
         let mut v: Self = unsafe { mem::zeroed() };
-        set_u16(&mut v.i_format, i_format);
-        set_u16(&mut v.i_mode, i_mode);
-        set_u16(&mut v.i_nb, i_nb);
-        set_u32(&mut v.i_size, i_size);
-        set_u32(&mut v.i_mtime, i_mtime);
-        set_u32(&mut v.i_u, i_u);
-        set_u32(&mut v.i_ino, i_ino);
-        set_u16(&mut v.i_uid, i_uid);
-        set_u16(&mut v.i_gid, i_gid);
+        write_u16(&mut v.i_format, i_format);
+        write_u16(&mut v.i_mode, i_mode);
+        write_u16(&mut v.i_nb, i_nb);
+        write_u32(&mut v.i_size, i_size);
+        write_u32(&mut v.i_mtime, i_mtime);
+        write_u32(&mut v.i_u, i_u);
+        write_u32(&mut v.i_ino, i_ino);
+        write_u16(&mut v.i_uid, i_uid);
+        write_u16(&mut v.i_gid, i_gid);
         v
     }
 
@@ -55,43 +55,43 @@ impl ErofsInodeCompact {
     }
 
     pub fn format(&self) -> u16 {
-        get_u16(&self.i_format)
+        read_u16(&self.i_format)
     }
 
     pub fn xattr_icount(&self) -> u16 {
-        get_u16(&self.i_xattr_icount)
+        read_u16(&self.i_xattr_icount)
     }
 
     pub fn mode(&self) -> u16 {
-        get_u16(&self.i_mode)
+        read_u16(&self.i_mode)
     }
 
     pub fn nb(&self) -> u16 {
-        get_u16(&self.i_nb)
+        read_u16(&self.i_nb)
     }
 
     pub fn size(&self) -> u64 {
-        get_u32(&self.i_size) as u64
+        read_u32(&self.i_size) as u64
     }
 
     pub fn mtime_delta(&self) -> u32 {
-        get_u32(&self.i_mtime)
+        read_u32(&self.i_mtime)
     }
 
     pub fn i_u(&self) -> u32 {
-        get_u32(&self.i_u)
+        read_u32(&self.i_u)
     }
 
     pub fn ino(&self) -> u32 {
-        get_u32(&self.i_ino)
+        read_u32(&self.i_ino)
     }
 
     pub fn uid(&self) -> u32 {
-        get_u16(&self.i_uid) as u32
+        read_u16(&self.i_uid) as u32
     }
 
     pub fn gid(&self) -> u32 {
-        get_u16(&self.i_gid) as u32
+        read_u16(&self.i_gid) as u32
     }
 }
 
@@ -131,17 +131,17 @@ impl ErofsInodeExtended {
         i_nlink: u32,
     ) -> Self {
         let mut v: Self = unsafe { mem::zeroed() };
-        set_u16(&mut v.i_format, i_format);
-        set_u16(&mut v.i_mode, i_mode);
-        set_u16(&mut v.i_nb, i_nb);
-        set_u64(&mut v.i_size, i_size);
-        set_u32(&mut v.i_u, i_u);
-        set_u32(&mut v.i_ino, i_ino);
-        set_u32(&mut v.i_uid, i_uid);
-        set_u32(&mut v.i_gid, i_gid);
-        set_u64(&mut v.i_mtime, i_mtime);
-        set_u32(&mut v.i_mtime_nsec, i_mtime_nsec);
-        set_u32(&mut v.i_nlink, i_nlink);
+        write_u16(&mut v.i_format, i_format);
+        write_u16(&mut v.i_mode, i_mode);
+        write_u16(&mut v.i_nb, i_nb);
+        write_u64(&mut v.i_size, i_size);
+        write_u32(&mut v.i_u, i_u);
+        write_u32(&mut v.i_ino, i_ino);
+        write_u32(&mut v.i_uid, i_uid);
+        write_u32(&mut v.i_gid, i_gid);
+        write_u64(&mut v.i_mtime, i_mtime);
+        write_u32(&mut v.i_mtime_nsec, i_mtime_nsec);
+        write_u32(&mut v.i_nlink, i_nlink);
         v
     }
 
@@ -152,51 +152,51 @@ impl ErofsInodeExtended {
     }
 
     pub fn format(&self) -> u16 {
-        get_u16(&self.i_format)
+        read_u16(&self.i_format)
     }
 
     pub fn xattr_icount(&self) -> u16 {
-        get_u16(&self.i_xattr_icount)
+        read_u16(&self.i_xattr_icount)
     }
 
     pub fn mode(&self) -> u16 {
-        get_u16(&self.i_mode)
+        read_u16(&self.i_mode)
     }
 
     pub fn nb(&self) -> u16 {
-        get_u16(&self.i_nb)
+        read_u16(&self.i_nb)
     }
 
     pub fn size(&self) -> u64 {
-        get_u64(&self.i_size)
+        read_u64(&self.i_size)
     }
 
     pub fn i_u(&self) -> u32 {
-        get_u32(&self.i_u)
+        read_u32(&self.i_u)
     }
 
     pub fn ino(&self) -> u32 {
-        get_u32(&self.i_ino)
+        read_u32(&self.i_ino)
     }
 
     pub fn uid(&self) -> u32 {
-        get_u32(&self.i_uid)
+        read_u32(&self.i_uid)
     }
 
     pub fn gid(&self) -> u32 {
-        get_u32(&self.i_gid)
+        read_u32(&self.i_gid)
     }
 
     pub fn mtime(&self) -> u64 {
-        get_u64(&self.i_mtime)
+        read_u64(&self.i_mtime)
     }
 
     pub fn mtime_nsec(&self) -> u32 {
-        get_u32(&self.i_mtime_nsec)
+        read_u32(&self.i_mtime_nsec)
     }
 
     pub fn nlink(&self) -> u32 {
-        get_u32(&self.i_nlink)
+        read_u32(&self.i_nlink)
     }
 }
 

--- a/nydus-core/src/metadata/mod.rs
+++ b/nydus-core/src/metadata/mod.rs
@@ -99,32 +99,32 @@ pub const NYDUS_XATTR_SUFFIX_PREFETCH_BLOBS: &[u8] = b"nydus.prefetch.blobs";
 
 /// Read a little-endian integer from a byte array.
 #[inline(always)]
-pub(crate) fn get_u16(b: &[u8; 2]) -> u16 {
+pub(crate) fn read_u16(b: &[u8; 2]) -> u16 {
     u16::from_le_bytes(*b)
 }
 
 #[inline(always)]
-pub(crate) fn set_u16(b: &mut [u8; 2], v: u16) {
+pub(crate) fn write_u16(b: &mut [u8; 2], v: u16) {
     *b = v.to_le_bytes();
 }
 
 #[inline(always)]
-pub(crate) fn get_u32(b: &[u8; 4]) -> u32 {
+pub(crate) fn read_u32(b: &[u8; 4]) -> u32 {
     u32::from_le_bytes(*b)
 }
 
 #[inline(always)]
-pub(crate) fn set_u32(b: &mut [u8; 4], v: u32) {
+pub(crate) fn write_u32(b: &mut [u8; 4], v: u32) {
     *b = v.to_le_bytes();
 }
 
 #[inline(always)]
-pub(crate) fn get_u64(b: &[u8; 8]) -> u64 {
+pub(crate) fn read_u64(b: &[u8; 8]) -> u64 {
     u64::from_le_bytes(*b)
 }
 
 #[inline(always)]
-pub(crate) fn set_u64(b: &mut [u8; 8], v: u64) {
+pub(crate) fn write_u64(b: &mut [u8; 8], v: u64) {
     *b = v.to_le_bytes();
 }
 

--- a/nydus-core/src/metadata/superblock.rs
+++ b/nydus-core/src/metadata/superblock.rs
@@ -53,18 +53,18 @@ impl ErofsSuperblock {
         uuid: &[u8; 16],
     ) -> Self {
         let mut sb: Self = unsafe { mem::zeroed() };
-        set_u32(&mut sb.magic, EROFS_SUPER_MAGIC_V1);
-        set_u32(&mut sb.feature_compat, feature_compat);
+        write_u32(&mut sb.magic, EROFS_SUPER_MAGIC_V1);
+        write_u32(&mut sb.feature_compat, feature_compat);
         sb.blkszbits = EROFS_BLKSZBITS;
-        set_u16(&mut sb.rootnid_2b, root_nid);
-        set_u64(&mut sb.inos, inos);
-        set_u64(&mut sb.epoch, epoch);
-        set_u32(&mut sb.blocks_lo, blocks as u32);
-        set_u32(&mut sb.meta_blkaddr, meta_blkaddr);
+        write_u16(&mut sb.rootnid_2b, root_nid);
+        write_u64(&mut sb.inos, inos);
+        write_u64(&mut sb.epoch, epoch);
+        write_u32(&mut sb.blocks_lo, blocks as u32);
+        write_u32(&mut sb.meta_blkaddr, meta_blkaddr);
         sb.uuid = *uuid;
-        set_u32(&mut sb.feature_incompat, feature_incompat);
-        set_u16(&mut sb.extra_devices, extra_devices);
-        set_u16(&mut sb.devt_slotoff, devt_slotoff);
+        write_u32(&mut sb.feature_incompat, feature_incompat);
+        write_u16(&mut sb.extra_devices, extra_devices);
+        write_u16(&mut sb.devt_slotoff, devt_slotoff);
         sb
     }
 
@@ -73,47 +73,47 @@ impl ErofsSuperblock {
     }
 
     pub fn magic(&self) -> u32 {
-        get_u32(&self.magic)
+        read_u32(&self.magic)
     }
 
     pub fn feature_compat(&self) -> u32 {
-        get_u32(&self.feature_compat)
+        read_u32(&self.feature_compat)
     }
 
     pub fn feature_incompat(&self) -> u32 {
-        get_u32(&self.feature_incompat)
+        read_u32(&self.feature_incompat)
     }
 
     pub fn root_nid(&self) -> u64 {
-        get_u16(&self.rootnid_2b) as u64
+        read_u16(&self.rootnid_2b) as u64
     }
 
     pub fn inos(&self) -> u64 {
-        get_u64(&self.inos)
+        read_u64(&self.inos)
     }
 
     pub fn epoch(&self) -> u64 {
-        get_u64(&self.epoch)
+        read_u64(&self.epoch)
     }
 
     pub fn fixed_nsec(&self) -> u32 {
-        get_u32(&self.fixed_nsec)
+        read_u32(&self.fixed_nsec)
     }
 
     pub fn blocks(&self) -> u64 {
-        get_u32(&self.blocks_lo) as u64
+        read_u32(&self.blocks_lo) as u64
     }
 
     pub fn meta_blkaddr(&self) -> u32 {
-        get_u32(&self.meta_blkaddr)
+        read_u32(&self.meta_blkaddr)
     }
 
     pub fn extra_devices(&self) -> u16 {
-        get_u16(&self.extra_devices)
+        read_u16(&self.extra_devices)
     }
 
     pub fn devt_slotoff(&self) -> u16 {
-        get_u16(&self.devt_slotoff)
+        read_u16(&self.devt_slotoff)
     }
 }
 
@@ -179,7 +179,7 @@ mod tests {
             &[0u8; 16],
         );
         if let Some(m) = magic {
-            set_u32(&mut sb.magic, m);
+            write_u32(&mut sb.magic, m);
         }
         let mut file = tempfile::NamedTempFile::new().unwrap();
         file.write_all(&[0u8; EROFS_SUPER_OFFSET as usize]).unwrap();

--- a/nydus-core/src/storage/backend/registry/mod.rs
+++ b/nydus-core/src/storage/backend/registry/mod.rs
@@ -188,7 +188,7 @@ impl RegistryState {
         self.token_expires_at.store(None);
     }
 
-    fn get_redirect(&self, hex: &str) -> Option<String> {
+    fn redirect(&self, hex: &str) -> Option<String> {
         self.cached_redirect.read().unwrap().get(hex).cloned()
     }
 
@@ -394,7 +394,7 @@ impl Registry {
         let range = format!("bytes={offset}-{end}");
 
         // Fast path: a previously cached redirect URL.
-        if let Some(redirect) = self.state.get_redirect(&hex) {
+        if let Some(redirect) = self.state.redirect(&hex) {
             let mut headers = HeaderMap::new();
             headers.insert(RANGE, range.parse().unwrap());
             let resp = self

--- a/nydus-core/src/storage/cache/local.rs
+++ b/nydus-core/src/storage/cache/local.rs
@@ -506,9 +506,9 @@ impl BlobCache for LocalBlobCache {
         // normally latches it through the shared ready counter, but a
         // historical writer crash between its bit and counter updates leaves
         // the counter short forever; the authoritative bitmap scan inside
-        // all_ready() latches the flag regardless.
+        // check_all_ready() latches the flag regardless.
         if !self.blob_meta.is_redirect_blob() {
-            self.groupmap.all_ready();
+            self.groupmap.check_all_ready();
         }
 
         Ok(())
@@ -629,7 +629,7 @@ impl BlobCache for LocalBlobCache {
             // so we can stop waiting; the caller's prefetch then reduces to a
             // cheap all-ready scan. A redirect blob never marks its own map,
             // so keep waiting for the lock and rely on segment skipping.
-            if !self.blob_meta.is_redirect_blob() && self.groupmap.all_ready() {
+            if !self.blob_meta.is_redirect_blob() && self.groupmap.check_all_ready() {
                 return None;
             }
             if !contention_logged {
@@ -647,7 +647,7 @@ impl BlobCache for LocalBlobCache {
         self.groupmap.is_ready(group_index).unwrap_or(false)
     }
 
-    fn fully_ready(&self) -> bool {
+    fn is_fully_ready(&self) -> bool {
         // A redirect blob never marks its own groupmap (its groups fill other
         // blobs' caches), so the flag is meaningless there.
         !self.blob_meta.is_redirect_blob() && self.groupmap.is_all_ready()

--- a/nydus-core/src/storage/cache/mod.rs
+++ b/nydus-core/src/storage/cache/mod.rs
@@ -89,7 +89,7 @@ pub trait BlobCache: Send + Sync {
     /// skip readiness bookkeeping entirely once the blob is fully warmed.
     /// Sticky: once true it stays true, since ready groups are never evicted
     /// within a cache generation.
-    fn fully_ready(&self) -> bool {
+    fn is_fully_ready(&self) -> bool {
         false
     }
 

--- a/nydus-core/src/storage/groupmap.rs
+++ b/nydus-core/src/storage/groupmap.rs
@@ -282,7 +282,7 @@ impl GroupMap {
     /// first; otherwise scans the shared bitmap and latches the flag when the
     /// scan proves completion (also healing any ready-count skew left by a
     /// crashed writer). The answer reflects updates from other processes.
-    pub fn all_ready(&self) -> bool {
+    pub fn check_all_ready(&self) -> bool {
         if self.is_all_ready() {
             return true;
         }
@@ -397,12 +397,12 @@ mod tests {
         assert!(!observer.is_ready(7).unwrap());
         writer.set_ready(7).unwrap();
         assert!(observer.is_ready(7).unwrap());
-        assert!(!observer.all_ready());
+        assert!(!observer.check_all_ready());
 
         for index in 0..20 {
             writer.set_ready(index).unwrap();
         }
-        assert!(observer.all_ready());
+        assert!(observer.check_all_ready());
     }
 
     #[test]
@@ -493,7 +493,7 @@ mod tests {
         // a concurrent observer see it without any bitmap scan or reopen.
         assert!(writer.is_all_ready());
         assert!(observer.is_all_ready());
-        assert!(observer.all_ready());
+        assert!(observer.check_all_ready());
 
         // ready_ranges collapses to the whole span on the fast path.
         assert_eq!(observer.ready_ranges(0, 8).unwrap(), vec![0..9]);
@@ -524,7 +524,7 @@ mod tests {
         // Open reconciles the flag from the authoritative bitmap.
         let map = GroupMap::open(&path, group_count).unwrap();
         assert!(map.is_all_ready());
-        assert!(map.all_ready());
+        assert!(map.check_all_ready());
         // The heal path also corrects the advisory ready counter.
         assert_eq!(map.ready_count(), group_count);
     }
@@ -536,7 +536,7 @@ mod tests {
 
         let map = GroupMap::open(&path, 0).unwrap();
         assert!(map.is_all_ready());
-        assert!(map.all_ready());
+        assert!(map.check_all_ready());
     }
 
     #[test]
@@ -545,7 +545,7 @@ mod tests {
         let path = dir.path().join("blob.group.map");
 
         // 9 groups spill into a second bitmap byte; exercise both byte
-        // boundaries and the partial final byte in all_ready().
+        // boundaries and the partial final byte in check_all_ready().
         let map = GroupMap::open(&path, 9).unwrap();
         for index in [0usize, 7, 8] {
             assert!(!map.is_ready(index).unwrap());
@@ -555,11 +555,11 @@ mod tests {
         for index in [1usize, 6] {
             assert!(!map.is_ready(index).unwrap(), "neighbor bit {index} leaked");
         }
-        assert!(!map.all_ready());
+        assert!(!map.check_all_ready());
         for index in 0..9 {
             map.set_ready(index).unwrap();
         }
-        assert!(map.all_ready());
+        assert!(map.check_all_ready());
 
         // Out-of-range indexes are rejected, not silently wrapped.
         assert_eq!(
@@ -600,7 +600,7 @@ mod tests {
         for index in 0..group_count {
             assert!(verify.is_ready(index).unwrap(), "lost update at {index}");
         }
-        assert!(verify.all_ready());
+        assert!(verify.check_all_ready());
     }
 
     #[test]
@@ -620,7 +620,7 @@ mod tests {
         for index in 0..group_count {
             assert!(map.is_ready(index).unwrap());
         }
-        assert!(map.all_ready());
+        assert!(map.check_all_ready());
         let elapsed = start.elapsed();
         // Generous bound (debug builds included): catches only pathological
         // regressions such as reintroducing per-bit file I/O.

--- a/nydus-core/src/storage/prefetch.rs
+++ b/nydus-core/src/storage/prefetch.rs
@@ -55,7 +55,7 @@ impl BlobPrefetcher {
         // not spent pulling whole source blobs.
         for blob_index in priority {
             if !self.full {
-                match self.reader.blob_is_redirect(blob_index) {
+                match self.reader.is_redirect_blob(blob_index) {
                     Ok(true) => {}
                     Ok(false) => continue,
                     Err(err) => {

--- a/nydus-core/tests/core.rs
+++ b/nydus-core/tests/core.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the `NydusAccessor` public API. They live in
+//! Integration tests for the `NydusCore` public API. They live in
 //! `tests/` (not as unit tests) because building fixture images requires the
 //! `nydus` builder, which itself depends on this crate.
 
@@ -23,7 +23,7 @@ use nydus_core::metadata::{
 };
 use nydus_core::metadata::{EROFS_BLOB_ID_SIZE, EROFS_BLOCK_SIZE};
 use nydus_core::utils::{hex_string, sha256_file};
-use nydus_core::{BlobID, FileType, NydusAccessor};
+use nydus_core::{BlobId, FileType, NydusCore};
 use std::collections::HashSet;
 use std::fs;
 use std::io::Write;
@@ -211,18 +211,15 @@ fn write_full_blob(
 }
 
 #[test]
-fn accessor_describes_devices_and_fetches_aligned_ranges() {
+fn core_describes_devices_and_fetches_aligned_ranges() {
     let dir = tempdir().unwrap();
     let (bootstrap, config, blob_id, _corpus) = build_flattened_test_image(dir.path());
-    let blob_id = BlobID::from(blob_id);
+    let blob_id = BlobId::from(blob_id);
 
-    let accessor = NydusAccessor::new(&bootstrap, config).unwrap();
-    assert_eq!(
-        accessor.bootstrap_size,
-        fs::metadata(&bootstrap).unwrap().len()
-    );
-    assert_eq!(accessor.bootstrap_size % EROFS_BLOCK_SIZE as u64, 0);
-    let blobs = accessor.blob.entries().unwrap();
+    let core = NydusCore::new(&bootstrap, config).unwrap();
+    assert_eq!(core.bootstrap_size, fs::metadata(&bootstrap).unwrap().len());
+    assert_eq!(core.bootstrap_size % EROFS_BLOCK_SIZE as u64, 0);
+    let blobs = core.blobs.entries().unwrap();
     assert_eq!(blobs.len(), 1);
     let descriptor = &blobs[0];
     assert_eq!(descriptor.index, 1);
@@ -232,7 +229,7 @@ fn accessor_describes_devices_and_fetches_aligned_ranges() {
         descriptor.cache_size,
         descriptor.blocks * EROFS_BLOCK_SIZE as u64
     );
-    assert!(descriptor.mapped_offset >= accessor.bootstrap_size);
+    assert!(descriptor.mapped_offset >= core.bootstrap_size);
     assert_eq!(
         descriptor.mapped_offset,
         descriptor.mapped_blkaddr * EROFS_BLOCK_SIZE as u64
@@ -240,19 +237,17 @@ fn accessor_describes_devices_and_fetches_aligned_ranges() {
     let meta = fs::metadata(&descriptor.cache_path).unwrap();
     assert_eq!(meta.len(), descriptor.cache_size);
     assert_eq!(
-        accessor.flat_size(),
+        core.flat_size(),
         descriptor.mapped_offset + descriptor.cache_size
     );
     assert_eq!(
-        accessor.bootstrap().metadata().unwrap().len(),
-        accessor.bootstrap_size
+        core.bootstrap().metadata().unwrap().len(),
+        core.bootstrap_size
     );
-    assert!(accessor.zero_fd() >= 0);
-    let bootstrap_ranges = accessor
-        .fetch_flat_ranges(0, EROFS_BLOCK_SIZE as u64)
-        .unwrap();
+    assert!(core.zero_fd() >= 0);
+    let bootstrap_ranges = core.fetch_flat_ranges(0, EROFS_BLOCK_SIZE as u64).unwrap();
     assert_eq!(bootstrap_ranges.len(), 1);
-    assert_eq!(bootstrap_ranges[0].fd, accessor.bootstrap().as_raw_fd());
+    assert_eq!(bootstrap_ranges[0].fd, core.bootstrap().as_raw_fd());
     assert_eq!(bootstrap_ranges[0].offset, 0);
     assert_eq!(bootstrap_ranges[0].source_offset, 0);
     assert_eq!(bootstrap_ranges[0].len, EROFS_BLOCK_SIZE as u64);
@@ -264,44 +259,44 @@ fn accessor_describes_devices_and_fetches_aligned_ranges() {
     let block = EROFS_BLOCK_SIZE as u64;
     let (blob_offset, len) = (256 * block, 16 * block);
     let offset = descriptor.mapped_offset + blob_offset;
-    assert!(accessor.probe_flat_ranges(offset, len).unwrap().is_empty());
-    let fd_ranges = accessor.fetch_flat_ranges(offset, len).unwrap();
+    assert!(core.probe_flat_ranges(offset, len).unwrap().is_empty());
+    let fd_ranges = core.fetch_flat_ranges(offset, len).unwrap();
     assert_eq!(fd_ranges.len(), 1);
     assert_eq!(fd_ranges[0].offset, blob_offset);
     assert_eq!(fd_ranges[0].len, len);
     assert_eq!(fd_ranges[0].source_offset, offset);
-    assert_ne!(fd_ranges[0].fd, accessor.zero_fd());
-    accessor.blob.fetch(&blob_id, blob_offset, len).unwrap();
+    assert_ne!(fd_ranges[0].fd, core.zero_fd());
+    core.blobs.fetch(&blob_id, blob_offset, len).unwrap();
     let cached = fs::read(&descriptor.cache_path).unwrap();
     assert!(cached[blob_offset as usize..(blob_offset + len) as usize]
         .iter()
         .any(|byte| *byte != 0));
-    assert_eq!(accessor.probe_flat_ranges(offset, len).unwrap(), fd_ranges);
+    assert_eq!(core.probe_flat_ranges(offset, len).unwrap(), fd_ranges);
 
     // Idempotent re-fetch and zero-length fetch are fine.
-    accessor.blob.fetch(&blob_id, offset, len).unwrap();
-    accessor.blob.fetch(&blob_id, 0, 0).unwrap();
+    core.blobs.fetch(&blob_id, offset, len).unwrap();
+    core.blobs.fetch(&blob_id, 0, 0).unwrap();
 
-    let trace = accessor.trace_snapshot();
+    let trace = core.trace_snapshot();
     assert_eq!(trace.patterns.len(), 1);
     assert_eq!(trace.patterns[0].blob_index, 1);
     assert_eq!(trace.patterns[0].group_index, 1);
     assert_eq!(
-        accessor.trace_json(),
+        core.trace_json(),
         "{\"version\":1,\"patterns\":[{\"blob_index\":1,\"group_index\":1}]}"
     );
 
     // Unaligned ranges and unknown blobs are rejected.
-    assert!(accessor.blob.fetch(&blob_id, 1, block).is_err());
-    assert!(accessor.blob.fetch(&blob_id, 0, block + 1).is_err());
-    assert!(accessor
-        .blob
-        .fetch(&BlobID::from([0u8; 32]), 0, block)
+    assert!(core.blobs.fetch(&blob_id, 1, block).is_err());
+    assert!(core.blobs.fetch(&blob_id, 0, block + 1).is_err());
+    assert!(core
+        .blobs
+        .fetch(&BlobId::from([0u8; 32]), 0, block)
         .is_err());
 
     // Out-of-range fetch fails rather than fabricating data.
-    assert!(accessor
-        .blob
+    assert!(core
+        .blobs
         .fetch(&blob_id, descriptor.cache_size, block)
         .is_err());
 }
@@ -381,14 +376,14 @@ fn flattened_bootstrap_records_mapped_device_slots() {
 }
 
 #[test]
-fn accessor_static_filesystem_api_reads_metadata_and_data() {
+fn core_static_filesystem_api_reads_metadata_and_data() {
     let dir = tempdir().unwrap();
     let (bootstrap, config, blob_id, corpus) = build_test_image(dir.path());
-    let blob_id = BlobID::from(blob_id);
+    let blob_id = BlobId::from(blob_id);
 
-    let accessor = NydusAccessor::new(&bootstrap, config).unwrap();
+    let core = NydusCore::new(&bootstrap, config).unwrap();
 
-    let root_entry = accessor.fs.open("/").unwrap();
+    let root_entry = core.fs.open("/").unwrap();
     let root = root_entry.metadata().unwrap();
     assert_eq!(root.file_type, FileType::Directory);
 
@@ -401,7 +396,7 @@ fn accessor_static_filesystem_api_reads_metadata_and_data() {
     assert!(names.contains(&"dir"));
     assert!(names.contains(&"link_to_file1"));
 
-    let file1_entry = accessor.fs.open("file1").unwrap();
+    let file1_entry = core.fs.open("file1").unwrap();
     let file1 = file1_entry.metadata().unwrap();
     assert_eq!(file1.file_type, FileType::RegularFile);
     assert!(file1.size >= corpus["file1"].len() as u64);
@@ -419,7 +414,7 @@ fn accessor_static_filesystem_api_reads_metadata_and_data() {
     assert_eq!(read, second.len());
     assert_eq!(&second, &corpus["file1"][777..777 + read]);
 
-    let tiny = accessor.fs.open("tiny.txt").unwrap().read().unwrap();
+    let tiny = core.fs.open("tiny.txt").unwrap().read().unwrap();
     assert_eq!(
         &tiny[..corpus["tiny.txt"].len()],
         corpus["tiny.txt"].as_slice()
@@ -427,14 +422,14 @@ fn accessor_static_filesystem_api_reads_metadata_and_data() {
     assert!(tiny[corpus["tiny.txt"].len()..]
         .iter()
         .all(|byte| *byte == 0));
-    assert!(accessor
+    assert!(core
         .fs
         .open("empty.txt")
         .unwrap()
         .read()
         .unwrap()
         .is_empty());
-    let small = accessor.fs.open("dir/small.txt").unwrap().read().unwrap();
+    let small = core.fs.open("dir/small.txt").unwrap().read().unwrap();
     assert_eq!(
         &small[..corpus["dir/small.txt"].len()],
         corpus["dir/small.txt"].as_slice()
@@ -443,7 +438,7 @@ fn accessor_static_filesystem_api_reads_metadata_and_data() {
         .iter()
         .all(|byte| *byte == 0));
 
-    let link_entry = accessor.fs.open("link_to_file1").unwrap();
+    let link_entry = core.fs.open("link_to_file1").unwrap();
     let link = link_entry.read_link().unwrap();
     assert_eq!(link, b"file1");
     assert_eq!(link_entry.read_link().unwrap(), b"file1");
@@ -455,7 +450,7 @@ fn accessor_static_filesystem_api_reads_metadata_and_data() {
         name.as_slice() == b"trusted.nydus.prefetch.blobs" && value.as_slice() == b"1"
     }));
 
-    let blobs = accessor.blob.entries().unwrap();
+    let blobs = core.blobs.entries().unwrap();
     let cached = fs::read(&blobs[0].cache_path).unwrap();
     assert!(cached.iter().any(|byte| *byte != 0));
     assert_eq!(blobs[0].id, blob_id);
@@ -466,22 +461,22 @@ fn fs_entry_fetch_populates_blob_cache_without_reading_data() {
     let dir = tempdir().unwrap();
     let (bootstrap, config, _blob_id, _corpus) = build_test_image(dir.path());
 
-    let accessor = NydusAccessor::new(&bootstrap, config).unwrap();
-    let blobs = accessor.blob.entries().unwrap();
+    let core = NydusCore::new(&bootstrap, config).unwrap();
+    let blobs = core.blobs.entries().unwrap();
     let before = fs::read(&blobs[0].cache_path).unwrap();
     assert!(before.iter().all(|byte| *byte == 0));
 
-    let file1_entry = accessor.fs.open("file1").unwrap();
+    let file1_entry = core.fs.open("file1").unwrap();
     assert!(file1_entry.probe_ranges(12345, 4097).unwrap().is_empty());
     let ranges = file1_entry.fetch_ranges(12345, 4097).unwrap();
     assert!(!ranges.is_empty());
     assert_eq!(ranges[0].source_offset, 12345);
-    assert_ne!(ranges[0].fd, accessor.zero_fd());
+    assert_ne!(ranges[0].fd, core.zero_fd());
     file1_entry.fetch(12345, 4097).unwrap();
     assert_eq!(file1_entry.probe_ranges(12345, 4097).unwrap(), ranges);
 
     let after = fs::read(&blobs[0].cache_path).unwrap();
     assert!(after.iter().any(|byte| *byte != 0));
     file1_entry.fetch(0, 0).unwrap();
-    accessor.fs.open("/").unwrap().fetch(0, 4096).unwrap_err();
+    core.fs.open("/").unwrap().fetch(0, 4096).unwrap_err();
 }

--- a/nydus/Cargo.toml
+++ b/nydus/Cargo.toml
@@ -3,7 +3,7 @@ name = "nydus"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-description = "EROFS-oriented image tooling and runtime accessor APIs for Nydus images."
+description = "EROFS-oriented image tooling and runtime core APIs for Nydus images."
 repository = "https://github.com/dragonflyoss/nydus"
 readme = "../README.md"
 
@@ -31,7 +31,7 @@ cli = [
   "dep:tracing-subscriber",
 ]
 # Device-level userfaultfd service for microVM virtio-pmem use cases.
-# This is intentionally not part of the default or builtin accessor path.
+# This is intentionally not part of the default or builtin core path.
 uffd = [
   "dep:sendfd",
   "dep:tokio",

--- a/nydus/src/fanotify/core.rs
+++ b/nydus/src/fanotify/core.rs
@@ -4,19 +4,19 @@
 //! shape is multi-device EROFS: the **bootstrap is a real local EROFS image**
 //! (superblock + all inode/dirent metadata + a device table) that the operator
 //! mounts directly, and each data **blob is a separate EROFS device** backed by
-//! the accessor's per-blob sparse cache file (`BlobInfo::cache_path`).
+//! the core's per-blob sparse cache file (`BlobInfo::cache_path`).
 //!
 //! Consequences:
 //! - The daemon marks each blob's cache file (the device), not the bootstrap.
 //!   Mount and metadata reads (`ls`, `stat`) hit the real local bootstrap and do
 //!   not involve fanotify at all; only cold blob-data reads fault.
-//! - Filling is `BlobAccessor::fetch(id, off, len)`, which decodes + validates +
+//! - Filling is `Blobs::fetch(id, off, len)`, which decodes + validates +
 //!   writes the blob's cache file *in place* (the same file the kernel reads) and
 //!   is idempotent — so no hand-rolled pwrite/dedup/fsync is needed here; that
 //!   I/O lives in (and is tested by) `nydus-core`.
 //!
 //! Kernel-independent logic here (device lookup, RANGE decision, fetch-range
-//! alignment) is unit-tested; the accessor fetch and the event loop are not
+//! alignment) is unit-tested; the core fetch and the event loop are not
 //! (they need a real image / kernel).
 
 use std::collections::HashMap;
@@ -30,11 +30,11 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use tracing::{debug, warn};
 
-use crate::{BlobID, Config, NydusAccessor};
+use crate::{BlobId, Config, NydusCore};
 
 use super::event::{PreContentEvent, Range, FAN_PRE_ACCESS};
 
-/// EROFS block size as u64 — reuses the canonical constant from the accessor.
+/// EROFS block size as u64 — reuses the canonical constant from the core.
 const BLOCK_SIZE: u64 = crate::metadata::EROFS_BLOCK_SIZE as u64;
 
 /// `fanotify_init(2)` flag: close-on-exec on the group descriptor.
@@ -94,7 +94,7 @@ pub enum RangeError {
 pub struct BlobDevice {
     /// 1-based device-table index, preserved from the bootstrap.
     pub index: u16,
-    pub id: BlobID,
+    pub id: BlobId,
     /// True for an "ondemand" redirect blob the guest must never read directly.
     pub is_redirect: bool,
     /// Host path of the blob's sparse cache file = the EROFS `device=` target.
@@ -108,7 +108,7 @@ pub struct BlobDevice {
 impl BlobDevice {
     pub(crate) fn for_test(
         index: u16,
-        id: BlobID,
+        id: BlobId,
         is_redirect: bool,
         cache_path: PathBuf,
         cache_size: u64,
@@ -124,21 +124,21 @@ impl BlobDevice {
 }
 
 pub struct FanotifyCore {
-    accessor: Arc<NydusAccessor>,
+    core: Arc<NydusCore>,
     devices: Vec<BlobDevice>,
     /// `(dev, ino)` → index into `devices` for O(1) event-fd lookup.
     device_index: HashMap<(u64, u64), usize>,
-    /// `BlobID` → index into `devices` for O(1) slot lookup by blob identity.
-    blob_slot: HashMap<BlobID, usize>,
+    /// `BlobId` → index into `devices` for O(1) slot lookup by blob identity.
+    blob_slot: HashMap<BlobId, usize>,
     /// Per-device-slot sticky flag: true once the fanotify mark has been removed
     /// (or was never added because the blob was already fully ready at startup).
-    /// Prevents redundant `fully_ready` probes and duplicate `FAN_MARK_REMOVE`
+    /// Prevents redundant `is_fully_ready` probes and duplicate `FAN_MARK_REMOVE`
     /// syscalls across concurrent fetch workers.
     unmarked: Vec<AtomicBool>,
 }
 
 impl FanotifyCore {
-    /// Build the accessor and enumerate the blob devices. `entries()` also
+    /// Build the core and enumerate the blob devices. `entries()` also
     /// prepares (creates + sizes) each blob's cache file, so the device files
     /// exist and can be marked/mounted immediately after this returns.
     ///
@@ -150,11 +150,10 @@ impl FanotifyCore {
     /// descriptor.
     pub fn new(bootstrap: &Path, config: Config) -> Result<Self> {
         validate_bounded_backend_timeout(&config)?;
-        let accessor = Arc::new(
-            NydusAccessor::new(bootstrap, config).context("failed to create nydus accessor")?,
-        );
-        let entries = accessor
-            .blob
+        let core =
+            Arc::new(NydusCore::new(bootstrap, config).context("failed to create nydus core")?);
+        let entries = core
+            .blobs
             .entries()
             .context("failed to enumerate blob devices")?;
 
@@ -197,7 +196,7 @@ impl FanotifyCore {
 
         let unmarked: Vec<AtomicBool> = devices.iter().map(|_| AtomicBool::new(false)).collect();
         Ok(Self {
-            accessor,
+            core,
             devices,
             device_index,
             blob_slot,
@@ -221,13 +220,13 @@ impl FanotifyCore {
 
     /// Return true when the authoritative groupmap already covers the complete
     /// aligned range. This never triggers backend I/O.
-    pub fn range_ready(&self, id: &BlobID, offset: u64, len: u64) -> Result<bool> {
+    pub fn is_range_ready(&self, id: &BlobId, offset: u64, len: u64) -> Result<bool> {
         let end = offset
             .checked_add(len)
             .ok_or_else(|| anyhow::anyhow!("ready range overflow"))?;
         let ready = self
-            .accessor
-            .blob
+            .core
+            .blobs
             .ready_ranges(id, offset, len)
             .context("failed to inspect blob ready ranges")?;
         Ok(ready.len() == 1 && ready[0].start == offset && ready[0].end == end)
@@ -237,7 +236,7 @@ impl FanotifyCore {
     /// the blob's cache file (the same file the kernel reads).
     pub fn fetch(
         &self,
-        id: &BlobID,
+        id: &BlobId,
         cache_size: u64,
         offset: u64,
         count: u64,
@@ -246,7 +245,7 @@ impl FanotifyCore {
         debug_assert!(offset % BLOCK_SIZE == 0);
         debug_assert!(count % BLOCK_SIZE == 0);
         debug_assert!(offset <= cache_size && offset + count <= cache_size);
-        self.accessor.blob.fetch(id, offset, count).map_err(|e| {
+        self.core.blobs.fetch(id, offset, count).map_err(|e| {
             FetchError::Backend(
                 e.context(format!("failed to fetch blob range [{offset}, +{count})")),
             )
@@ -275,7 +274,7 @@ impl FanotifyCore {
     /// `fan_fd` must be a live fanotify group descriptor. `fanotify_mark` is
     /// thread-safe; concurrent calls with `FAN_MARK_REMOVE` on the same path
     /// are harmless (the loser gets `ENOENT`).
-    pub fn try_unmark(&self, fan_fd: RawFd, id: &BlobID) -> bool {
+    pub fn try_unmark(&self, fan_fd: RawFd, id: &BlobId) -> bool {
         let Some(&slot) = self.blob_slot.get(id) else {
             return false;
         };
@@ -286,7 +285,7 @@ impl FanotifyCore {
             return false;
         }
         // O(1) probe: single atomic load on the groupmap's shared ALL_READY flag.
-        if !self.accessor.blob.fully_ready(id).unwrap_or(false) {
+        if !self.core.blobs.is_fully_ready(id).unwrap_or(false) {
             return false;
         }
         // Claim the unmark: exactly one thread wins the CAS.
@@ -359,7 +358,7 @@ pub fn decide(event: &PreContentEvent) -> Decision {
 }
 
 /// Align `[offset, offset + count)` outward to whole 4 KiB blocks and clamp to
-/// `cache_size` (`BlobAccessor::fetch` requires block-aligned arguments), using
+/// `cache_size` (`Blobs::fetch` requires block-aligned arguments), using
 /// checked arithmetic throughout. Reports why the range is unusable instead of
 /// silently producing an empty range that a caller might treat as success.
 pub(crate) fn align_fetch_range(

--- a/nydus/src/fanotify/mod.rs
+++ b/nydus/src/fanotify/mod.rs
@@ -3,8 +3,8 @@
 //! nydus's native shape is multi-device EROFS: the **bootstrap is a real local
 //! EROFS image** (superblock + all inode/dirent metadata + a device table) that
 //! the operator mounts directly, and each data **blob is a separate EROFS device**
-//! backed by the accessor's per-blob sparse cache file. This daemon marks the
-//! blob devices and fills them on demand via [`NydusAccessor`]'s blob fetch.
+//! backed by the core's per-blob sparse cache file. This daemon marks the
+//! blob devices and fills them on demand via [`NydusCore`]'s blob fetch.
 //!
 //! Consequences of the multi-device split: mount and metadata reads (`ls`,
 //! `stat`) hit the real local bootstrap and never involve fanotify; only cold
@@ -20,7 +20,7 @@
 //! and response ownership — is unit-tested; the full on-demand data path has
 //! been verified end-to-end with a registry backend on a 6.15 kernel.
 //!
-//! [`NydusAccessor`]: crate::NydusAccessor
+//! [`NydusCore`]: crate::NydusCore
 
 pub mod core;
 pub mod event;

--- a/nydus/src/fanotify/mount.rs
+++ b/nydus/src/fanotify/mount.rs
@@ -116,12 +116,12 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
-    use crate::BlobID;
+    use crate::BlobId;
 
     fn device(index: u16, path: &str) -> BlobDevice {
         BlobDevice::for_test(
             index,
-            BlobID::from_str(&format!("{index:064x}")).unwrap(),
+            BlobId::from_str(&format!("{index:064x}")).unwrap(),
             false,
             PathBuf::from(path),
             4096,

--- a/nydus/src/fanotify/service.rs
+++ b/nydus/src/fanotify/service.rs
@@ -1,6 +1,6 @@
 //! Fanotify pre-content group setup and an event coordinator (epoll + thread pool).
 //!
-//! The coordinator runs one event loop and never runs the synchronous accessor
+//! The coordinator runs one event loop and never runs the synchronous core
 //! fetch inline. Each event dispatches its fetch to a thread pool; the task
 //! reports every result back through a completion channel. Concurrency is
 //! bounded by the pool size (--fetch-concurrency).
@@ -21,7 +21,7 @@ use std::thread;
 use anyhow::{anyhow, Context, Result};
 use tracing::{debug, warn};
 
-use crate::BlobID;
+use crate::BlobId;
 
 use super::core::{
     align_fetch_range, decide, fd_identity, Decision, DenyReason, FanotifyCore, FetchError,
@@ -54,7 +54,7 @@ struct Completion {
 
 /// Coalescing key: identical (blob, aligned offset, aligned length) reads share
 /// one fetch job and are all answered by its single completion.
-type FetchKey = (BlobID, u64, u64);
+type FetchKey = (BlobId, u64, u64);
 
 /// One in-flight fetch job and every permission event waiting on it. Concurrent
 /// reads of the same range (common at container start: many tasks page in the
@@ -257,7 +257,7 @@ impl FanotifyService {
 
         for (slot, device) in core.devices().iter().enumerate() {
             if core
-                .range_ready(&device.id, 0, device.cache_size)
+                .is_range_ready(&device.id, 0, device.cache_size)
                 .unwrap_or(false)
             {
                 // Record that this slot's mark was never added, so runtime
@@ -676,7 +676,7 @@ fn admit_event(
             return Ok(());
         }
     };
-    match core.range_ready(&device.id, offset, count) {
+    match core.is_range_ready(&device.id, offset, count) {
         Ok(true) => {
             debug!(
                 "fanotify: range [{}, +{}) already ready for blob {}; allowing immediately",
@@ -961,7 +961,7 @@ mod tests {
     }
 
     fn key() -> FetchKey {
-        (BlobID::from_str(&format!("{:064x}", 7)).unwrap(), 0, 4096)
+        (BlobId::from_str(&format!("{:064x}", 7)).unwrap(), 0, 4096)
     }
 
     /// Two readers coalesced onto one job both receive the fetch's decision.

--- a/nydus/src/fuse.rs
+++ b/nydus/src/fuse.rs
@@ -116,7 +116,7 @@ impl ErofsFs {
         Ok(handle)
     }
 
-    fn get_dir_handle(&self, handle: u64) -> io::Result<Arc<DirHandle>> {
+    fn dir_handle(&self, handle: u64) -> io::Result<Arc<DirHandle>> {
         self.dir_handles
             .lock()
             .unwrap()
@@ -392,7 +392,7 @@ impl Filesystem for ErofsFs {
         mut reply: ReplyDirectory,
     ) {
         let mut m = FsOpMetric::new(metrics::FsOp::Readdir);
-        let dir_handle = match self.get_dir_handle(fh.0) {
+        let dir_handle = match self.dir_handle(fh.0) {
             Ok(h) => h,
             Err(e) => {
                 m.fail();
@@ -421,7 +421,7 @@ impl Filesystem for ErofsFs {
         mut reply: ReplyDirectoryPlus,
     ) {
         let mut m = FsOpMetric::new(metrics::FsOp::Readdirplus);
-        let dir_handle = match self.get_dir_handle(fh.0) {
+        let dir_handle = match self.dir_handle(fh.0) {
             Ok(h) => h,
             Err(e) => {
                 m.fail();

--- a/nydus/src/lib.rs
+++ b/nydus/src/lib.rs
@@ -1,7 +1,7 @@
-// Re-export the accessor runtime modules so that in-crate paths like
+// Re-export the core runtime modules so that in-crate paths like
 // `crate::metadata` keep resolving for `build`, `merge`, `uffd` and the
 // `nydus` binary after the split into the `nydus-core` crate.
-pub use nydus_core::{accessor, config, fs, metadata, metrics, storage, utils};
+pub use nydus_core::{config, core, fs, metadata, metrics, storage, utils};
 
 pub mod build;
 #[cfg(feature = "fanotify")]
@@ -24,9 +24,8 @@ pub use fuse::ErofsFs;
 #[cfg(feature = "backend-registry")]
 pub use nydus_core::Registry;
 pub use nydus_core::{
-    build_backend, BlobAccessor, BlobBackend, BlobID, BlobInfo, BlobMeta, BlobMetaChunk,
-    BlobMetaGroup, BlobMetaHeader, BlobPrefetcher, Config, DirEntry, FdRange, FileType, FsAccessor,
-    FsEntry, GroupMap, LocalBackend, Metadata, MetricsSnapshot, NydusAccessor, RequestSource,
-    TraceDocument, TracePattern, TraceRecorder, BLOB_META_HEADER_SIZE, BLOB_META_MAGIC,
-    DEFAULT_PREFETCH_THREADS,
+    build_backend, BlobBackend, BlobId, BlobInfo, BlobMeta, BlobMetaChunk, BlobMetaGroup,
+    BlobMetaHeader, BlobPrefetcher, Blobs, Config, DirEntry, FdRange, FileType, Fs, FsEntry,
+    GroupMap, LocalBackend, Metadata, MetricsSnapshot, NydusCore, RequestSource, TraceDocument,
+    TracePattern, TraceRecorder, BLOB_META_HEADER_SIZE, BLOB_META_MAGIC, DEFAULT_PREFETCH_THREADS,
 };

--- a/nydus/src/nbd/core.rs
+++ b/nydus/src/nbd/core.rs
@@ -1,6 +1,6 @@
 //! Fill engine for the NBD service, flat single-device model.
 //!
-//! The accessor exposes the whole image as one flattened device view: the
+//! The core exposes the whole image as one flattened device view: the
 //! bootstrap at the head, then each blob at its `mapped_offset`, with gaps
 //! (and any redirect blob) reported as `/dev/zero`. [`NbdCore`] wraps that
 //! view with a synchronous `read` that fetches the covering ranges and copies
@@ -27,19 +27,19 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 
 use crate::metadata::EROFS_BLOCK_SIZE;
-use crate::{Config, NydusAccessor};
+use crate::{Config, NydusCore};
 
-/// EROFS block size as u64 — reuses the canonical constant from the accessor.
+/// EROFS block size as u64 — reuses the canonical constant from the core.
 const BLOCK_SIZE: u64 = EROFS_BLOCK_SIZE as u64;
 
 /// Read-side handle for the NBD on-demand service.
 ///
-/// Holds a shared accessor (so background prefetch keeps running) and the
+/// Holds a shared core (so background prefetch keeps running) and the
 /// flattened device size computed at construction. All read paths are
-/// block-aligned by the NBD protocol, which matches the accessor's fetch
+/// block-aligned by the NBD protocol, which matches the core's fetch
 /// precondition.
 pub struct NbdCore {
-    accessor: Arc<NydusAccessor>,
+    core: Arc<NydusCore>,
     flat_size: u64,
 }
 
@@ -48,11 +48,10 @@ impl NbdCore {
     /// No blob meta is downloaded and no cache file is created until a read
     /// first touches a blob, so this returns quickly even for large images.
     pub fn new(bootstrap: &Path, config: Config) -> Result<Self> {
-        let accessor = Arc::new(
-            NydusAccessor::new(bootstrap, config).context("failed to create nydus accessor")?,
-        );
+        let core =
+            Arc::new(NydusCore::new(bootstrap, config).context("failed to create nydus core")?);
 
-        let flat_size = accessor.flat_size();
+        let flat_size = core.flat_size();
         if flat_size == 0 {
             anyhow::bail!("flattened image size is zero");
         }
@@ -61,10 +60,7 @@ impl NbdCore {
                 "flattened image size {flat_size} is not a multiple of the {BLOCK_SIZE} B EROFS block size"
             );
         }
-        Ok(Self {
-            accessor,
-            flat_size,
-        })
+        Ok(Self { core, flat_size })
     }
 
     /// Total size in bytes of the flattened block device exposed to the kernel.
@@ -100,10 +96,10 @@ impl NbdCore {
         }
 
         let ranges = self
-            .accessor
+            .core
             .fetch_flat_ranges(offset, len)
             .context("failed to fetch flat ranges for nbd read")?;
-        let zero_fd = self.accessor.zero_fd();
+        let zero_fd = self.core.zero_fd();
         let mut written = 0usize;
         for range in ranges {
             // The fetch contract is a gapless cover of the request window;
@@ -137,7 +133,7 @@ impl NbdCore {
             }
             written += seg_len;
         }
-        // The accessor resolves the whole requested window, so every byte is
+        // The core resolves the whole requested window, so every byte is
         // accounted for; pad the tail with zeros defensively if it ever is not.
         if written < buf.len() {
             buf[written..].fill(0);

--- a/nydus/src/nbd/mod.rs
+++ b/nydus/src/nbd/mod.rs
@@ -3,7 +3,7 @@
 //! Exposes the flattened EROFS image (bootstrap + all data blobs) as a single
 //! read-only block device through the Linux NBD driver. The kernel reads
 //! `/dev/nbdX`; each cold read fetches the covering blob ranges through
-//! [`NydusAccessor`]'s on-demand backend into the per-blob sparse cache file.
+//! [`NydusCore`]'s on-demand backend into the per-blob sparse cache file.
 //! Repeat reads are served by the page cache above the device; reads that do
 //! reach the daemon again (after eviction) pread cache-resident ranges
 //! locally without touching the backend.
@@ -13,7 +13,7 @@
 //! through the NBD socket protocol instead of fanotify pre-content hooks, so
 //! it works on kernels without `FAN_CLASS_PRE_CONTENT` (Linux < 6.15).
 //!
-//! [`NydusAccessor`]: crate::NydusAccessor
+//! [`NydusCore`]: crate::NydusCore
 
 pub mod core;
 pub mod mount;

--- a/nydus/src/nbd/mount.rs
+++ b/nydus/src/nbd/mount.rs
@@ -4,7 +4,7 @@
 //! the source plus repeated `device=` options), the NBD daemon exposes a
 //! single block device `/dev/nbdX` carrying the whole flattened image, so
 //! mounting is a plain `mount(2)` of that device at the target with the image's
-//! filesystem type (ERofs for a nydus image). No loop device, no `device=`
+//! filesystem type (EROFS for a nydus image). No loop device, no `device=`
 //! options, no option-length budget.
 
 use std::ffi::CString;
@@ -15,7 +15,7 @@ use anyhow::{Context, Result};
 
 /// Mount the NBD block device `device` at `mountpoint` as `fstype`, read-only.
 ///
-/// Read-only because the daemon only ever writes to the accessor's cache files
+/// Read-only because the daemon only ever writes to the core's cache files
 /// through `fetch`, never through the NBD device; `MS_NODEV`/`MS_NOSUID` match
 /// the fanotify EROFS mount policy for a content-addressed image.
 pub fn mount_nbd(device: &str, mountpoint: &Path, fstype: &str) -> Result<()> {

--- a/nydus/src/ublk/device.rs
+++ b/nydus/src/ublk/device.rs
@@ -1,6 +1,6 @@
 //! Flattened block-device view of a nydus image.
 //!
-//! [`UblkDevice`] turns [`NydusAccessor`]'s flattened device view into a plain
+//! [`UblkDevice`] turns [`NydusCore`]'s flattened device view into a plain
 //! `read_at(offset, buf)` interface: the bootstrap is exposed at the beginning
 //! of the address space, each blob at the `mapped_blkaddr` recorded in the
 //! bootstrap device table, and the gaps in between as zeroes. That is exactly
@@ -15,8 +15,8 @@ use std::sync::RwLock;
 
 use anyhow::{Context, Result};
 
-use crate::accessor::{FdRange, NydusAccessor};
 use crate::config::Config;
+use crate::core::{FdRange, NydusCore};
 use crate::metadata::EROFS_BLOCK_SIZE;
 
 /// Logical block size exposed by the ublk device. Matching the EROFS block size
@@ -25,7 +25,7 @@ pub const UBLK_LOGICAL_BLOCK_SIZE: u64 = EROFS_BLOCK_SIZE as u64;
 
 /// Read-only block device backed by a nydus image.
 pub struct UblkDevice {
-    accessor: NydusAccessor,
+    core: NydusCore,
     zero_fd: RawFd,
     size: u64,
     maps: FileMaps,
@@ -37,24 +37,23 @@ impl UblkDevice {
     /// table are prepared up front, and background prefetch follows
     /// `config.prefetch`.
     pub fn new(bootstrap: &Path, config: Config) -> Result<Self> {
-        let accessor = NydusAccessor::new(bootstrap, config)
+        let core = NydusCore::new(bootstrap, config)
             .context("failed to open nydus image for the ublk device")?;
-        let zero_fd = accessor.zero_fd();
+        let zero_fd = core.zero_fd();
         // Round the device size up to a whole block: the kernel always reads in
         // block units, and the tail block of the last blob may be partial.
-        let size = round_up(accessor.flat_size(), UBLK_LOGICAL_BLOCK_SIZE)
+        let size = round_up(core.flat_size(), UBLK_LOGICAL_BLOCK_SIZE)
             .context("flattened device size overflow")?;
         // Preparing a blob downloads and validates its meta and sizes its cache
         // file, which takes seconds for a large image. Left to the first block
         // read it stalls whoever gets there first — typically `mount`, which
         // then appears to hang long after the device was announced as ready.
-        accessor
-            .blob
+        core.blobs
             .flat_layout()
             .context("failed to prepare the blobs backing the device")?;
 
         Ok(Self {
-            accessor,
+            core,
             zero_fd,
             size,
             maps: FileMaps::default(),
@@ -67,9 +66,9 @@ impl UblkDevice {
         self.size
     }
 
-    /// Borrow the underlying accessor, e.g. to snapshot metrics.
-    pub fn accessor(&self) -> &NydusAccessor {
-        &self.accessor
+    /// Borrow the underlying core, e.g. to snapshot metrics.
+    pub fn core(&self) -> &NydusCore {
+        &self.core
     }
 
     /// Read `buf.len()` bytes at `offset` of the flattened device.
@@ -89,7 +88,7 @@ impl UblkDevice {
 
         let len = (buf.len() as u64).min(self.size - offset);
         let ranges = self
-            .accessor
+            .core
             .fetch_flat_ranges(offset, len)
             .map_err(|err| io::Error::other(format!("{err:#}")))?;
 
@@ -205,7 +204,7 @@ impl Mapping {
             return None;
         }
         let len = usize::try_from(stat.st_size).ok().filter(|len| *len > 0)?;
-        // SAFETY: `fd` is a readable regular file owned by the accessor and
+        // SAFETY: `fd` is a readable regular file owned by the core and
         // kept open for the whole life of the device.
         let addr = unsafe {
             libc::mmap(
@@ -260,7 +259,7 @@ impl Drop for Mapping {
 /// Read `buf.len()` bytes at `offset` from `fd`, zero-filling the tail on EOF.
 ///
 /// Blob cache files are sparse and sized to the blob's dense block address
-/// space, but a short read can still happen when the accessor resolved a range
+/// space, but a short read can still happen when the core resolved a range
 /// that extends past the current file size; treat it the same way a block
 /// device treats an unwritten sector.
 fn pread_exact(fd: RawFd, buf: &mut [u8], offset: u64) -> io::Result<()> {

--- a/nydus/src/ublk/mod.rs
+++ b/nydus/src/ublk/mod.rs
@@ -1,6 +1,6 @@
 //! ublk block device target for flattened nydus images.
 //!
-//! This module is feature-gated by `ublk` so users that only need the accessor
+//! This module is feature-gated by `ublk` so users that only need the core
 //! or FUSE paths do not pull in the ublk/io_uring stack. It requires Linux 6.0
 //! or later (`CONFIG_BLK_DEV_UBLK`).
 

--- a/nydus/src/uffd/core.rs
+++ b/nydus/src/uffd/core.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Context, Result};
 
-use crate::{Config, FdRange, NydusAccessor};
+use crate::{Config, FdRange, NydusCore};
 
 use super::proto::{DeviceRange, FaultPolicy, VmaRegion};
 
@@ -67,22 +67,19 @@ enum ResolveMode {
 }
 
 pub struct UffdCore {
-    accessor: Arc<NydusAccessor>,
+    core: Arc<NydusCore>,
     total_size: u64,
 }
 
 impl UffdCore {
     pub fn new(options: UffdOptions) -> Result<Self> {
-        let accessor = Arc::new(
-            NydusAccessor::new(&options.bootstrap, options.config)
-                .context("failed to create nydus accessor")?,
+        let core = Arc::new(
+            NydusCore::new(&options.bootstrap, options.config)
+                .context("failed to create nydus core")?,
         );
-        let total_size = align_up(accessor.flat_size(), UFFD_TOTAL_SIZE_ALIGNMENT)?;
+        let total_size = align_up(core.flat_size(), UFFD_TOTAL_SIZE_ALIGNMENT)?;
 
-        Ok(Self {
-            accessor,
-            total_size,
-        })
+        Ok(Self { core, total_size })
     }
 
     pub fn total_size(&self) -> u64 {
@@ -110,7 +107,7 @@ impl UffdCore {
             FaultPolicy::Copy => {
                 for range in ranges {
                     let addr = region.virt_addr + (range.source_offset - region.offset);
-                    if range.fd == self.accessor.zero_fd() {
+                    if range.fd == self.core.zero_fd() {
                         uffdio_zeropage(uffd_fd, addr, range.len)?;
                     } else {
                         uffdio_copy_from_fd(uffd_fd, addr, range.fd, range.offset, range.len)?;
@@ -157,23 +154,23 @@ impl UffdCore {
             .ok_or_else(|| anyhow!("device range overflow"))?;
         let mut ranges = Vec::new();
 
-        let flat_end = end.min(self.accessor.flat_size());
+        let flat_end = end.min(self.core.flat_size());
         if device_offset < flat_end {
             let flat_ranges = match mode {
                 ResolveMode::Fetch => self
-                    .accessor
+                    .core
                     .fetch_flat_ranges(device_offset, flat_end - device_offset)?,
                 ResolveMode::Probe => self
-                    .accessor
+                    .core
                     .probe_flat_ranges(device_offset, flat_end - device_offset)?,
             };
             ranges.extend(flat_ranges);
         }
 
-        let tail_start = device_offset.max(self.accessor.flat_size());
+        let tail_start = device_offset.max(self.core.flat_size());
         if tail_start < end {
             ranges.push(FdRange {
-                fd: self.accessor.zero_fd(),
+                fd: self.core.zero_fd(),
                 offset: 0,
                 len: end - tail_start,
                 source_offset: tail_start,

--- a/nydus/src/uffd/mod.rs
+++ b/nydus/src/uffd/mod.rs
@@ -1,6 +1,6 @@
 //! Device-level userfaultfd service for flattened Nydus virtio-pmem images.
 //!
-//! This module is feature-gated by `uffd` so builtin accessor users do not pull
+//! This module is feature-gated by `uffd` so builtin core users do not pull
 //! in the tokio-based server stack.
 
 pub mod core;

--- a/tests/integration/core_test.go
+++ b/tests/integration/core_test.go
@@ -34,19 +34,19 @@ import (
 
 // Processes contending on one cache directory. Four is enough to show
 // duplicate work without making the suite heavy.
-const accessorProcs = 4
+const coreProcs = 4
 
-const accessorChunkSize = 4096
+const coreChunkSize = 4096
 
-// accessorMount is a running `nydus fuse` process together with the Unix
+// coreMount is a running `nydus fuse` process together with the Unix
 // socket its metrics are served on.
-type accessorMount struct {
+type coreMount struct {
 	mnt  string
 	sock string
 	cmd  *exec.Cmd
 }
 
-type accessorMountOpts struct {
+type coreMountOpts struct {
 	bootstrap string
 	blobDir   string
 	cacheDir  string
@@ -78,9 +78,9 @@ prefetch:
 	require.NoError(t, os.WriteFile(path, []byte(config), 0644))
 }
 
-// startAccessorMount mounts an image and waits until both the mountpoint and
+// startCoreMount mounts an image and waits until both the mountpoint and
 // the metrics endpoint answer.
-func startAccessorMount(t *testing.T, nydusBin string, opts accessorMountOpts) *accessorMount {
+func startCoreMount(t *testing.T, nydusBin string, opts coreMountOpts) *coreMount {
 	t.Helper()
 
 	_ = exec.Command("fusermount", "-u", opts.mnt).Run()
@@ -116,7 +116,7 @@ func startAccessorMount(t *testing.T, nydusBin string, opts accessorMountOpts) *
 	cmd.Stderr = os.Stderr
 	require.NoError(t, cmd.Start())
 
-	m := &accessorMount{mnt: opts.mnt, sock: sock, cmd: cmd}
+	m := &coreMount{mnt: opts.mnt, sock: sock, cmd: cmd}
 	t.Cleanup(m.stop)
 
 	require.Eventually(t, func() bool {
@@ -130,7 +130,7 @@ func startAccessorMount(t *testing.T, nydusBin string, opts accessorMountOpts) *
 	return m
 }
 
-func (m *accessorMount) stop() {
+func (m *coreMount) stop() {
 	_ = exec.Command("fusermount", "-u", m.mnt).Run()
 	if m.cmd.Process == nil {
 		return
@@ -147,7 +147,7 @@ func (m *accessorMount) stop() {
 
 // kill terminates the process without giving it a chance to clean up, standing
 // in for a crash.
-func (m *accessorMount) kill(t *testing.T) {
+func (m *coreMount) kill(t *testing.T) {
 	t.Helper()
 	require.NotNil(t, m.cmd.Process)
 	require.NoError(t, m.cmd.Process.Kill())
@@ -155,7 +155,7 @@ func (m *accessorMount) kill(t *testing.T) {
 	_ = exec.Command("fusermount", "-u", m.mnt).Run()
 }
 
-func (m *accessorMount) tryMetrics() (map[string]float64, error) {
+func (m *coreMount) tryMetrics() (map[string]float64, error) {
 	client := &http.Client{
 		Timeout: 5 * time.Second,
 		Transport: &http.Transport{
@@ -175,7 +175,7 @@ func (m *accessorMount) tryMetrics() (map[string]float64, error) {
 	return parsePrometheusText(resp.Body)
 }
 
-func (m *accessorMount) metrics(t *testing.T) map[string]float64 {
+func (m *coreMount) metrics(t *testing.T) map[string]float64 {
 	t.Helper()
 	values, err := m.tryMetrics()
 	require.NoError(t, err)
@@ -206,12 +206,12 @@ func parsePrometheusText(r io.Reader) (map[string]float64, error) {
 	return values, scanner.Err()
 }
 
-// accessorFixture is two images sharing one blob, so the tests can tell
+// coreFixture is two images sharing one blob, so the tests can tell
 // per-image cache state apart from per-blob cache state.
 //
 //	image1 = blobA + blobB
 //	image2 =         blobB + blobC
-type accessorFixture struct {
+type coreFixture struct {
 	blobDir    string
 	blobA      string
 	blobB      string
@@ -222,7 +222,7 @@ type accessorFixture struct {
 	files map[string][]byte
 }
 
-func buildAccessorFixture(t *testing.T, nydusBin, root string) *accessorFixture {
+func buildCoreFixture(t *testing.T, nydusBin, root string) *coreFixture {
 	t.Helper()
 
 	corpusA := filepath.Join(root, "corpusA")
@@ -243,16 +243,16 @@ func buildAccessorFixture(t *testing.T, nydusBin, root string) *accessorFixture 
 
 	// Distinct file names across the corpora keep overlay merge from shadowing
 	// anything, so every blob stays reachable in the merged images.
-	blobA := buildNydusFSImageToDir(t, nydusBin, "", blobDir, corpusA, accessorChunkSize)
-	blobB := buildNydusFSImageToDir(t, nydusBin, "", blobDir, corpusB, accessorChunkSize)
-	blobC := buildNydusFSImageToDir(t, nydusBin, "", blobDir, corpusC, accessorChunkSize)
+	blobA := buildNydusFSImageToDir(t, nydusBin, "", blobDir, corpusA, coreChunkSize)
+	blobB := buildNydusFSImageToDir(t, nydusBin, "", blobDir, corpusB, coreChunkSize)
+	blobC := buildNydusFSImageToDir(t, nydusBin, "", blobDir, corpusC, coreChunkSize)
 
 	bootstrap1 := filepath.Join(root, "image1.bootstrap")
 	bootstrap2 := filepath.Join(root, "image2.bootstrap")
 	mergeNydusBootstrap(t, nydusBin, bootstrap1, blobA, blobB)
 	mergeNydusBootstrap(t, nydusBin, bootstrap2, blobB, blobC)
 
-	return &accessorFixture{
+	return &coreFixture{
 		blobDir:    blobDir,
 		blobA:      blobA,
 		blobB:      blobB,
@@ -325,7 +325,7 @@ func cacheEntries(t *testing.T, cacheDir, suffix string) []string {
 // readConcurrently has every mount read the same relative path at once, so the
 // processes genuinely race on a cold cache instead of warming it for each
 // other in turn.
-func readConcurrently(t *testing.T, mounts []*accessorMount, rel string) []string {
+func readConcurrently(t *testing.T, mounts []*coreMount, rel string) []string {
 	t.Helper()
 
 	start := make(chan struct{})
@@ -335,7 +335,7 @@ func readConcurrently(t *testing.T, mounts []*accessorMount, rel string) []strin
 	var wg sync.WaitGroup
 	for i, m := range mounts {
 		wg.Add(1)
-		go func(i int, m *accessorMount) {
+		go func(i int, m *coreMount) {
 			defer wg.Done()
 			<-start
 			data, err := os.ReadFile(filepath.Join(m.mnt, rel))
@@ -365,7 +365,7 @@ func requireRoot(t *testing.T) {
 
 // sumMetric adds one counter across every mount, which is how the duplicate
 // work of processes sharing a cache directory shows up.
-func sumMetric(t *testing.T, mounts []*accessorMount, name string) float64 {
+func sumMetric(t *testing.T, mounts []*coreMount, name string) float64 {
 	t.Helper()
 	var total float64
 	for _, m := range mounts {
@@ -374,20 +374,20 @@ func sumMetric(t *testing.T, mounts []*accessorMount, name string) float64 {
 	return total
 }
 
-// TestAccessorConcurrentColdReadIsConsistent covers the baseline guarantee:
+// TestCoreConcurrentColdReadIsConsistent covers the baseline guarantee:
 // however much duplicate work the processes do, they all observe the same
 // bytes and the cache never serves a torn group.
-func TestAccessorConcurrentColdReadIsConsistent(t *testing.T) {
+func TestCoreConcurrentColdReadIsConsistent(t *testing.T) {
 	requireRoot(t)
 
 	root := t.TempDir()
 	nydusBin := mustLookupExecutable(t, "nydus")
-	fixture := buildAccessorFixture(t, nydusBin, root)
+	fixture := buildCoreFixture(t, nydusBin, root)
 	cacheDir := filepath.Join(root, "cache")
 
-	mounts := make([]*accessorMount, accessorProcs)
+	mounts := make([]*coreMount, coreProcs)
 	for i := range mounts {
-		mounts[i] = startAccessorMount(t, nydusBin, accessorMountOpts{
+		mounts[i] = startCoreMount(t, nydusBin, coreMountOpts{
 			bootstrap: fixture.bootstrap1,
 			blobDir:   fixture.blobDir,
 			cacheDir:  cacheDir,
@@ -402,34 +402,34 @@ func TestAccessorConcurrentColdReadIsConsistent(t *testing.T) {
 	}
 }
 
-// TestAccessorConcurrentColdReadAmplification measures how much duplicate
+// TestCoreConcurrentColdReadAmplification measures how much duplicate
 // fetching the processes do, calibrated against a single process doing the
 // same read so the assertion does not depend on the blob's group count.
-func TestAccessorConcurrentColdReadAmplification(t *testing.T) {
+func TestCoreConcurrentColdReadAmplification(t *testing.T) {
 	requireRoot(t)
 
 	root := t.TempDir()
 	nydusBin := mustLookupExecutable(t, "nydus")
-	fixture := buildAccessorFixture(t, nydusBin, root)
+	fixture := buildCoreFixture(t, nydusBin, root)
 
 	// Baseline: one process filling a cold cache on its own.
 	soloCache := filepath.Join(root, "cache-solo")
-	solo := startAccessorMount(t, nydusBin, accessorMountOpts{
+	solo := startCoreMount(t, nydusBin, coreMountOpts{
 		bootstrap: fixture.bootstrap1,
 		blobDir:   fixture.blobDir,
 		cacheDir:  soloCache,
 		mnt:       filepath.Join(root, "mnt-solo"),
 	})
-	readConcurrently(t, []*accessorMount{solo}, "shared.bin")
+	readConcurrently(t, []*coreMount{solo}, "shared.bin")
 	soloFill := solo.metrics(t)["cache_ondemand_fill_group"]
 	require.Greater(t, soloFill, 1.0,
 		"the read must span several groups for the comparison below to mean anything")
 
 	// Contended: the same read, from a cold cache, by several processes.
 	sharedCache := filepath.Join(root, "cache-shared")
-	mounts := make([]*accessorMount, accessorProcs)
+	mounts := make([]*coreMount, coreProcs)
 	for i := range mounts {
-		mounts[i] = startAccessorMount(t, nydusBin, accessorMountOpts{
+		mounts[i] = startCoreMount(t, nydusBin, coreMountOpts{
 			bootstrap: fixture.bootstrap1,
 			blobDir:   fixture.blobDir,
 			cacheDir:  sharedCache,
@@ -440,7 +440,7 @@ func TestAccessorConcurrentColdReadAmplification(t *testing.T) {
 	totalFill := sumMetric(t, mounts, "cache_ondemand_fill_group")
 
 	t.Logf("cold read amplification: solo=%.0f groups, %d processes=%.0f groups (%.2fx)",
-		soloFill, accessorProcs, totalFill, totalFill/soloFill)
+		soloFill, coreProcs, totalFill, totalFill/soloFill)
 
 	// Whoever wins a group's fetch right publishes it, and the processes that
 	// waited find it ready instead of fetching it again, so the total should
@@ -450,18 +450,18 @@ func TestAccessorConcurrentColdReadAmplification(t *testing.T) {
 		"concurrent cold reads should not refetch the same groups per process")
 }
 
-// TestAccessorConcurrentPrefetchDeduplicates checks the path that already has
+// TestCoreConcurrentPrefetchDeduplicates checks the path that already has
 // cross-process exclusion: the per-blob prefetch lock should keep all but one
 // process from streaming the blob.
-func TestAccessorConcurrentPrefetchDeduplicates(t *testing.T) {
+func TestCoreConcurrentPrefetchDeduplicates(t *testing.T) {
 	requireRoot(t)
 
 	root := t.TempDir()
 	nydusBin := mustLookupExecutable(t, "nydus")
-	fixture := buildAccessorFixture(t, nydusBin, root)
+	fixture := buildCoreFixture(t, nydusBin, root)
 
 	soloCache := filepath.Join(root, "cache-solo")
-	solo := startAccessorMount(t, nydusBin, accessorMountOpts{
+	solo := startCoreMount(t, nydusBin, coreMountOpts{
 		bootstrap:    fixture.bootstrap1,
 		blobDir:      fixture.blobDir,
 		cacheDir:     soloCache,
@@ -476,9 +476,9 @@ func TestAccessorConcurrentPrefetchDeduplicates(t *testing.T) {
 	}, 60*time.Second, 200*time.Millisecond, "solo prefetch never filled a group")
 
 	sharedCache := filepath.Join(root, "cache-shared")
-	mounts := make([]*accessorMount, accessorProcs)
+	mounts := make([]*coreMount, coreProcs)
 	for i := range mounts {
-		mounts[i] = startAccessorMount(t, nydusBin, accessorMountOpts{
+		mounts[i] = startCoreMount(t, nydusBin, coreMountOpts{
 			bootstrap:    fixture.bootstrap1,
 			blobDir:      fixture.blobDir,
 			cacheDir:     sharedCache,
@@ -499,29 +499,29 @@ func TestAccessorConcurrentPrefetchDeduplicates(t *testing.T) {
 	}, 60*time.Second, 500*time.Millisecond, "prefetch never settled")
 
 	t.Logf("prefetch amplification: solo=%.0f groups, %d processes=%.0f groups",
-		soloFill, accessorProcs, totalFill)
+		soloFill, coreProcs, totalFill)
 	require.LessOrEqual(t, totalFill, soloFill*1.5,
 		"the per-blob prefetch lock should keep all but one process from refetching")
 }
 
-// TestAccessorSharedBlobUsesOneCacheEntry checks that two images referencing
+// TestCoreSharedBlobUsesOneCacheEntry checks that two images referencing
 // the same blob converge on one set of cache files, which is what makes a node
 // running many images cheap.
-func TestAccessorSharedBlobUsesOneCacheEntry(t *testing.T) {
+func TestCoreSharedBlobUsesOneCacheEntry(t *testing.T) {
 	requireRoot(t)
 
 	root := t.TempDir()
 	nydusBin := mustLookupExecutable(t, "nydus")
-	fixture := buildAccessorFixture(t, nydusBin, root)
+	fixture := buildCoreFixture(t, nydusBin, root)
 	cacheDir := filepath.Join(root, "cache")
 
-	image1 := startAccessorMount(t, nydusBin, accessorMountOpts{
+	image1 := startCoreMount(t, nydusBin, coreMountOpts{
 		bootstrap: fixture.bootstrap1,
 		blobDir:   fixture.blobDir,
 		cacheDir:  cacheDir,
 		mnt:       filepath.Join(root, "mnt1"),
 	})
-	image2 := startAccessorMount(t, nydusBin, accessorMountOpts{
+	image2 := startCoreMount(t, nydusBin, coreMountOpts{
 		bootstrap: fixture.bootstrap2,
 		blobDir:   fixture.blobDir,
 		cacheDir:  cacheDir,
@@ -535,7 +535,7 @@ func TestAccessorSharedBlobUsesOneCacheEntry(t *testing.T) {
 	require.Equal(t, sha256Bytes(fixture.files["file3.bin"]),
 		sha256File(t, filepath.Join(image2.mnt, "file3.bin")))
 
-	digests := readConcurrently(t, []*accessorMount{image1, image2}, "shared.bin")
+	digests := readConcurrently(t, []*coreMount{image1, image2}, "shared.bin")
 	want := sha256Bytes(fixture.files["shared.bin"])
 	require.Equal(t, []string{want, want}, digests)
 
@@ -547,18 +547,18 @@ func TestAccessorSharedBlobUsesOneCacheEntry(t *testing.T) {
 		"expected one cache entry per distinct blob (A, B, C)")
 }
 
-// TestAccessorPrefetchAndOnDemandConcurrent runs a prefetching process against
+// TestCorePrefetchAndOnDemandConcurrent runs a prefetching process against
 // an on-demand one on the same cache. Neither may deadlock and both must see
 // correct data.
-func TestAccessorPrefetchAndOnDemandConcurrent(t *testing.T) {
+func TestCorePrefetchAndOnDemandConcurrent(t *testing.T) {
 	requireRoot(t)
 
 	root := t.TempDir()
 	nydusBin := mustLookupExecutable(t, "nydus")
-	fixture := buildAccessorFixture(t, nydusBin, root)
+	fixture := buildCoreFixture(t, nydusBin, root)
 	cacheDir := filepath.Join(root, "cache")
 
-	prefetcher := startAccessorMount(t, nydusBin, accessorMountOpts{
+	prefetcher := startCoreMount(t, nydusBin, coreMountOpts{
 		bootstrap:    fixture.bootstrap1,
 		blobDir:      fixture.blobDir,
 		cacheDir:     cacheDir,
@@ -566,14 +566,14 @@ func TestAccessorPrefetchAndOnDemandConcurrent(t *testing.T) {
 		prefetch:     true,
 		fullPrefetch: true,
 	})
-	reader := startAccessorMount(t, nydusBin, accessorMountOpts{
+	reader := startCoreMount(t, nydusBin, coreMountOpts{
 		bootstrap: fixture.bootstrap1,
 		blobDir:   fixture.blobDir,
 		cacheDir:  cacheDir,
 		mnt:       filepath.Join(root, "mnt-ondemand"),
 	})
 
-	digests := readConcurrently(t, []*accessorMount{prefetcher, reader}, "shared.bin")
+	digests := readConcurrently(t, []*coreMount{prefetcher, reader}, "shared.bin")
 	want := sha256Bytes(fixture.files["shared.bin"])
 	require.Equal(t, []string{want, want}, digests)
 
@@ -585,18 +585,18 @@ func TestAccessorPrefetchAndOnDemandConcurrent(t *testing.T) {
 	require.Equal(t, want, sha256File(t, filepath.Join(reader.mnt, "shared.bin")))
 }
 
-// TestAccessorSurvivesPeerCrash kills one process mid-flight; the survivors
+// TestCoreSurvivesPeerCrash kills one process mid-flight; the survivors
 // must still complete their reads. Once per-group locks land this also covers
 // a dead lock holder being taken over.
-func TestAccessorSurvivesPeerCrash(t *testing.T) {
+func TestCoreSurvivesPeerCrash(t *testing.T) {
 	requireRoot(t)
 
 	root := t.TempDir()
 	nydusBin := mustLookupExecutable(t, "nydus")
-	fixture := buildAccessorFixture(t, nydusBin, root)
+	fixture := buildCoreFixture(t, nydusBin, root)
 	cacheDir := filepath.Join(root, "cache")
 
-	victim := startAccessorMount(t, nydusBin, accessorMountOpts{
+	victim := startCoreMount(t, nydusBin, coreMountOpts{
 		bootstrap:    fixture.bootstrap1,
 		blobDir:      fixture.blobDir,
 		cacheDir:     cacheDir,
@@ -604,7 +604,7 @@ func TestAccessorSurvivesPeerCrash(t *testing.T) {
 		prefetch:     true,
 		fullPrefetch: true,
 	})
-	survivor := startAccessorMount(t, nydusBin, accessorMountOpts{
+	survivor := startCoreMount(t, nydusBin, coreMountOpts{
 		bootstrap: fixture.bootstrap1,
 		blobDir:   fixture.blobDir,
 		cacheDir:  cacheDir,
@@ -631,19 +631,19 @@ func TestAccessorSurvivesPeerCrash(t *testing.T) {
 	}
 }
 
-// TestAccessorStaleGroupmapKeepsInode deletes the cached blob data behind a
+// TestCoreStaleGroupmapKeepsInode deletes the cached blob data behind a
 // live mount. The readiness bitmap has to be reset, but every process must end
 // up on the same bitmap file: if the reset swaps the inode, a live process
 // keeps publishing readiness that newcomers can never see.
-func TestAccessorStaleGroupmapKeepsInode(t *testing.T) {
+func TestCoreStaleGroupmapKeepsInode(t *testing.T) {
 	requireRoot(t)
 
 	root := t.TempDir()
 	nydusBin := mustLookupExecutable(t, "nydus")
-	fixture := buildAccessorFixture(t, nydusBin, root)
+	fixture := buildCoreFixture(t, nydusBin, root)
 	cacheDir := filepath.Join(root, "cache")
 
-	first := startAccessorMount(t, nydusBin, accessorMountOpts{
+	first := startCoreMount(t, nydusBin, coreMountOpts{
 		bootstrap: fixture.bootstrap1,
 		blobDir:   fixture.blobDir,
 		cacheDir:  cacheDir,
@@ -663,7 +663,7 @@ func TestAccessorStaleGroupmapKeepsInode(t *testing.T) {
 	// first mount is still running.
 	require.NoError(t, os.Remove(blobData))
 
-	second := startAccessorMount(t, nydusBin, accessorMountOpts{
+	second := startCoreMount(t, nydusBin, coreMountOpts{
 		bootstrap: fixture.bootstrap1,
 		blobDir:   fixture.blobDir,
 		cacheDir:  cacheDir,

--- a/tests/integration/fanotify_test.go
+++ b/tests/integration/fanotify_test.go
@@ -19,7 +19,7 @@ package integration
 //	C5  demand-paging proof: cache grows sparse -> filled, correlated to reads
 //	C6  event-driven proof: daemon logs show no unknown-fd / invalid-range /
 //	    backend-failure denies
-//	C7  warm fast-path: re-read triggers range_ready ALLOW, no new backend fetch
+//	C7  warm fast-path: re-read triggers is_range_ready ALLOW, no new backend fetch
 //	C8  concurrency/stress: many parallel readers, all correct, no deadlock/deny
 //	C9  persistence across restart: warm cache re-serves with no backend fetch
 //	C10 graceful shutdown: SIGTERM -> clean unmount, no leak
@@ -279,7 +279,7 @@ prefetch:
 
 // wipeCache removes every per-blob artifact so the next daemon starts COLD.
 // Leaving a stale .group.map behind makes the daemon believe groups are ready
-// while the re-created .blob.data is all zeros — range_ready would ALLOW
+// while the re-created .blob.data is all zeros — is_range_ready would ALLOW
 // without fetching and the reader gets a sparse hole. Wipe data+meta+map+lock.
 func (e *fanotifyEnv) wipeCache(t *testing.T) {
 	t.Helper()
@@ -439,14 +439,14 @@ func (e *fanotifyEnv) caseEventDriven(t *testing.T) { // C6 — daemon health un
 
 func (e *fanotifyEnv) caseWarmFastpath(t *testing.T) { // C7 — behavioural warm-path proof
 	// Everything is already cached from C4. A warm re-read must serve identical
-	// bytes AND allocate ~no new blocks (range_ready short-circuits the fetch).
+	// bytes AND allocate ~no new blocks (is_range_ready short-circuits the fetch).
 	blob := e.cacheBlob(t)
 	before := usedBytes(blob)
 	got := shaFile(t, filepath.Join(e.mntDir, "large.bin"))
 	want := shaFile(t, filepath.Join(e.sourceDir, "large.bin"))
 	after := usedBytes(blob)
 	assert.Equal(t, want, got, "warm re-read is byte-exact")
-	assert.Less(t, after-before, int64(1<<20), "warm re-read allocates ~no new cache blocks (range_ready fast path)")
+	assert.Less(t, after-before, int64(1<<20), "warm re-read allocates ~no new cache blocks (is_range_ready fast path)")
 }
 
 func (e *fanotifyEnv) caseConcurrency(t *testing.T) { // C8 — stress per-event tasks + singleflight

--- a/tests/integration/nbd_test.go
+++ b/tests/integration/nbd_test.go
@@ -183,7 +183,7 @@ func (e *nbdEnv) writeConfig(t *testing.T) {
 // ----------------------------------------------------------------- daemon ----
 
 // wipeCache removes every per-blob artifact so the next daemon starts COLD.
-// Leaving a stale .group.map behind makes the accessor believe groups are
+// Leaving a stale .group.map behind makes the core believe groups are
 // ready while the re-created .blob.data is all zeros — reads would return
 // zeros without fetching. Wipe data+meta+map+lock.
 func (e *nbdEnv) wipeCache(t *testing.T) {
@@ -298,7 +298,7 @@ func (e *nbdEnv) caseReadiness(t *testing.T) { // C0
 	assert.Greater(t, e.countLogs(`mounted `), 0, "daemon logged mount")
 	// EROFS metadata reads come from the local bootstrap, not blob cache: no
 	// whole-blob prefetch may have happened. Some blob-tail allocation IS
-	// expected before any file read: the accessor validates each blob's
+	// expected before any file read: the core validates each blob's
 	// footer (at the blob's tail) on its first flat-range resolve, and the
 	// kernel's block-device open scans the device tail too — every such read
 	// rounds outward to whole blob-meta groups. Bound the cache well below a
@@ -369,7 +369,7 @@ func (e *nbdEnv) caseDaemonHealth(t *testing.T) { // C6 — daemon health under 
 
 func (e *nbdEnv) caseWarmFastpath(t *testing.T) { // C7 — behavioural warm-path proof
 	// Everything is already cached from C4. A warm re-read must serve identical
-	// bytes AND allocate ~no new blocks (the accessor's fully-ready fast path
+	// bytes AND allocate ~no new blocks (the core's fully-ready fast path
 	// short-circuits the fetch).
 	before := e.cacheUsed()
 	got := shaFile(t, filepath.Join(e.mntDir, "large.bin"))
@@ -445,7 +445,7 @@ func (e *nbdEnv) casePersistence(t *testing.T) { // C9 — warm cache survives a
 	assert.Equal(t, want, got, "large.bin still byte-exact after restart")
 	after := e.cacheUsed()
 	// Warm cache: re-reading the same data should not grow the cache (the
-	// accessor's persisted groupmap short-circuits the fetch).
+	// core's persisted groupmap short-circuits the fetch).
 	assert.Less(t, after-before, int64(1<<20), "warm cache re-serves with no new cache allocation after restart")
 }
 


### PR DESCRIPTION



## Overview
_Please briefly describe the changes your pull request makes._
Rename `NydusAccessor` → `NydusCore`, `BlobAccessor` → `Blobs`, `BlobID` → `BlobId`, `get`/`set` → `read`/`write`, `all_ready` → `check_all_ready`, and `blob_is_redirect` → `is_redirect_blob` for consistency and clarity throughout the codebase.

Add a host-side EROFS/virtio-pmem blob access layer to `NydusCore`, along with integration tests covering the public API and cross-process shared cache behaviour. The test crate is renamed from `test-accessor` to `test-core` to match.

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [x] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.