### PR TITLE
refactor(ublk): rename `UblkTarget` to `UblkService` and `target`

### DIFF
--- a/nydus/src/bin/nydus/ublk.rs
+++ b/nydus/src/bin/nydus/ublk.rs
@@ -6,7 +6,7 @@ use clap::Args;
 use nydus::config::Config;
 use nydus::tracing::init_tracing;
 use nydus::ublk::{
-    default_queues, UblkCore, UblkOptions, UblkTarget, DEFAULT_IO_BUF_BYTES, DEFAULT_QUEUE_DEPTH,
+    default_queues, UblkCore, UblkOptions, UblkService, DEFAULT_IO_BUF_BYTES, DEFAULT_QUEUE_DEPTH,
 };
 use signal_hook::consts::{signal::SIGHUP, TERM_SIGNALS};
 use signal_hook::iterator::Signals;
@@ -107,10 +107,10 @@ pub fn run_ublk(args: UblkArgs) -> Result<()> {
         io_buf_bytes: args.io_buf_bytes,
         unprivileged: args.unprivileged,
     };
-    let target = UblkTarget::new(core, &options)?;
-    println!("{}", target.dev_path());
+    let service = UblkService::new(core, &options)?;
+    println!("{}", service.dev_path());
 
-    let handle = target.handle();
+    let handle = service.handle();
     let signal_thread = std::thread::Builder::new()
         .name("nydus_ublk_signal".to_string())
         .spawn(move || {
@@ -121,8 +121,8 @@ pub fn run_ublk(args: UblkArgs) -> Result<()> {
         })
         .context("failed to spawn ublk signal thread")?;
 
-    let result = target.run();
-    target.delete();
+    let result = service.run();
+    service.delete();
 
     signal_handle.close();
     signal_thread

--- a/nydus/src/ublk/mod.rs
+++ b/nydus/src/ublk/mod.rs
@@ -5,10 +5,10 @@
 //! or later (`CONFIG_BLK_DEV_UBLK`).
 
 pub mod core;
-pub mod target;
+pub mod service;
 
 pub use core::{UblkCore, UBLK_LOGICAL_BLOCK_SIZE};
-pub use target::{
-    default_queues, UblkHandle, UblkOptions, UblkTarget, DEFAULT_IO_BUF_BYTES, DEFAULT_QUEUE_DEPTH,
-    MAX_DEFAULT_QUEUES,
+pub use service::{
+    default_queues, UblkHandle, UblkOptions, UblkService, DEFAULT_IO_BUF_BYTES,
+    DEFAULT_QUEUE_DEPTH, MAX_DEFAULT_QUEUES,
 };

--- a/nydus/src/ublk/service.rs
+++ b/nydus/src/ublk/service.rs
@@ -63,14 +63,14 @@ impl Default for UblkOptions {
 }
 
 /// A running ublk device serving a nydus image.
-pub struct UblkTarget {
+pub struct UblkService {
     ctrl: Arc<UblkCtrl>,
     core: Arc<UblkCore>,
 }
 
-impl UblkTarget {
+impl UblkService {
     /// Create the ublk device. The device is added to the driver here but does
-    /// not serve I/O until [`UblkTarget::run`] is called.
+    /// not serve I/O until [`UblkService::run`] is called.
     pub fn new(core: Arc<UblkCore>, options: &UblkOptions) -> Result<Self> {
         let ctrl_flags = if options.unprivileged {
             libublk::sys::UBLK_F_UNPRIVILEGED_DEV as u64
@@ -130,14 +130,14 @@ impl UblkTarget {
     }
 }
 
-/// Thread-safe handle for stopping a running [`UblkTarget`].
+/// Thread-safe handle for stopping a running [`UblkService`].
 #[derive(Clone)]
 pub struct UblkHandle {
     ctrl: Arc<UblkCtrl>,
 }
 
 impl UblkHandle {
-    /// Stop the device, which makes [`UblkTarget::run`] return.
+    /// Stop the device, which makes [`UblkService::run`] return.
     pub fn stop(&self) {
         if let Err(err) = self.ctrl.kill_dev() {
             error!("failed to stop ublk device: {err}");

--- a/nydus/src/uffd/service.rs
+++ b/nydus/src/uffd/service.rs
@@ -189,7 +189,7 @@ impl UffdConn {
             };
             match event {
                 ConnectionEvent::Socket(message) => self.dispatch_message(message).await?,
-                ConnectionEvent::Uffd(msg) => self.handle_uffd_event(msg).await?,
+                ConnectionEvent::Uffd(msg) => self.handle_page_fault(msg).await?,
             }
         }
         info!("nydus uffd connection stopped");
@@ -281,7 +281,7 @@ impl UffdConn {
         })
     }
 
-    async fn handle_uffd_event(&self, msg: UffdMsg) -> Result<()> {
+    async fn handle_page_fault(&self, msg: UffdMsg) -> Result<()> {
         let state = self
             .state
             .as_ref()


### PR DESCRIPTION



## Overview

Move duplicated LE helpers, IO utilities, block/align helpers, and test fixtures into shared modules in nydus-core. Extract repeated OCI helper logic in nydusify into a new internal/oci package consumed by checker, converter, and other callers.

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [x] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.