### PR TITLE
refactor: consolidate shared utilities and extract OCI helpers into dedicated packages

### DIFF
--- a/nydus-core/src/metadata/blob_footer.rs
+++ b/nydus-core/src/metadata/blob_footer.rs
@@ -4,6 +4,8 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use super::EROFS_BLOCK_SIZE;
+use crate::utils::blocks_to_bytes;
+use crate::utils::le::{read_u32_at, read_u64_at, write_u32_at, write_u64_at};
 
 /// On-disk magic: 8 raw ASCII bytes, written as-is so a hexdump of the
 /// footer starts with the readable string. Same style and `magic + version +
@@ -174,16 +176,16 @@ impl BlobFooter {
         // that this reader ignores. Corruption is caught by the footer crc32c.
         let footer = Self {
             magic: data[0..8].try_into().expect("slice checked"),
-            version: read_u32(data, 8),
-            flags: read_u32(data, 12),
-            crc32: read_u32(data, 16),
-            reserved0: read_u32(data, 20),
-            compressed_data_offset: read_u64(data, 24),
-            bootstrap_offset: read_u64(data, 32),
-            blob_meta_offset: read_u64(data, 40),
-            compressed_data_size: read_u64(data, 48),
-            bootstrap_blocks: read_u32(data, 56),
-            blob_meta_blocks: read_u32(data, 60),
+            version: read_u32_at(data, 8),
+            flags: read_u32_at(data, 12),
+            crc32: read_u32_at(data, 16),
+            reserved0: read_u32_at(data, 20),
+            compressed_data_offset: read_u64_at(data, 24),
+            bootstrap_offset: read_u64_at(data, 32),
+            blob_meta_offset: read_u64_at(data, 40),
+            compressed_data_size: read_u64_at(data, 48),
+            bootstrap_blocks: read_u32_at(data, 56),
+            blob_meta_blocks: read_u32_at(data, 60),
         };
         footer.validate_common()?;
         // Verify the crc32 over the raw incoming bytes (with the crc32 field
@@ -202,16 +204,16 @@ impl BlobFooter {
     fn to_bytes(self) -> [u8; NYDUS_BLOB_FOOTER_SIZE] {
         let mut data = [0u8; NYDUS_BLOB_FOOTER_SIZE];
         data[0..8].copy_from_slice(&self.magic);
-        write_u32(&mut data, 8, self.version);
-        write_u32(&mut data, 12, self.flags);
-        write_u32(&mut data, 16, self.crc32);
-        write_u32(&mut data, 20, self.reserved0);
-        write_u64(&mut data, 24, self.compressed_data_offset);
-        write_u64(&mut data, 32, self.bootstrap_offset);
-        write_u64(&mut data, 40, self.blob_meta_offset);
-        write_u64(&mut data, 48, self.compressed_data_size);
-        write_u32(&mut data, 56, self.bootstrap_blocks);
-        write_u32(&mut data, 60, self.blob_meta_blocks);
+        write_u32_at(&mut data, 8, self.version);
+        write_u32_at(&mut data, 12, self.flags);
+        write_u32_at(&mut data, 16, self.crc32);
+        write_u32_at(&mut data, 20, self.reserved0);
+        write_u64_at(&mut data, 24, self.compressed_data_offset);
+        write_u64_at(&mut data, 32, self.bootstrap_offset);
+        write_u64_at(&mut data, 40, self.blob_meta_offset);
+        write_u64_at(&mut data, 48, self.compressed_data_size);
+        write_u32_at(&mut data, 56, self.bootstrap_blocks);
+        write_u32_at(&mut data, 60, self.blob_meta_blocks);
         data
     }
 
@@ -281,26 +283,6 @@ impl BlobFooter {
         data[16..20].fill(0);
         crc32c::crc32c(&data)
     }
-}
-
-fn blocks_to_bytes(blocks: u32) -> u64 {
-    blocks as u64 * EROFS_BLOCK_SIZE as u64
-}
-
-fn read_u32(data: &[u8], offset: usize) -> u32 {
-    u32::from_le_bytes(data[offset..offset + 4].try_into().expect("slice checked"))
-}
-
-fn read_u64(data: &[u8], offset: usize) -> u64 {
-    u64::from_le_bytes(data[offset..offset + 8].try_into().expect("slice checked"))
-}
-
-fn write_u32(data: &mut [u8], offset: usize, value: u32) {
-    data[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
-}
-
-fn write_u64(data: &mut [u8], offset: usize, value: u64) {
-    data[offset..offset + 8].copy_from_slice(&value.to_le_bytes());
 }
 
 #[cfg(test)]

--- a/nydus-core/src/metadata/blob_meta.rs
+++ b/nydus-core/src/metadata/blob_meta.rs
@@ -1,4 +1,5 @@
 use super::{EROFS_BLOB_ID_SIZE, EROFS_BLOCK_SIZE};
+use crate::utils::le::{read_u16_from, read_u32_from, read_u64_from};
 use anyhow::{bail, Context, Result};
 use bitflags::bitflags;
 use crc32c::crc32c_append;
@@ -357,14 +358,14 @@ impl BlobMetaHeader {
     fn read_from(reader: &mut dyn Read) -> Result<Self> {
         let header = Self {
             magic: read_magic(reader)?,
-            version: read_u32(reader)?,
-            flags: read_u32(reader)?,
-            crc32: read_u32(reader)?,
-            reserved0: read_u32(reader)?,
-            chunks_offset: read_u64(reader)?,
-            groups_offset: read_u64(reader)?,
-            chunk_count: read_u32(reader)?,
-            group_count: read_u32(reader)?,
+            version: read_u32_from(reader)?,
+            flags: read_u32_from(reader)?,
+            crc32: read_u32_from(reader)?,
+            reserved0: read_u32_from(reader)?,
+            chunks_offset: read_u64_from(reader)?,
+            groups_offset: read_u64_from(reader)?,
+            chunk_count: read_u32_from(reader)?,
+            group_count: read_u32_from(reader)?,
             chunk_block_bits: read_u8(reader)?,
             group_block_bits: {
                 let bits = read_u8(reader)?;
@@ -541,13 +542,13 @@ impl BlobMetaGroup {
 
     pub fn read_from(reader: &mut dyn Read) -> Result<Self> {
         let group = Self {
-            uncompressed_block_offset: read_u64(reader)?,
-            compressed_byte_offset: read_u64(reader)?,
-            uncompressed_block_count: read_u32(reader)?,
-            compressed_size: read_u32(reader)?,
-            crc32: read_u32(reader)?,
-            source_group_index: read_u32(reader)?,
-            source_blob_index: read_u16(reader)?,
+            uncompressed_block_offset: read_u64_from(reader)?,
+            compressed_byte_offset: read_u64_from(reader)?,
+            uncompressed_block_count: read_u32_from(reader)?,
+            compressed_size: read_u32_from(reader)?,
+            crc32: read_u32_from(reader)?,
+            source_group_index: read_u32_from(reader)?,
+            source_blob_index: read_u16_from(reader)?,
             reserved: read_group_reserved(reader)?,
         };
         group.validate()?;
@@ -648,9 +649,9 @@ impl BlobMetaChunk {
     pub fn read_from(reader: &mut dyn Read) -> Result<Self> {
         let chunk = Self {
             digest: read_digest(reader)?,
-            uncompressed_block_offset: read_u64(reader)?,
-            uncompressed_block_count: read_u32(reader)?,
-            reserved: read_u32(reader)?,
+            uncompressed_block_offset: read_u64_from(reader)?,
+            uncompressed_block_count: read_u32_from(reader)?,
+            reserved: read_u32_from(reader)?,
         };
         chunk.validate()?;
         Ok(chunk)
@@ -1168,12 +1169,6 @@ fn mapped_groups<'a>(data: &'a [u8], header: &BlobMetaHeader) -> &'a [BlobMetaGr
     unsafe { std::slice::from_raw_parts(ptr, header.group_count() as usize) }
 }
 
-fn read_u32(reader: &mut dyn Read) -> Result<u32> {
-    let mut buf = [0u8; 4];
-    reader.read_exact(&mut buf)?;
-    Ok(u32::from_le_bytes(buf))
-}
-
 fn read_u8(reader: &mut dyn Read) -> Result<u8> {
     let mut buf = [0u8; 1];
     reader.read_exact(&mut buf)?;
@@ -1186,22 +1181,10 @@ fn read_magic(reader: &mut dyn Read) -> Result<[u8; 8]> {
     Ok(buf)
 }
 
-fn read_u16(reader: &mut dyn Read) -> Result<u16> {
-    let mut buf = [0u8; 2];
-    reader.read_exact(&mut buf)?;
-    Ok(u16::from_le_bytes(buf))
-}
-
 fn read_group_reserved(reader: &mut dyn Read) -> Result<[u8; 6]> {
     let mut buf = [0u8; 6];
     reader.read_exact(&mut buf)?;
     Ok(buf)
-}
-
-fn read_u64(reader: &mut dyn Read) -> Result<u64> {
-    let mut buf = [0u8; 8];
-    reader.read_exact(&mut buf)?;
-    Ok(u64::from_le_bytes(buf))
 }
 
 fn read_digest(reader: &mut dyn Read) -> Result<[u8; 32]> {

--- a/nydus-core/src/metadata/mod.rs
+++ b/nydus-core/src/metadata/mod.rs
@@ -97,36 +97,9 @@ pub const EROFS_NULL_ADDR: u64 = u64::MAX;
 /// Nydus internal xattr suffix for prefetch blobs ("trusted.nydus.prefetch.blobs").
 pub const NYDUS_XATTR_SUFFIX_PREFETCH_BLOBS: &[u8] = b"nydus.prefetch.blobs";
 
-/// Read a little-endian integer from a byte array.
-#[inline(always)]
-pub(crate) fn read_u16(b: &[u8; 2]) -> u16 {
-    u16::from_le_bytes(*b)
-}
-
-#[inline(always)]
-pub(crate) fn write_u16(b: &mut [u8; 2], v: u16) {
-    *b = v.to_le_bytes();
-}
-
-#[inline(always)]
-pub(crate) fn read_u32(b: &[u8; 4]) -> u32 {
-    u32::from_le_bytes(*b)
-}
-
-#[inline(always)]
-pub(crate) fn write_u32(b: &mut [u8; 4], v: u32) {
-    *b = v.to_le_bytes();
-}
-
-#[inline(always)]
-pub(crate) fn read_u64(b: &[u8; 8]) -> u64 {
-    u64::from_le_bytes(*b)
-}
-
-#[inline(always)]
-pub(crate) fn write_u64(b: &mut [u8; 8], v: u64) {
-    *b = v.to_le_bytes();
-}
+// Little-endian field helpers live in `utils::le`; re-exported so the
+// `use super::*` metadata modules keep resolving them unqualified.
+pub(crate) use crate::utils::le::{read_u16, read_u32, read_u64, write_u16, write_u32, write_u64};
 
 /// Cast a byte slice to a reference of `T` (`#[repr(C, packed)]`).
 #[inline]

--- a/nydus-core/src/storage/backend/local.rs
+++ b/nydus-core/src/storage/backend/local.rs
@@ -157,7 +157,7 @@ impl LocalBackend {
         if let (Some(offset), Some(size)) = (source.blob_meta_offset, source.blob_meta_size) {
             let file = File::open(&source.path)?;
             let mut data = vec![0u8; size as usize];
-            read_exact_at(&file, offset, &mut data)?;
+            file.read_exact_at(&mut data, offset)?;
             return Ok(data);
         }
 
@@ -220,7 +220,7 @@ impl BlobBackend for LocalBackend {
             ));
         }
         let file = self.source_file(blob_id)?;
-        read_exact_at(&file, source.data_offset + offset, dst)
+        file.read_exact_at(dst, source.data_offset + offset)
     }
 }
 
@@ -240,21 +240,6 @@ fn inspect_full_blob_source(
         blob_meta_offset: Some(footer.blob_meta_offset()),
         blob_meta_size: Some(footer.blob_meta_size()),
     }))
-}
-
-fn read_exact_at(file: &File, offset: u64, buf: &mut [u8]) -> io::Result<()> {
-    let mut read_total = 0usize;
-    while read_total < buf.len() {
-        let read = file.read_at(&mut buf[read_total..], offset + read_total as u64)?;
-        if read == 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "backend range read ended early",
-            ));
-        }
-        read_total += read;
-    }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -278,52 +263,19 @@ mod tests {
         .unwrap()
     }
 
-    fn write_full_blob(
-        dir: &Path,
-        payload: &[u8],
-        save_sidecar: bool,
-    ) -> ([u8; EROFS_BLOB_ID_SIZE], [u8; EROFS_BLOB_ID_SIZE]) {
-        let data_blob_id = sha256_bytes(payload);
-        let mut bootstrap = vec![0u8; 8192];
-        let sb = ErofsSuperblock::new(0, 0, 0, 0, 0, 2, 1, 0, 0, &[0u8; 16]);
-        let sb_start = EROFS_SUPER_OFFSET as usize;
-        let sb_end = sb_start + sb.as_bytes().len();
-        bootstrap[sb_start..sb_end].copy_from_slice(sb.as_bytes());
-        let blob_meta = blob_meta(data_blob_id, payload);
-        let footer = BlobFooter::new(
-            0,
-            payload.len() as u64,
-            payload.len() as u64,
-            (bootstrap.len() as u64 / EROFS_BLOCK_SIZE as u64) as u32,
-            payload.len() as u64 + bootstrap.len() as u64,
-            (blob_meta.metadata_size() / EROFS_BLOCK_SIZE as u64) as u32,
-        )
-        .unwrap();
-
-        let temp_full_blob_path = dir.join("full-blob.bin");
-        let mut full_blob = File::create(&temp_full_blob_path).unwrap();
-        full_blob.write_all(payload).unwrap();
-        full_blob.write_all(&bootstrap).unwrap();
-        blob_meta.write_to(&mut full_blob).unwrap();
-        footer.write_to(&mut full_blob).unwrap();
-        let full_blob_id = sha256_file(&temp_full_blob_path).unwrap();
-        let full_blob_path = dir.join(hex_string(&full_blob_id));
-        fs::rename(&temp_full_blob_path, &full_blob_path).unwrap();
-
-        if save_sidecar {
-            blob_meta
-                .save(&dir.join(format!("{}.blob.meta", hex_string(&full_blob_id))))
-                .unwrap();
-        }
-
-        (full_blob_id, data_blob_id)
-    }
+    use crate::storage::test_util::write_full_blob;
 
     #[test]
     fn local_backend_reads_full_blob_file_and_sidecar_meta() {
         let dir = tempdir().unwrap();
         let payload = vec![0xabu8; 4096];
-        let (full_blob_id, _data_blob_id) = write_full_blob(dir.path(), &payload, true);
+        let data_blob_id = sha256_bytes(&payload);
+        let full_blob_id = write_full_blob(
+            dir.path(),
+            &payload,
+            &blob_meta(data_blob_id, &payload),
+            true,
+        );
 
         let backend = LocalBackend::new(dir.path().to_path_buf());
         let blob_meta = backend.load_blob_meta(&full_blob_id).unwrap();
@@ -339,7 +291,13 @@ mod tests {
     fn local_backend_reads_embedded_blob_meta_from_full_blob() {
         let dir = tempdir().unwrap();
         let payload = vec![0xcdu8; 4096];
-        let (full_blob_id, data_blob_id) = write_full_blob(dir.path(), &payload, false);
+        let data_blob_id = sha256_bytes(&payload);
+        let full_blob_id = write_full_blob(
+            dir.path(),
+            &payload,
+            &blob_meta(data_blob_id, &payload),
+            false,
+        );
         let backend = LocalBackend::new(dir.path().to_path_buf());
 
         let blob_meta = backend.load_blob_meta(&full_blob_id).unwrap();

--- a/nydus-core/src/storage/cache/local.rs
+++ b/nydus-core/src/storage/cache/local.rs
@@ -519,7 +519,7 @@ impl BlobCache for LocalBlobCache {
         // The cache file mirrors the dense uncompressed address space, so once
         // the covering groups are decoded the absolute offset indexes straight
         // into it for a single contiguous read.
-        read_exact_at(cache_file.as_ref(), offset, dst)
+        cache_file.as_ref().read_exact_at(dst, offset)
     }
 
     fn prepare(&self) -> io::Result<PathBuf> {
@@ -842,21 +842,6 @@ fn load_cached_blob_meta(
     BlobMeta::load_checked_crc32_with_blob_id(blob_meta_path, blob_id).map_err(io::Error::other)
 }
 
-fn read_exact_at(file: &File, offset: u64, buf: &mut [u8]) -> io::Result<()> {
-    let mut read_total = 0usize;
-    while read_total < buf.len() {
-        let read = file.read_at(&mut buf[read_total..], offset + read_total as u64)?;
-        if read == 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "cache file read ended early",
-            ));
-        }
-        read_total += read;
-    }
-    Ok(())
-}
-
 /// Drop guard that ensures a leader always signals its flight and cleans up
 /// the inflight map, even when the fetch body panics. Without this, a panic in
 /// `fetch_decode_validate_group_into` (or any helper it calls) would leave
@@ -924,44 +909,7 @@ mod tests {
         .unwrap()
     }
 
-    fn write_full_blob(
-        dir: &Path,
-        payload: &[u8],
-        blob_meta: &BlobMeta,
-        save_sidecar: bool,
-    ) -> [u8; EROFS_BLOB_ID_SIZE] {
-        let mut bootstrap = vec![0u8; 8192];
-        let sb = ErofsSuperblock::new(0, 0, 0, 0, 0, 2, 1, 0, 0, &[0u8; 16]);
-        let sb_start = EROFS_SUPER_OFFSET as usize;
-        let sb_end = sb_start + sb.as_bytes().len();
-        bootstrap[sb_start..sb_end].copy_from_slice(sb.as_bytes());
-
-        let footer = BlobFooter::new(
-            0,
-            payload.len() as u64,
-            payload.len() as u64,
-            (bootstrap.len() as u64 / EROFS_BLOCK_SIZE as u64) as u32,
-            payload.len() as u64 + bootstrap.len() as u64,
-            (blob_meta.metadata_size() / EROFS_BLOCK_SIZE as u64) as u32,
-        )
-        .unwrap();
-
-        let mut full_blob = Vec::new();
-        full_blob.write_all(payload).unwrap();
-        full_blob.write_all(&bootstrap).unwrap();
-        blob_meta.write_to(&mut full_blob).unwrap();
-        footer.write_to(&mut full_blob).unwrap();
-        let full_blob_id = sha256_bytes(&full_blob);
-
-        fs::write(dir.join(hex_string(&full_blob_id)), &full_blob).unwrap();
-        if save_sidecar {
-            blob_meta
-                .save(&dir.join(format!("{}.blob.meta", hex_string(&full_blob_id))))
-                .unwrap();
-        }
-
-        full_blob_id
-    }
+    use crate::storage::test_util::write_full_blob;
 
     /// Wraps a real backend and counts data-range reads, so tests can assert
     /// that cross-process sharing (groupmap + prefetch lock + segment skip)

--- a/nydus-core/src/storage/mod.rs
+++ b/nydus-core/src/storage/mod.rs
@@ -2,3 +2,59 @@ pub mod backend;
 pub mod cache;
 pub mod group_map;
 pub mod prefetch;
+
+/// Fixture builders shared by the storage unit tests.
+#[cfg(test)]
+pub(crate) mod test_util {
+    use std::fs;
+    use std::io::Write;
+    use std::path::Path;
+
+    use crate::metadata::{
+        BlobFooter, BlobMeta, ErofsSuperblock, EROFS_BLOB_ID_SIZE, EROFS_BLOCK_SIZE,
+        EROFS_SUPER_OFFSET,
+    };
+    use crate::utils::{hex_string, sha256_bytes};
+
+    /// Assemble a minimal full blob (`payload + trivial bootstrap + blob meta
+    /// + footer`) into `dir`, named by its full SHA256, optionally with a
+    /// `.blob.meta` sidecar. Returns the full blob id.
+    pub(crate) fn write_full_blob(
+        dir: &Path,
+        payload: &[u8],
+        blob_meta: &BlobMeta,
+        save_sidecar: bool,
+    ) -> [u8; EROFS_BLOB_ID_SIZE] {
+        let mut bootstrap = vec![0u8; 8192];
+        let sb = ErofsSuperblock::new(0, 0, 0, 0, 0, 2, 1, 0, 0, &[0u8; 16]);
+        let sb_start = EROFS_SUPER_OFFSET as usize;
+        let sb_end = sb_start + sb.as_bytes().len();
+        bootstrap[sb_start..sb_end].copy_from_slice(sb.as_bytes());
+
+        let footer = BlobFooter::new(
+            0,
+            payload.len() as u64,
+            payload.len() as u64,
+            (bootstrap.len() as u64 / EROFS_BLOCK_SIZE as u64) as u32,
+            payload.len() as u64 + bootstrap.len() as u64,
+            (blob_meta.metadata_size() / EROFS_BLOCK_SIZE as u64) as u32,
+        )
+        .unwrap();
+
+        let mut full_blob = Vec::new();
+        full_blob.write_all(payload).unwrap();
+        full_blob.write_all(&bootstrap).unwrap();
+        blob_meta.write_to(&mut full_blob).unwrap();
+        footer.write_to(&mut full_blob).unwrap();
+        let full_blob_id = sha256_bytes(&full_blob);
+
+        fs::write(dir.join(hex_string(&full_blob_id)), &full_blob).unwrap();
+        if save_sidecar {
+            blob_meta
+                .save(&dir.join(format!("{}.blob.meta", hex_string(&full_blob_id))))
+                .unwrap();
+        }
+
+        full_blob_id
+    }
+}

--- a/nydus-core/src/utils/align.rs
+++ b/nydus-core/src/utils/align.rs
@@ -1,0 +1,27 @@
+/// Round `value` up to the next multiple of `align`.
+///
+/// `align` must be a power of two. Returns `None` when the rounded value
+/// would overflow `u64`.
+#[inline]
+pub fn align_up(value: u64, align: u64) -> Option<u64> {
+    debug_assert!(align.is_power_of_two());
+    value.checked_add(align - 1).map(|v| v & !(align - 1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::align_up;
+
+    #[test]
+    fn align_up_rounds_up_to_alignment() {
+        assert_eq!(align_up(0, 8), Some(0));
+        assert_eq!(align_up(1, 8), Some(8));
+        assert_eq!(align_up(16, 8), Some(16));
+        assert_eq!(align_up(4097, 4096), Some(8192));
+    }
+
+    #[test]
+    fn align_up_detects_overflow() {
+        assert_eq!(align_up(u64::MAX, 4096), None);
+    }
+}

--- a/nydus-core/src/utils/block.rs
+++ b/nydus-core/src/utils/block.rs
@@ -1,0 +1,20 @@
+//! EROFS block-size conversions.
+
+use anyhow::{bail, Context, Result};
+
+use crate::metadata::EROFS_BLOCK_SIZE;
+
+/// Convert a byte size to a 4 KiB block count. `name` labels the region in
+/// error messages.
+pub fn bytes_to_blocks(size: u64, name: &str) -> Result<u32> {
+    if size % EROFS_BLOCK_SIZE as u64 != 0 {
+        bail!("{name} size is not block aligned: {size}");
+    }
+    u32::try_from(size / EROFS_BLOCK_SIZE as u64)
+        .with_context(|| format!("{name} exceeds u32 block count"))
+}
+
+/// Convert a 4 KiB block count to a byte size.
+pub fn blocks_to_bytes(blocks: u32) -> u64 {
+    blocks as u64 * EROFS_BLOCK_SIZE as u64
+}

--- a/nydus-core/src/utils/io.rs
+++ b/nydus-core/src/utils/io.rs
@@ -1,0 +1,94 @@
+use std::io::{self, Write};
+use std::os::fd::RawFd;
+
+/// Read exactly `buf.len()` bytes from `fd` at `offset` without moving the
+/// file position (safe on a shared fd). Retries on `EINTR` and zero-fills the
+/// remainder on EOF: the cache file's block-aligned sizing should never
+/// produce one, but block-device replies must be full-length.
+pub fn pread_exact(fd: RawFd, buf: &mut [u8], offset: u64) -> io::Result<()> {
+    let mut filled = 0usize;
+    while filled < buf.len() {
+        let ret = unsafe {
+            libc::pread(
+                fd,
+                buf[filled..].as_mut_ptr() as *mut libc::c_void,
+                buf.len() - filled,
+                (offset + filled as u64) as libc::off_t,
+            )
+        };
+        match ret {
+            0 => {
+                buf[filled..].fill(0);
+                return Ok(());
+            }
+            n if n > 0 => filled += n as usize,
+            _ => {
+                let err = io::Error::last_os_error();
+                if err.kind() == io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(err);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Write `aligned - current` zero bytes to pad a region up to its aligned
+/// end. Errors when `aligned < current`.
+pub fn write_zero_padding(writer: &mut dyn Write, current: u64, aligned: u64) -> io::Result<()> {
+    if aligned < current {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "invalid blob region alignment",
+        ));
+    }
+    let padding = (aligned - current) as usize;
+    if padding > 0 {
+        writer.write_all(&vec![0u8; padding])?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+    use std::os::fd::AsRawFd as _;
+
+    #[test]
+    fn pread_exact_zero_len_is_noop() {
+        // An empty buffer must return immediately without touching the fd.
+        let mut buf = [0u8; 0];
+        pread_exact(libc::STDIN_FILENO, &mut buf, 0).unwrap();
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn pread_exact_zero_fills_past_eof() {
+        let mut file = tempfile::tempfile().unwrap();
+        file.write_all(b"nydus").unwrap();
+
+        let mut buf = [0xffu8; 8];
+        pread_exact(file.as_raw_fd(), &mut buf, 0).unwrap();
+        assert_eq!(&buf, b"nydus\0\0\0");
+    }
+
+    #[test]
+    fn pread_exact_zero_fills_past_eof_without_duplicating() {
+        let mut f = tempfile::tempfile().unwrap();
+        let content: Vec<u8> = (0u8..100).collect();
+        f.write_all(&content).unwrap();
+
+        // Read [80, 144) from a 100-byte file: the first pread returns only
+        // 20 bytes, so the loop must advance the offset, hit EOF, and
+        // zero-fill the tail — not re-read the same 20 bytes forever.
+        let mut buf = [0xAAu8; 64];
+        pread_exact(f.as_raw_fd(), &mut buf, 80).unwrap();
+        assert_eq!(&buf[..20], &content[80..]);
+        assert!(
+            buf[20..].iter().all(|&b| b == 0),
+            "tail past EOF must be zero-filled, not duplicated file data"
+        );
+    }
+}

--- a/nydus-core/src/utils/le.rs
+++ b/nydus-core/src/utils/le.rs
@@ -1,0 +1,80 @@
+//! Little-endian integer helpers for the on-disk formats.
+//!
+//! Three shapes for three call patterns: fixed-size byte-array struct fields
+//! (`read_u32`), offset-addressed buffers (`read_u32_at`), and sequential
+//! readers (`read_u32_from`).
+
+use std::io::{self, Read};
+
+/// Read a little-endian integer from a byte array.
+#[inline(always)]
+pub fn read_u16(b: &[u8; 2]) -> u16 {
+    u16::from_le_bytes(*b)
+}
+
+#[inline(always)]
+pub fn write_u16(b: &mut [u8; 2], v: u16) {
+    *b = v.to_le_bytes();
+}
+
+#[inline(always)]
+pub fn read_u32(b: &[u8; 4]) -> u32 {
+    u32::from_le_bytes(*b)
+}
+
+#[inline(always)]
+pub fn write_u32(b: &mut [u8; 4], v: u32) {
+    *b = v.to_le_bytes();
+}
+
+#[inline(always)]
+pub fn read_u64(b: &[u8; 8]) -> u64 {
+    u64::from_le_bytes(*b)
+}
+
+#[inline(always)]
+pub fn write_u64(b: &mut [u8; 8], v: u64) {
+    *b = v.to_le_bytes();
+}
+
+/// Read a little-endian integer from `data` at `offset`.
+///
+/// Panics when `data` is too short — callers validate region sizes up front.
+#[inline]
+pub fn read_u32_at(data: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes(data[offset..offset + 4].try_into().expect("slice checked"))
+}
+
+#[inline]
+pub fn read_u64_at(data: &[u8], offset: usize) -> u64 {
+    u64::from_le_bytes(data[offset..offset + 8].try_into().expect("slice checked"))
+}
+
+#[inline]
+pub fn write_u32_at(data: &mut [u8], offset: usize, value: u32) {
+    data[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+}
+
+#[inline]
+pub fn write_u64_at(data: &mut [u8], offset: usize, value: u64) {
+    data[offset..offset + 8].copy_from_slice(&value.to_le_bytes());
+}
+
+/// Read a little-endian integer from a sequential reader.
+pub fn read_u16_from(reader: &mut dyn Read) -> io::Result<u16> {
+    let mut buf = [0u8; 2];
+    reader.read_exact(&mut buf)?;
+    Ok(u16::from_le_bytes(buf))
+}
+
+pub fn read_u32_from(reader: &mut dyn Read) -> io::Result<u32> {
+    let mut buf = [0u8; 4];
+    reader.read_exact(&mut buf)?;
+    Ok(u32::from_le_bytes(buf))
+}
+
+pub fn read_u64_from(reader: &mut dyn Read) -> io::Result<u64> {
+    let mut buf = [0u8; 8];
+    reader.read_exact(&mut buf)?;
+    Ok(u64::from_le_bytes(buf))
+}

--- a/nydus-core/src/utils/mod.rs
+++ b/nydus-core/src/utils/mod.rs
@@ -1,5 +1,16 @@
+pub mod align;
+pub mod block;
 pub mod digest;
+pub mod io;
+pub mod le;
+#[cfg(target_os = "linux")]
+pub mod mount;
 
+pub use self::align::align_up;
+pub use self::block::{blocks_to_bytes, bytes_to_blocks};
 pub use self::digest::{
     hex_string, parse_sha256_hex, sha256_bytes, sha256_file, sha256_file_range, sha256_file_region,
 };
+pub use self::io::{pread_exact, write_zero_padding};
+#[cfg(target_os = "linux")]
+pub use self::mount::{path_cstring, unmount};

--- a/nydus-core/src/utils/mount.rs
+++ b/nydus-core/src/utils/mount.rs
@@ -1,0 +1,25 @@
+//! Mount helpers shared by the fanotify and NBD mount lifecycles.
+
+use std::ffi::CString;
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+/// NUL-check a path before handing it to a `mount(2)`-family syscall.
+pub fn path_cstring(path: &Path, kind: &str) -> Result<CString> {
+    CString::new(path.as_os_str().as_bytes())
+        .with_context(|| format!("{kind} path contains an interior NUL byte"))
+}
+
+/// Unmount whatever is mounted at `mountpoint`. A plain `umount2(., 0)`; any
+/// EBUSY retry loop lives in the caller.
+pub fn unmount(mountpoint: &Path) -> Result<()> {
+    let target = path_cstring(mountpoint, "mountpoint")?;
+    let ret = unsafe { libc::umount2(target.as_ptr(), 0) };
+    if ret < 0 {
+        return Err(std::io::Error::last_os_error())
+            .with_context(|| format!("failed to unmount {}", mountpoint.display()));
+    }
+    Ok(())
+}

--- a/nydus-core/tests/common/mod.rs
+++ b/nydus-core/tests/common/mod.rs
@@ -1,18 +1,15 @@
 //! Helpers shared by the integration tests for assembling footer-based
-//! full blobs.
+//! full blobs. Thin infallible wrappers over the production helpers in
+//! `nydus_core::utils` — fixtures use static sizes, so failures are bugs.
 
 use std::io::Write;
 
-use nydus_core::metadata::EROFS_BLOCK_SIZE;
-
 pub fn align_up(value: u64, align: u64) -> u64 {
-    debug_assert!(align.is_power_of_two());
-    (value + align - 1) & !(align - 1)
+    nydus_core::utils::align_up(value, align).expect("test alignment overflow")
 }
 
 pub fn bytes_to_blocks(size: u64) -> u32 {
-    assert_eq!(size % EROFS_BLOCK_SIZE as u64, 0);
-    (size / EROFS_BLOCK_SIZE as u64) as u32
+    nydus_core::utils::bytes_to_blocks(size, "test region").expect("test region not block aligned")
 }
 
 pub fn write_zero_padding(
@@ -20,9 +17,5 @@ pub fn write_zero_padding(
     current: u64,
     aligned: u64,
 ) -> std::io::Result<()> {
-    let padding = aligned - current;
-    if padding > 0 {
-        writer.write_all(&vec![0u8; padding as usize])?;
-    }
-    Ok(())
+    nydus_core::utils::write_zero_padding(writer, current, aligned)
 }

--- a/nydus/src/bin/nydus/build.rs
+++ b/nydus/src/bin/nydus/build.rs
@@ -7,7 +7,7 @@ use nydus::fs::ErofsReader;
 use nydus::metadata::*;
 use nydus::tracing::{init_command_tracing, init_command_tracing_stderr};
 use nydus::unpack::unpack_to_tar;
-use nydus::utils::hex_string;
+use nydus::utils::{align_up, bytes_to_blocks, hex_string, write_zero_padding};
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::fs::{self, File, OpenOptions};
@@ -282,7 +282,8 @@ fn run_dir_to_nydus(args: BuildArgs) -> Result<()> {
     let bootstrap_offset = align_up(
         compressed_data_offset + compressed_data_size,
         NYDUS_BLOB_FOOTER_ALIGNMENT,
-    );
+    )
+    .context("bootstrap offset overflow")?;
     write_zero_padding(
         &mut blob_writer_stream,
         compressed_data_offset + compressed_data_size,
@@ -303,7 +304,8 @@ fn run_dir_to_nydus(args: BuildArgs) -> Result<()> {
     let blob_meta_offset = align_up(
         bootstrap_offset + bootstrap_size,
         NYDUS_BLOB_FOOTER_ALIGNMENT,
-    );
+    )
+    .context("blob meta offset overflow")?;
     write_zero_padding(
         &mut blob_writer_stream,
         bootstrap_offset + bootstrap_size,
@@ -371,30 +373,6 @@ fn run_dir_to_nydus(args: BuildArgs) -> Result<()> {
         blob_meta_path: &blob_meta_path,
         bootstrap_path: args.bootstrap.as_deref(),
     });
-    Ok(())
-}
-
-fn align_up(value: u64, align: u64) -> u64 {
-    debug_assert!(align.is_power_of_two());
-    (value + align - 1) & !(align - 1)
-}
-
-fn bytes_to_blocks(size: u64, name: &str) -> Result<u32> {
-    if size % EROFS_BLOCK_SIZE as u64 != 0 {
-        bail!("{name} size is not block aligned: {size}");
-    }
-    u32::try_from(size / EROFS_BLOCK_SIZE as u64)
-        .with_context(|| format!("{name} exceeds u32 block count"))
-}
-
-fn write_zero_padding(writer: &mut dyn Write, current: u64, aligned: u64) -> Result<()> {
-    if aligned < current {
-        bail!("invalid blob region alignment");
-    }
-    let padding = (aligned - current) as usize;
-    if padding > 0 {
-        writer.write_all(&vec![0u8; padding])?;
-    }
     Ok(())
 }
 
@@ -584,13 +562,6 @@ mod tests {
     #[test]
     fn default_chunk_size_is_one_megabyte() {
         assert_eq!(DEFAULT_CHUNK_SIZE, 1_048_576);
-    }
-
-    #[test]
-    fn align_up_rounds_up_to_alignment() {
-        assert_eq!(align_up(0, 8), 0);
-        assert_eq!(align_up(1, 8), 8);
-        assert_eq!(align_up(16, 8), 16);
     }
 
     #[test]

--- a/nydus/src/bin/nydus/optimize.rs
+++ b/nydus/src/bin/nydus/optimize.rs
@@ -7,7 +7,7 @@ use nydus::metadata::*;
 use nydus::storage::backend::build_backend;
 use nydus::storage::cache::{BlobCache, LocalBlobCache};
 use nydus::tracing::init_command_tracing;
-use nydus::utils::hex_string;
+use nydus::utils::{align_up, hex_string};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -351,7 +351,8 @@ fn fetch_trace(apiserver: &str) -> Result<Vec<u8>> {
 /// embedded bootstrap) and return its bytes, full SHA256 digest, and footer.
 fn assemble_artifact(data: &[u8], blob_meta: &BlobMeta) -> Result<(Vec<u8>, [u8; 32], BlobFooter)> {
     let compressed_data_size = data.len() as u64;
-    let bootstrap_offset = align_up(compressed_data_size, NYDUS_BLOB_FOOTER_ALIGNMENT);
+    let bootstrap_offset = align_up(compressed_data_size, NYDUS_BLOB_FOOTER_ALIGNMENT)
+        .context("bootstrap offset overflow")?;
     let blob_meta_offset = bootstrap_offset;
     let blob_meta_size = blob_meta.metadata_size();
     let blob_meta_blocks = u32::try_from(blob_meta_size / EROFS_BLOCK_SIZE as u64)
@@ -387,11 +388,6 @@ fn assemble_artifact(data: &[u8], blob_meta: &BlobMeta) -> Result<(Vec<u8>, [u8;
     let mut digest = [0u8; 32];
     digest.copy_from_slice(&hasher.finalize());
     Ok((artifact, digest, footer))
-}
-
-fn align_up(value: u64, align: u64) -> u64 {
-    debug_assert!(align.is_power_of_two());
-    (value + align - 1) & !(align - 1)
 }
 
 fn compression_is_worthwhile(compressed_len: usize, uncompressed_len: usize) -> bool {

--- a/nydus/src/fanotify/mount.rs
+++ b/nydus/src/fanotify/mount.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 
 use super::core::BlobDevice;
+use crate::utils::path_cstring;
 
 /// The kernel copies `mount(2)` data into a single page (`copy_mount_options`),
 /// so a longer option string is silently truncated — dropping `device=` slots
@@ -53,18 +54,7 @@ pub fn mount_erofs(bootstrap: &Path, devices: &[BlobDevice], mountpoint: &Path) 
 
 /// Unmount the EROFS at `mountpoint`.
 pub fn unmount_erofs(mountpoint: &Path) -> Result<()> {
-    let target = path_cstring(mountpoint, "mountpoint")?;
-    let ret = unsafe { libc::umount2(target.as_ptr(), 0) };
-    if ret < 0 {
-        return Err(std::io::Error::last_os_error())
-            .with_context(|| format!("failed to unmount {}", mountpoint.display()));
-    }
-    Ok(())
-}
-
-fn path_cstring(path: &Path, kind: &str) -> Result<CString> {
-    CString::new(path.as_os_str().as_bytes())
-        .with_context(|| format!("{kind} path contains an interior NUL byte"))
+    crate::utils::unmount(mountpoint)
 }
 
 /// Build the binary mount data without lossy UTF-8 conversion. A comma in a

--- a/nydus/src/nbd/core.rs
+++ b/nydus/src/nbd/core.rs
@@ -20,13 +20,13 @@
 //! `device_id` to 0 and treats blob-relative addresses as flat offsets, so
 //! files silently read back bootstrap bytes or holes.
 
-use std::os::fd::RawFd;
 use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
 
 use crate::metadata::EROFS_BLOCK_SIZE;
+use crate::utils::pread_exact;
 use crate::{Config, NydusCore};
 
 /// EROFS block size as u64 — reuses the canonical constant from the core.
@@ -142,67 +142,5 @@ impl NbdCore {
             buf[written..].fill(0);
         }
         Ok(())
-    }
-}
-
-/// Read exactly `buf.len()` bytes from `fd` at `offset` without moving the
-/// file position (safe on a shared fd). Zero-fills the remainder on EOF: the
-/// cache file's block-aligned sizing should never produce one, but the NBD
-/// reply must be full-length.
-fn pread_exact(fd: RawFd, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
-    let mut filled = 0usize;
-    while filled < buf.len() {
-        let n = unsafe {
-            libc::pread(
-                fd,
-                buf[filled..].as_mut_ptr() as *mut libc::c_void,
-                buf.len() - filled,
-                (offset + filled as u64) as libc::off_t,
-            )
-        };
-        if n < 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        if n == 0 {
-            // EOF before the expected length: zero-fill the rest.
-            buf[filled..].fill(0);
-            return Ok(());
-        }
-        filled += n as usize;
-    }
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn pread_exact_zero_len_is_noop() {
-        // An empty buffer must return immediately without touching the fd.
-        let mut buf = [0u8; 0];
-        pread_exact(libc::STDIN_FILENO, &mut buf, 0).unwrap();
-        assert!(buf.is_empty());
-    }
-
-    #[test]
-    fn pread_exact_zero_fills_past_eof_without_duplicating() {
-        use std::io::Write as _;
-        use std::os::fd::AsRawFd as _;
-
-        let mut f = tempfile::tempfile().unwrap();
-        let content: Vec<u8> = (0u8..100).collect();
-        f.write_all(&content).unwrap();
-
-        // Read [80, 144) from a 100-byte file: the first pread returns only
-        // 20 bytes, so the loop must advance the offset, hit EOF, and
-        // zero-fill the tail — not re-read the same 20 bytes forever.
-        let mut buf = [0xAAu8; 64];
-        pread_exact(f.as_raw_fd(), &mut buf, 80).unwrap();
-        assert_eq!(&buf[..20], &content[80..]);
-        assert!(
-            buf[20..].iter().all(|&b| b == 0),
-            "tail past EOF must be zero-filled, not duplicated file data"
-        );
     }
 }

--- a/nydus/src/nbd/mount.rs
+++ b/nydus/src/nbd/mount.rs
@@ -8,10 +8,11 @@
 //! options, no option-length budget.
 
 use std::ffi::CString;
-use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 
 use anyhow::{Context, Result};
+
+use crate::utils::path_cstring;
 
 /// Mount the NBD block device `device` at `mountpoint` as `fstype`, read-only.
 ///
@@ -47,18 +48,7 @@ pub fn mount_nbd(device: &str, mountpoint: &Path, fstype: &str) -> Result<()> {
 /// Unmount whatever is mounted at `mountpoint`. A plain `umount2(., 0)`; the
 /// EBUSY retry loop lives in the CLI, mirroring fanotify's shutdown ordering.
 pub fn unmount_nbd(mountpoint: &Path) -> Result<()> {
-    let target = path_cstring(mountpoint, "mountpoint")?;
-    let ret = unsafe { libc::umount2(target.as_ptr(), 0) };
-    if ret < 0 {
-        return Err(std::io::Error::last_os_error())
-            .with_context(|| format!("failed to unmount {}", mountpoint.display()));
-    }
-    Ok(())
-}
-
-fn path_cstring(path: &Path, kind: &str) -> Result<CString> {
-    CString::new(path.as_os_str().as_bytes())
-        .with_context(|| format!("{kind} path contains an interior NUL byte"))
+    crate::utils::unmount(mountpoint)
 }
 
 #[cfg(test)]

--- a/nydus/src/ublk/core.rs
+++ b/nydus/src/ublk/core.rs
@@ -18,6 +18,7 @@ use anyhow::{Context, Result};
 use crate::config::Config;
 use crate::core::{FdRange, NydusCore};
 use crate::metadata::EROFS_BLOCK_SIZE;
+use crate::utils::{align_up, pread_exact};
 
 /// Logical block size exposed by the ublk device. Matching the EROFS block size
 /// keeps every incoming request aligned to a whole number of EROFS blocks.
@@ -262,38 +263,6 @@ impl Drop for Mapping {
 /// space, but a short read can still happen when the core resolved a range
 /// that extends past the current file size; treat it the same way a block
 /// device treats an unwritten sector.
-fn pread_exact(fd: RawFd, buf: &mut [u8], offset: u64) -> io::Result<()> {
-    let mut done = 0usize;
-    while done < buf.len() {
-        let ret = unsafe {
-            libc::pread(
-                fd,
-                buf[done..].as_mut_ptr() as *mut libc::c_void,
-                buf.len() - done,
-                (offset + done as u64) as libc::off_t,
-            )
-        };
-        match ret {
-            0 => {
-                buf[done..].fill(0);
-                return Ok(());
-            }
-            n if n > 0 => done += n as usize,
-            _ => {
-                let err = io::Error::last_os_error();
-                if err.kind() == io::ErrorKind::Interrupted {
-                    continue;
-                }
-                return Err(err);
-            }
-        }
-    }
-    Ok(())
-}
-
-fn align_up(value: u64, align: u64) -> Option<u64> {
-    value.checked_add(align - 1).map(|v| v & !(align - 1))
-}
 
 #[cfg(test)]
 mod tests {
@@ -317,24 +286,6 @@ mod tests {
             len,
             source_offset,
         }
-    }
-
-    #[test]
-    fn rounds_size_up_to_block() {
-        assert_eq!(align_up(0, 4096), Some(0));
-        assert_eq!(align_up(1, 4096), Some(4096));
-        assert_eq!(align_up(4096, 4096), Some(4096));
-        assert_eq!(align_up(4097, 4096), Some(8192));
-        assert_eq!(align_up(u64::MAX, 4096), None);
-    }
-
-    #[test]
-    fn pread_exact_zero_fills_past_eof() {
-        let file = temp_file(b"nydus");
-
-        let mut buf = [0xffu8; 8];
-        pread_exact(file.as_raw_fd(), &mut buf, 0).unwrap();
-        assert_eq!(&buf, b"nydus\0\0\0");
     }
 
     #[test]

--- a/nydus/src/uffd/core.rs
+++ b/nydus/src/uffd/core.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Context, Result};
 
+use crate::utils::align_up;
 use crate::{Config, FdRange, NydusCore};
 
 use super::proto::{DeviceRange, FaultPolicy, VmaRegion};
@@ -69,7 +70,8 @@ impl UffdCore {
     pub fn new(bootstrap: &Path, config: Config) -> Result<Self> {
         let core =
             Arc::new(NydusCore::new(bootstrap, config).context("failed to create nydus core")?);
-        let device_size = align_up(core.flat_size(), UFFD_TOTAL_SIZE_ALIGNMENT)?;
+        let device_size = align_up(core.flat_size(), UFFD_TOTAL_SIZE_ALIGNMENT)
+            .ok_or_else(|| anyhow!("alignment overflow"))?;
 
         Ok(Self { core, device_size })
     }
@@ -321,11 +323,4 @@ fn uffdio_zeropage(uffd_fd: RawFd, start: u64, len: u64) -> Result<()> {
         bail!("UFFDIO_ZEROPAGE failed: {err}");
     }
     Ok(())
-}
-
-fn align_up(value: u64, alignment: u64) -> Result<u64> {
-    Ok(value
-        .checked_add(alignment - 1)
-        .ok_or_else(|| anyhow!("alignment overflow"))?
-        & !(alignment - 1))
 }

--- a/nydusify/internal/checker/filesystem.go
+++ b/nydusify/internal/checker/filesystem.go
@@ -8,6 +8,7 @@ package checker
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/base64"
 	"os"
@@ -24,6 +25,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/dragonflyoss/nydus/nydusify/internal/remote"
+	pkgconv "github.com/dragonflyoss/nydus/nydusify/pkg/converter"
 )
 
 // filesystemRule mounts both the source and target images and compares their
@@ -169,7 +171,7 @@ func (r *filesystemRule) fuseMount(ctx context.Context, dir string, reg remote.S
 	// nydus fuse runs in the foreground; start it detached and wait for the
 	// mountpoint to become active. Keep its output buffered for startup errors;
 	// the check command itself owns the user-facing progress logs.
-	cmd := exec.Command(builderBinary(r.builder), args...)
+	cmd := exec.Command(cmp.Or(r.builder, pkgconv.DefaultBuilder), args...)
 	var fuseLog bytes.Buffer
 	cmd.Stdout = &fuseLog
 	cmd.Stderr = &fuseLog

--- a/nydusify/internal/checker/image.go
+++ b/nydusify/internal/checker/image.go
@@ -8,16 +8,15 @@ package checker
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 
 	"github.com/dragonflyoss/nydus/nydusify/internal/converter"
+	"github.com/dragonflyoss/nydus/nydusify/internal/oci"
 	"github.com/dragonflyoss/nydus/nydusify/internal/remote"
 )
 
@@ -81,18 +80,18 @@ func loadImage(ctx context.Context, provider *remote.Provider, ref string, platf
 // Image, reading the manifest and config from cs and classifying the image as
 // OCI or nydus.
 func parseImage(ctx context.Context, cs content.Store, ref string, rootDesc ocispec.Descriptor, platformMC platforms.MatchComparer) (*Image, error) {
-	manifestDesc, err := resolveManifest(ctx, cs, rootDesc, platformMC)
+	manifestDesc, err := oci.ResolveManifest(ctx, cs, rootDesc, platformMC)
 	if err != nil {
 		return nil, errors.Wrap(err, "select platform manifest")
 	}
 
 	var manifest ocispec.Manifest
-	if err := readJSON(ctx, cs, manifestDesc, &manifest); err != nil {
+	if err := oci.ReadJSON(ctx, cs, manifestDesc, &manifest); err != nil {
 		return nil, errors.Wrap(err, "read manifest")
 	}
 
 	var config ocispec.Image
-	if err := readJSON(ctx, cs, manifest.Config, &config); err != nil {
+	if err := oci.ReadJSON(ctx, cs, manifest.Config, &config); err != nil {
 		return nil, errors.Wrap(err, "read image config")
 	}
 
@@ -121,57 +120,4 @@ func parseImage(ctx context.Context, cs content.Store, ref string, rootDesc ocis
 	}
 
 	return img, nil
-}
-
-// resolveManifest returns the manifest descriptor for the requested platform. If
-// rootDesc is already a manifest it is returned as-is.
-func resolveManifest(ctx context.Context, cs content.Store, rootDesc ocispec.Descriptor, platformMC platforms.MatchComparer) (ocispec.Descriptor, error) {
-	if images.IsManifestType(rootDesc.MediaType) {
-		return rootDesc, nil
-	}
-	if !images.IsIndexType(rootDesc.MediaType) {
-		return ocispec.Descriptor{}, errors.Errorf("unsupported root media type %q", rootDesc.MediaType)
-	}
-
-	var index ocispec.Index
-	if err := readJSON(ctx, cs, rootDesc, &index); err != nil {
-		return ocispec.Descriptor{}, errors.Wrap(err, "read index")
-	}
-	if len(index.Manifests) == 0 {
-		return ocispec.Descriptor{}, errors.New("image index has no manifests")
-	}
-
-	var candidates []ocispec.Descriptor
-	for _, m := range index.Manifests {
-		if !images.IsManifestType(m.MediaType) {
-			continue
-		}
-		if m.Platform == nil || platformMC.Match(*m.Platform) {
-			candidates = append(candidates, m)
-		}
-	}
-	if len(candidates) == 0 {
-		return ocispec.Descriptor{}, errors.New("no manifest matches the requested platform")
-	}
-
-	// Prefer the platform the matcher considers most specific.
-	best := candidates[0]
-	for _, c := range candidates[1:] {
-		if c.Platform != nil && best.Platform != nil && platformMC.Less(*c.Platform, *best.Platform) {
-			best = c
-		}
-	}
-	return best, nil
-}
-
-// readJSON reads desc from cs and unmarshals it into v.
-func readJSON(ctx context.Context, cs content.Store, desc ocispec.Descriptor, v interface{}) error {
-	b, err := content.ReadBlob(ctx, cs, desc)
-	if err != nil {
-		return errors.Wrapf(err, "read blob %s", desc.Digest)
-	}
-	if err := json.Unmarshal(b, v); err != nil {
-		return errors.Wrapf(err, "unmarshal %s", desc.Digest)
-	}
-	return nil
 }

--- a/nydusify/internal/checker/mount.go
+++ b/nydusify/internal/checker/mount.go
@@ -7,6 +7,7 @@
 package checker
 
 import (
+	"cmp"
 	"context"
 	"os"
 	"os/exec"
@@ -20,6 +21,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/dragonflyoss/nydus/nydusify/internal/remote"
+	pkgconv "github.com/dragonflyoss/nydus/nydusify/pkg/converter"
 )
 
 // MountOption configures a Mounter.
@@ -165,11 +167,11 @@ func (m *Mounter) mountNydus(ctx context.Context, provider *remote.Provider, cs 
 		"--config", configPath,
 		"--mountpoint", m.opt.Mountpoint,
 		"--apiserver", "unix://" + apiSocket,
-		"--log-level", nydusLogLevel(m.opt.LogLevel),
+		"--log-level", cmp.Or(m.opt.LogLevel, pkgconv.DefaultLogLevel),
 		"--log-dir", logDir,
 		"--console",
 	}
-	cmd := exec.Command(builderBinary(m.opt.Builder), args...)
+	cmd := exec.Command(cmp.Or(m.opt.Builder, pkgconv.DefaultBuilder), args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {

--- a/nydusify/internal/checker/optimize.go
+++ b/nydusify/internal/checker/optimize.go
@@ -8,6 +8,7 @@ package checker
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"io"
 	"os"
@@ -26,6 +27,7 @@ import (
 
 	"github.com/dragonflyoss/nydus/nydusify/internal/converter"
 	"github.com/dragonflyoss/nydus/nydusify/internal/remote"
+	pkgconv "github.com/dragonflyoss/nydus/nydusify/pkg/converter"
 )
 
 // OptimizeOption configures an Optimizer.
@@ -214,10 +216,10 @@ func (o *Optimizer) runNydusOptimize(ctx context.Context, parentBootstrap, boots
 		"--bootstrap", bootstrap,
 		"--blob-dir", blobDir,
 		"--config", configPath,
-		"--log-level", nydusLogLevel(o.opt.LogLevel),
+		"--log-level", cmp.Or(o.opt.LogLevel, pkgconv.DefaultLogLevel),
 		"--trace-file", o.opt.Pattern,
 	}
-	cmd := exec.CommandContext(ctx, builderBinary(o.opt.Builder), args...)
+	cmd := exec.CommandContext(ctx, cmp.Or(o.opt.Builder, pkgconv.DefaultBuilder), args...)
 	var output bytes.Buffer
 	cmd.Stdout = io.MultiWriter(&output, os.Stderr)
 	cmd.Stderr = os.Stderr

--- a/nydusify/internal/checker/tool.go
+++ b/nydusify/internal/checker/tool.go
@@ -9,6 +9,7 @@ package checker
 import (
 	"archive/tar"
 	"bytes"
+	"cmp"
 	"context"
 	"io"
 	"os"
@@ -25,23 +26,8 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dragonflyoss/nydus/nydusify/internal/converter"
+	pkgconv "github.com/dragonflyoss/nydus/nydusify/pkg/converter"
 )
-
-func builderBinary(bin string) string {
-	if bin == "" {
-		return "nydus"
-	}
-	return bin
-}
-
-// nydusLogLevel returns level, or "info" when level is empty, so a nydus
-// subprocess always receives a valid `--log-level` value.
-func nydusLogLevel(level string) string {
-	if level == "" {
-		return "info"
-	}
-	return level
-}
 
 // blobMetaLinkConcurrency bounds how many blob meta files are hardlinked/copied
 // into the cache directory in parallel.
@@ -275,7 +261,7 @@ func runNydusCheck(ctx context.Context, builder, bootstrapPath string) error {
 		"check",
 		"--bootstrap", bootstrapPath,
 	}
-	cmd := exec.CommandContext(ctx, builderBinary(builder), args...)
+	cmd := exec.CommandContext(ctx, cmp.Or(builder, pkgconv.DefaultBuilder), args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/nydusify/internal/converter/hook.go
+++ b/nydusify/internal/converter/hook.go
@@ -21,6 +21,7 @@ import (
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/images/converter"
 	"github.com/containerd/errdefs"
+	"github.com/dragonflyoss/nydus/nydusify/internal/oci"
 	pkgconv "github.com/dragonflyoss/nydus/nydusify/pkg/converter"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -57,7 +58,7 @@ func ConvertHookFunc(opt MergeOption) converter.ConvertHookFunc {
 // contains only one entry, mirroring the nydus behavior.
 func convertIndex(ctx context.Context, cs content.Store, newDesc *ocispec.Descriptor) (*ocispec.Descriptor, error) {
 	var index ocispec.Index
-	if _, err := readJSON(ctx, cs, &index, *newDesc); err != nil {
+	if err := oci.ReadJSON(ctx, cs, *newDesc, &index); err != nil {
 		return nil, errors.Wrap(err, "read index json")
 	}
 	if len(index.Manifests) == 1 {
@@ -70,8 +71,11 @@ func convertIndex(ctx context.Context, cs content.Store, newDesc *ocispec.Descri
 // nydus bootstrap layer, rewrites the image config, and rewrites the manifest.
 func convertManifest(ctx context.Context, cs content.Store, newDesc *ocispec.Descriptor, opt MergeOption) (*ocispec.Descriptor, error) {
 	var manifest ocispec.Manifest
-	manifestLabels, err := readJSON(ctx, cs, &manifest, *newDesc)
+	manifestLabels, err := oci.Labels(ctx, cs, newDesc.Digest)
 	if err != nil {
+		return nil, err
+	}
+	if err := oci.ReadJSON(ctx, cs, *newDesc, &manifest); err != nil {
 		return nil, errors.Wrap(err, "read manifest json")
 	}
 
@@ -108,8 +112,11 @@ func convertManifest(ctx context.Context, cs content.Store, newDesc *ocispec.Des
 	}
 
 	var rawConfig json.RawMessage
-	configLabels, err := readJSON(ctx, cs, &rawConfig, manifest.Config)
+	configLabels, err := oci.Labels(ctx, cs, manifest.Config.Digest)
 	if err != nil {
+		return nil, err
+	}
+	if err := oci.ReadJSON(ctx, cs, manifest.Config, &rawConfig); err != nil {
 		return nil, errors.Wrap(err, "read image config")
 	}
 	newConfig, err := rewriteBootstrapConfig(rawConfig, diffIDs)
@@ -332,27 +339,6 @@ func WriteBootstrapLayer(ctx context.Context, cs content.Store, bootstrapData []
 			LayerAnnotationNydusFsVersion: NydusFsVersion,
 		},
 	}, nil
-}
-
-// readJSON reads and unmarshals a JSON blob (manifest/index/config) from the
-// content store, returning its labels.
-func readJSON(ctx context.Context, cs content.Store, x interface{}, desc ocispec.Descriptor) (map[string]string, error) {
-	info, err := cs.Info(ctx, desc.Digest)
-	if err != nil {
-		return nil, errors.Wrap(err, "stat content")
-	}
-	labels := info.Labels
-	if labels == nil {
-		labels = map[string]string{}
-	}
-	b, err := content.ReadBlob(ctx, cs, desc)
-	if err != nil {
-		return nil, errors.Wrap(err, "read content blob")
-	}
-	if err := json.Unmarshal(b, x); err != nil {
-		return nil, errors.Wrap(err, "unmarshal json")
-	}
-	return labels, nil
 }
 
 // WriteJSON marshals x to JSON and commits it to the content store, returning a

--- a/nydusify/internal/converter/multi.go
+++ b/nydusify/internal/converter/multi.go
@@ -22,6 +22,8 @@ import (
 	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+
+	"github.com/dragonflyoss/nydus/nydusify/internal/oci"
 )
 
 // Source describes one input of a multi-source conversion. Exactly one of the
@@ -292,13 +294,13 @@ func convertImageSource(ctx context.Context, cs content.Store, opt MultiSourceOp
 		newDesc = &srcDesc
 	}
 
-	manifestDesc, err := resolveManifest(ctx, cs, *newDesc, platformMC)
+	manifestDesc, err := oci.ResolveManifest(ctx, cs, *newDesc, platformMC)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var manifest ocispec.Manifest
-	if _, err := readJSON(ctx, cs, &manifest, manifestDesc); err != nil {
+	if err := oci.ReadJSON(ctx, cs, manifestDesc, &manifest); err != nil {
 		return nil, nil, errors.Wrap(err, "read manifest json")
 	}
 
@@ -316,7 +318,7 @@ func convertImageSource(ctx context.Context, cs content.Store, opt MultiSourceOp
 	}
 
 	var config json.RawMessage
-	if _, err := readJSON(ctx, cs, &config, manifest.Config); err != nil {
+	if err := oci.ReadJSON(ctx, cs, manifest.Config, &config); err != nil {
 		return nil, nil, errors.Wrap(err, "read image config")
 	}
 	return blobs, config, nil
@@ -371,7 +373,7 @@ func labelNydusBlobDiffIDs(ctx context.Context, cs content.Store, rootDesc ocisp
 		manifestDescs = []ocispec.Descriptor{rootDesc}
 	case images.IsIndexType(rootDesc.MediaType):
 		var index ocispec.Index
-		if _, err := readJSON(ctx, cs, &index, rootDesc); err != nil {
+		if err := oci.ReadJSON(ctx, cs, rootDesc, &index); err != nil {
 			return errors.Wrap(err, "read index json")
 		}
 		for _, m := range index.Manifests {
@@ -385,7 +387,7 @@ func labelNydusBlobDiffIDs(ctx context.Context, cs content.Store, rootDesc ocisp
 
 	for _, manifestDesc := range manifestDescs {
 		var manifest ocispec.Manifest
-		if _, err := readJSON(ctx, cs, &manifest, manifestDesc); err != nil {
+		if err := oci.ReadJSON(ctx, cs, manifestDesc, &manifest); err != nil {
 			return errors.Wrap(err, "read manifest json")
 		}
 		for _, layer := range manifest.Layers {
@@ -413,26 +415,4 @@ func labelNydusBlobDiffIDs(ctx context.Context, cs content.Store, rootDesc ocisp
 		}
 	}
 	return nil
-}
-
-// resolveManifest returns the platform-specific manifest descriptor,
-// selecting from an index when rootDesc is multi-platform.
-func resolveManifest(ctx context.Context, cs content.Store, rootDesc ocispec.Descriptor, platformMC platforms.MatchComparer) (ocispec.Descriptor, error) {
-	if images.IsManifestType(rootDesc.MediaType) {
-		return rootDesc, nil
-	}
-	if !images.IsIndexType(rootDesc.MediaType) {
-		return ocispec.Descriptor{}, errors.Errorf("unsupported root media type %q", rootDesc.MediaType)
-	}
-
-	var index ocispec.Index
-	if _, err := readJSON(ctx, cs, &index, rootDesc); err != nil {
-		return ocispec.Descriptor{}, errors.Wrap(err, "read index json")
-	}
-	for _, m := range index.Manifests {
-		if m.Platform == nil || platformMC.Match(*m.Platform) {
-			return m, nil
-		}
-	}
-	return ocispec.Descriptor{}, errors.New("no manifest matches the requested platform")
 }

--- a/nydusify/internal/converter/tooci.go
+++ b/nydusify/internal/converter/tooci.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/pkg/archive/compression"
 	"github.com/containerd/errdefs"
+	"github.com/dragonflyoss/nydus/nydusify/internal/oci"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -63,8 +64,11 @@ func ConvertToOCI(ctx context.Context, cs content.Store, srcDesc ocispec.Descrip
 
 func convertIndexToOCI(ctx context.Context, cs content.Store, desc ocispec.Descriptor, opt ToOCIOption) (*ocispec.Descriptor, error) {
 	var index ocispec.Index
-	labels, err := readJSON(ctx, cs, &index, desc)
+	labels, err := oci.Labels(ctx, cs, desc.Digest)
 	if err != nil {
+		return nil, err
+	}
+	if err := oci.ReadJSON(ctx, cs, desc, &index); err != nil {
 		return nil, errors.Wrap(err, "read index json")
 	}
 
@@ -83,8 +87,11 @@ func convertIndexToOCI(ctx context.Context, cs content.Store, desc ocispec.Descr
 
 func convertManifestToOCI(ctx context.Context, cs content.Store, desc ocispec.Descriptor, opt ToOCIOption) (*ocispec.Descriptor, error) {
 	var manifest ocispec.Manifest
-	manifestLabels, err := readJSON(ctx, cs, &manifest, desc)
+	manifestLabels, err := oci.Labels(ctx, cs, desc.Digest)
 	if err != nil {
+		return nil, err
+	}
+	if err := oci.ReadJSON(ctx, cs, desc, &manifest); err != nil {
 		return nil, errors.Wrap(err, "read manifest json")
 	}
 
@@ -111,8 +118,11 @@ func convertManifestToOCI(ctx context.Context, cs content.Store, desc ocispec.De
 	}
 
 	var rawConfig json.RawMessage
-	configLabels, err := readJSON(ctx, cs, &rawConfig, manifest.Config)
+	configLabels, err := oci.Labels(ctx, cs, manifest.Config.Digest)
 	if err != nil {
+		return nil, err
+	}
+	if err := oci.ReadJSON(ctx, cs, manifest.Config, &rawConfig); err != nil {
 		return nil, errors.Wrap(err, "read image config")
 	}
 	newConfig, err := rewriteOCIConfig(rawConfig, diffIDs, len(manifest.Layers)-len(layers))

--- a/nydusify/internal/oci/oci.go
+++ b/nydusify/internal/oci/oci.go
@@ -1,0 +1,92 @@
+// Package oci reads OCI image structures (manifests, indexes, configs) from
+// a containerd content store.
+package oci
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/platforms"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// ResolveManifest returns the manifest descriptor for the requested platform.
+// If rootDesc is already a manifest it is returned as-is; an index is resolved
+// to its most specific matching manifest entry, skipping non-manifest entries
+// such as attestations.
+func ResolveManifest(ctx context.Context, cs content.Store, rootDesc ocispec.Descriptor, platformMC platforms.MatchComparer) (ocispec.Descriptor, error) {
+	if images.IsManifestType(rootDesc.MediaType) {
+		return rootDesc, nil
+	}
+
+	if !images.IsIndexType(rootDesc.MediaType) {
+		return ocispec.Descriptor{}, errors.Errorf("unsupported root media type %q", rootDesc.MediaType)
+	}
+
+	var index ocispec.Index
+	if err := ReadJSON(ctx, cs, rootDesc, &index); err != nil {
+		return ocispec.Descriptor{}, errors.Wrap(err, "read index")
+	}
+
+	if len(index.Manifests) == 0 {
+		return ocispec.Descriptor{}, errors.New("image index has no manifests")
+	}
+
+	var candidates []ocispec.Descriptor
+	for _, m := range index.Manifests {
+		if !images.IsManifestType(m.MediaType) {
+			continue
+		}
+
+		if m.Platform == nil || platformMC.Match(*m.Platform) {
+			candidates = append(candidates, m)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return ocispec.Descriptor{}, errors.New("no manifest matches the requested platform")
+	}
+
+	// Prefer the platform the matcher considers most specific.
+	best := candidates[0]
+	for _, c := range candidates[1:] {
+		if c.Platform != nil && best.Platform != nil && platformMC.Less(*c.Platform, *best.Platform) {
+			best = c
+		}
+	}
+
+	return best, nil
+}
+
+// ReadJSON reads desc from cs and unmarshals it into v.
+func ReadJSON(ctx context.Context, cs content.Store, desc ocispec.Descriptor, v any) error {
+	b, err := content.ReadBlob(ctx, cs, desc)
+	if err != nil {
+		return errors.Wrapf(err, "read blob %s", desc.Digest)
+	}
+
+	if err := json.Unmarshal(b, v); err != nil {
+		return errors.Wrapf(err, "unmarshal %s", desc.Digest)
+	}
+
+	return nil
+}
+
+// Labels returns the content-store labels of the blob at dgst. The result is
+// never nil, so callers can extend it without a nil check.
+func Labels(ctx context.Context, cs content.Store, dgst digest.Digest) (map[string]string, error) {
+	info, err := cs.Info(ctx, dgst)
+	if err != nil {
+		return nil, errors.Wrapf(err, "stat content %s", dgst)
+	}
+
+	if info.Labels == nil {
+		return map[string]string{}, nil
+	}
+
+	return info.Labels, nil
+}

--- a/nydusify/main.go
+++ b/nydusify/main.go
@@ -8,12 +8,10 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"strings"
 
 	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/dustin/go-humanize"
@@ -24,6 +22,7 @@ import (
 
 	"github.com/dragonflyoss/nydus/nydusify/internal/checker"
 	"github.com/dragonflyoss/nydus/nydusify/internal/converter"
+	"github.com/dragonflyoss/nydus/nydusify/internal/oci"
 	"github.com/dragonflyoss/nydus/nydusify/internal/remote"
 )
 
@@ -329,18 +328,14 @@ func isDir(path string) bool {
 // totalLayerSize resolves rootDesc (a manifest or a multi-platform index) for
 // the requested platform and returns the sum of its layer descriptor sizes.
 func totalLayerSize(ctx context.Context, cs content.Store, rootDesc ocispec.Descriptor, platformMC platforms.MatchComparer) (uint64, error) {
-	manifestDesc, err := resolveManifest(ctx, cs, rootDesc, platformMC)
+	manifestDesc, err := oci.ResolveManifest(ctx, cs, rootDesc, platformMC)
 	if err != nil {
 		return 0, err
 	}
 
 	var manifest ocispec.Manifest
-	b, err := content.ReadBlob(ctx, cs, manifestDesc)
-	if err != nil {
-		return 0, errors.Wrap(err, "read manifest blob")
-	}
-	if err := json.Unmarshal(b, &manifest); err != nil {
-		return 0, errors.Wrap(err, "unmarshal manifest")
+	if err := oci.ReadJSON(ctx, cs, manifestDesc, &manifest); err != nil {
+		return 0, errors.Wrap(err, "read manifest")
 	}
 
 	var total uint64
@@ -350,32 +345,6 @@ func totalLayerSize(ctx context.Context, cs content.Store, rootDesc ocispec.Desc
 		}
 	}
 	return total, nil
-}
-
-// resolveManifest returns the platform-specific manifest descriptor, selecting
-// from an index when rootDesc is multi-platform.
-func resolveManifest(ctx context.Context, cs content.Store, rootDesc ocispec.Descriptor, platformMC platforms.MatchComparer) (ocispec.Descriptor, error) {
-	if images.IsManifestType(rootDesc.MediaType) {
-		return rootDesc, nil
-	}
-	if !images.IsIndexType(rootDesc.MediaType) {
-		return ocispec.Descriptor{}, errors.Errorf("unsupported root media type %q", rootDesc.MediaType)
-	}
-
-	var index ocispec.Index
-	b, err := content.ReadBlob(ctx, cs, rootDesc)
-	if err != nil {
-		return ocispec.Descriptor{}, errors.Wrap(err, "read index blob")
-	}
-	if err := json.Unmarshal(b, &index); err != nil {
-		return ocispec.Descriptor{}, errors.Wrap(err, "unmarshal index")
-	}
-	for _, m := range index.Manifests {
-		if m.Platform == nil || platformMC.Match(*m.Platform) {
-			return m, nil
-		}
-	}
-	return ocispec.Descriptor{}, errors.New("no manifest matches the requested platform")
 }
 
 func checkCommand() *cli.Command {

--- a/nydusify/pkg/converter/builder.go
+++ b/nydusify/pkg/converter/builder.go
@@ -8,6 +8,7 @@ package converter
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"io"
 	"os/exec"
@@ -15,6 +16,14 @@ import (
 
 	"github.com/pkg/errors"
 )
+
+// DefaultBuilder is the PATH-resolvable nydus binary name used when no
+// explicit builder path is configured.
+const DefaultBuilder = "nydus"
+
+// DefaultLogLevel is passed to nydus subprocesses when no level is set, so
+// they always receive a valid `--log-level` value.
+const DefaultLogLevel = "info"
 
 // BuildOption describes a single `nydus build` invocation that converts a
 // directory tree into a nydus full blob.
@@ -69,22 +78,6 @@ type UnpackOption struct {
 	LogLevel string
 }
 
-func builderBinary(path string) string {
-	if path == "" {
-		return "nydus"
-	}
-	return path
-}
-
-// nydusLogLevel returns level, or "info" when level is empty, so a nydus
-// subprocess always receives a valid `--log-level` value.
-func nydusLogLevel(level string) string {
-	if level == "" {
-		return "info"
-	}
-	return level
-}
-
 // RunNydusBuild executes `nydus build` to produce a full blob at opt.BlobPath.
 //
 // The blob is written strictly sequentially (data -> bootstrap -> blob meta ->
@@ -97,18 +90,19 @@ func RunNydusBuild(ctx context.Context, opt BuildOption) error {
 		"--chunk-size", strconv.FormatUint(uint64(opt.ChunkSize), 10),
 		"--compress-size", strconv.FormatUint(uint64(opt.CompressSize), 10),
 		"--compressor", opt.Compressor,
-		"--log-level", nydusLogLevel(opt.LogLevel),
+		"--log-level", cmp.Or(opt.LogLevel, DefaultLogLevel),
 	}
 	for _, excl := range opt.Excludes {
 		args = append(args, "--exclude", excl)
 	}
 
-	cmd := exec.CommandContext(ctx, builderBinary(opt.BuilderPath), args...)
+	cmd := exec.CommandContext(ctx, cmp.Or(opt.BuilderPath, DefaultBuilder), args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		return errors.Wrapf(err, "nydus build failed: %s", stderr.String())
 	}
+
 	return nil
 }
 
@@ -121,10 +115,10 @@ func RunNydusMerge(ctx context.Context, opt MergeBuildOption) error {
 	args = append(args,
 		"--bootstrap", opt.BootstrapPath,
 		"--whiteout-spec", "oci",
-		"--log-level", nydusLogLevel(opt.LogLevel),
+		"--log-level", cmp.Or(opt.LogLevel, DefaultLogLevel),
 	)
 
-	cmd := exec.CommandContext(ctx, builderBinary(opt.BuilderPath), args...)
+	cmd := exec.CommandContext(ctx, cmp.Or(opt.BuilderPath, DefaultBuilder), args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -143,15 +137,16 @@ func RunNydusToTar(ctx context.Context, opt UnpackOption, dest io.Writer) error 
 		"build", opt.BlobPath,
 		"--type", "nydus-tar",
 		"--output", "-",
-		"--log-level", nydusLogLevel(opt.LogLevel),
+		"--log-level", cmp.Or(opt.LogLevel, DefaultLogLevel),
 	}
 
-	cmd := exec.CommandContext(ctx, builderBinary(opt.BuilderPath), args...)
+	cmd := exec.CommandContext(ctx, cmp.Or(opt.BuilderPath, DefaultBuilder), args...)
 	cmd.Stdout = dest
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		return errors.Wrapf(err, "nydus build --type nydus-tar failed: %s", stderr.String())
 	}
+
 	return nil
 }


### PR DESCRIPTION


## Overview

Move duplicated LE helpers, IO utilities, block/align helpers, and test fixtures into shared modules in nydus-core. Extract repeated OCI helper logic in nydusify into a new internal/oci package consumed by checker, converter, and other callers.


## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [x] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.