### PR TITLE
Refactor internal helpers and improve clarity of identifiers

### DIFF
--- a/nydus-core/src/core.rs
+++ b/nydus-core/src/core.rs
@@ -565,6 +565,19 @@ impl Blobs {
             .expect("flat layout is initialised above"))
     }
 
+    /// Resolve a blob id to its device-table index and opened cache.
+    fn blob_cache_for(&self, id: &BlobId) -> Result<(u16, Arc<dyn crate::storage::cache::BlobCache>)> {
+        let blob_index = *self
+            .index_by_blob_id
+            .get(id)
+            .ok_or_else(|| anyhow::anyhow!("blob is not referenced by the bootstrap"))?;
+        let cache = self
+            .reader
+            .blob_cache(blob_index)
+            .with_context(|| format!("failed to open blob {blob_index}"))?;
+        Ok((blob_index, cache))
+    }
+
     /// Ensure `[offset, offset + len)` of the blob's dense uncompressed
     /// address space is decoded, CRC-validated, and written to its cache data
     /// file, fetching missing groups through the backend. Both `offset` and
@@ -579,21 +592,14 @@ impl Blobs {
             return Ok(());
         }
 
-        let blob_index = *self
-            .index_by_blob_id
-            .get(id)
-            .ok_or_else(|| anyhow::anyhow!("blob is not referenced by the bootstrap"))?;
-        let cache = self
-            .reader
-            .blob_cache(blob_index)
-            .with_context(|| format!("failed to open blob {blob_index}"))?;
+        let (blob_index, cache) = self.blob_cache_for(id)?;
         cache
             .ensure_range(offset, len)
             .with_context(|| format!("failed to fetch blob {blob_index} range [{offset}, +{len})"))
     }
 
     /// Return cache-ready byte intervals overlapping `[offset, offset + len)`
-    /// without triggering a backend fetch. The groupmap remains authoritative.
+    /// without triggering a backend fetch. The group_map remains authoritative.
     pub fn ready_ranges(
         &self,
         id: &BlobId,
@@ -603,14 +609,7 @@ impl Blobs {
         if len == 0 {
             return Ok(Vec::new());
         }
-        let blob_index = *self
-            .index_by_blob_id
-            .get(id)
-            .ok_or_else(|| anyhow::anyhow!("blob is not referenced by the bootstrap"))?;
-        let cache = self
-            .reader
-            .blob_cache(blob_index)
-            .with_context(|| format!("failed to open blob {blob_index}"))?;
+        let (blob_index, cache) = self.blob_cache_for(id)?;
         cache.ready_ranges(offset, len).with_context(|| {
             format!("failed to inspect blob {blob_index} ready range [{offset}, +{len})")
         })
@@ -622,14 +621,7 @@ impl Blobs {
     /// event — or once per blob, since the answer is sticky — to bypass range
     /// readiness checks and fetch plumbing entirely for fully warmed blobs.
     pub fn is_all_ready(&self, id: &BlobId) -> Result<bool> {
-        let blob_index = *self
-            .index_by_blob_id
-            .get(id)
-            .ok_or_else(|| anyhow::anyhow!("blob is not referenced by the bootstrap"))?;
-        let cache = self
-            .reader
-            .blob_cache(blob_index)
-            .with_context(|| format!("failed to open blob {blob_index}"))?;
+        let (_, cache) = self.blob_cache_for(id)?;
         Ok(cache.is_all_ready())
     }
 }
@@ -798,38 +790,37 @@ impl FsEntry {
             bail!("not a regular file");
         }
         self.reader
-            .read_file_data_sync(self.ino, inode, offset, size)
+            .read_file_data(self.ino, inode, offset, size)
             .with_context(|| format!("failed to read file inode {}", self.ino))
     }
 
     fn fetch_chunk_data(&self, inode: &ErofsInode<'_>, offset: u64, len: u64) -> Result<()> {
         let chunkbits = self.reader.sb().blkszbits as u32 + (inode.chunk_format() as u32 & 0x1F);
-        let chunksize = 1u64 << chunkbits;
-        let chunk_indexes = self
+        let chunk_size = 1u64 << chunkbits;
+        let chunk_index_entries = self
             .reader
-            .read_chunk_indexes(self.ino, inode)
+            .read_chunk_index_entries(self.ino, inode)
             .with_context(|| format!("failed to read chunk indexes for inode {}", self.ino))?;
 
         let mut remaining = len;
         let mut file_pos = offset;
         while remaining > 0 {
-            let file_chunk_index = (file_pos / chunksize) as usize;
-            let chunk_off = file_pos % chunksize;
-            let to_fetch = remaining.min(chunksize - chunk_off);
-            let Some(chunk_index) = chunk_indexes.get(file_chunk_index) else {
+            let file_chunk_index = (file_pos / chunk_size) as usize;
+            let chunk_off = file_pos % chunk_size;
+            let to_fetch = remaining.min(chunk_size - chunk_off);
+            let Some(entry) = chunk_index_entries.get(file_chunk_index) else {
                 break;
             };
 
-            if chunk_index.blkaddr != u64::MAX {
-                let chunk_addr = chunk_index
-                    .blkaddr
+            if entry.blkaddr != u64::MAX {
+                let chunk_addr = entry.blkaddr
                     .checked_mul(EROFS_BLOCK_SIZE as u64)
                     .ok_or_else(|| anyhow::anyhow!("blob fetch offset overflow"))?;
                 // Resolve the chunk to a blob: the legacy layout names the blob
                 // by a non-zero device_id with a blob-relative address; the
                 // flattened layout uses device_id 0 with an absolute address.
-                let resolved = if chunk_index.device_id > 0 {
-                    Some((chunk_index.device_id, chunk_addr))
+                let resolved = if entry.device_id > 0 {
+                    Some((entry.device_id, chunk_addr))
                 } else {
                     self.reader.flat_blob_at(chunk_addr)?
                 };
@@ -894,10 +885,10 @@ impl FsEntry {
         mode: ResolveMode,
     ) -> Result<Vec<FdRange>> {
         let chunkbits = self.reader.sb().blkszbits as u32 + (inode.chunk_format() as u32 & 0x1F);
-        let chunksize = 1u64 << chunkbits;
-        let chunk_indexes = self
+        let chunk_size = 1u64 << chunkbits;
+        let chunk_index_entries = self
             .reader
-            .read_chunk_indexes(self.ino, inode)
+            .read_chunk_index_entries(self.ino, inode)
             .with_context(|| format!("failed to read chunk indexes for inode {}", self.ino))?;
         let blob_layout = self.reader.blob_infos()?;
 
@@ -905,27 +896,26 @@ impl FsEntry {
         let mut remaining = len;
         let mut file_pos = offset;
         while remaining > 0 {
-            let file_chunk_index = (file_pos / chunksize) as usize;
-            let chunk_off = file_pos % chunksize;
-            let to_resolve = remaining.min(chunksize - chunk_off);
-            let Some(chunk_index) = chunk_indexes.get(file_chunk_index) else {
+            let file_chunk_index = (file_pos / chunk_size) as usize;
+            let chunk_off = file_pos % chunk_size;
+            let to_resolve = remaining.min(chunk_size - chunk_off);
+            let Some(entry) = chunk_index_entries.get(file_chunk_index) else {
                 break;
             };
 
-            if chunk_index.blkaddr == EROFS_NULL_ADDR {
+            if entry.blkaddr == EROFS_NULL_ADDR {
                 push_fd_range(
                     &mut ranges,
                     FdRange::new(self.zero_file.as_raw_fd(), 0, to_resolve, file_pos),
                     self.zero_file.as_raw_fd(),
                 );
             } else {
-                let chunk_addr = chunk_index
-                    .blkaddr
+                let chunk_addr = entry.blkaddr
                     .checked_mul(EROFS_BLOCK_SIZE as u64)
                     .ok_or_else(|| anyhow::anyhow!("blob fetch offset overflow"))?;
-                let resolved = if chunk_index.device_id > 0 {
+                let resolved = if entry.device_id > 0 {
                     // Legacy layout: device_id directly names the blob.
-                    Some((chunk_index.device_id, chunk_addr))
+                    Some((entry.device_id, chunk_addr))
                 } else {
                     // Flattened layout: device_id 0 stores a flat device address.
                     blob_layout.iter().find_map(|blob| {
@@ -979,8 +969,11 @@ fn metadata_from_inode(reader: &ErofsReader, ino: u64, inode: &ErofsInode<'_>) -
     })
 }
 
-#[derive(Clone, Copy)]
-enum ResolveMode {
+/// How a range resolution treats missing data: `Fetch` pulls it into the
+/// cache, `Probe` only reports readiness. Shared by the flat-device and
+/// per-file resolution paths here and by transports (e.g. uffd).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ResolveMode {
     Fetch,
     Probe,
 }

--- a/nydus-core/src/core.rs
+++ b/nydus-core/src/core.rs
@@ -566,7 +566,10 @@ impl Blobs {
     }
 
     /// Resolve a blob id to its device-table index and opened cache.
-    fn blob_cache_for(&self, id: &BlobId) -> Result<(u16, Arc<dyn crate::storage::cache::BlobCache>)> {
+    fn blob_cache_for(
+        &self,
+        id: &BlobId,
+    ) -> Result<(u16, Arc<dyn crate::storage::cache::BlobCache>)> {
         let blob_index = *self
             .index_by_blob_id
             .get(id)
@@ -813,7 +816,8 @@ impl FsEntry {
             };
 
             if entry.blkaddr != u64::MAX {
-                let chunk_addr = entry.blkaddr
+                let chunk_addr = entry
+                    .blkaddr
                     .checked_mul(EROFS_BLOCK_SIZE as u64)
                     .ok_or_else(|| anyhow::anyhow!("blob fetch offset overflow"))?;
                 // Resolve the chunk to a blob: the legacy layout names the blob
@@ -910,7 +914,8 @@ impl FsEntry {
                     self.zero_file.as_raw_fd(),
                 );
             } else {
-                let chunk_addr = entry.blkaddr
+                let chunk_addr = entry
+                    .blkaddr
                     .checked_mul(EROFS_BLOCK_SIZE as u64)
                     .ok_or_else(|| anyhow::anyhow!("blob fetch offset overflow"))?;
                 let resolved = if entry.device_id > 0 {

--- a/nydus-core/src/fs/data.rs
+++ b/nydus-core/src/fs/data.rs
@@ -281,7 +281,6 @@ impl ErofsReader {
         Ok(result)
     }
 
-
     /// Resolve one chunk's data into `dst`. Handles holes, the legacy
     /// separate-blob layout (non-zero device_id, blob-relative address) and the
     /// flattened layout (device_id 0 with an absolute address, resolved to a

--- a/nydus-core/src/fs/data.rs
+++ b/nydus-core/src/fs/data.rs
@@ -25,7 +25,7 @@ impl ErofsReader {
         self.sb().blkszbits as u32 + (inode.chunk_format() as u32 & 0x1F)
     }
 
-    fn chunk_indexes<'a>(&'a self, nid: u64, inode: &ErofsInode<'_>) -> io::Result<&'a [u8]> {
+    fn chunk_index_bytes<'a>(&'a self, nid: u64, inode: &ErofsInode<'_>) -> io::Result<&'a [u8]> {
         if inode.data_layout() != EROFS_INODE_CHUNK_BASED {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -33,21 +33,21 @@ impl ErofsReader {
             ));
         }
         let chunkbits = self.chunkbits(inode);
-        let chunksize = 1u64 << chunkbits;
-        let nchunks = inode.size().div_ceil(chunksize) as usize;
+        let chunk_size = 1u64 << chunkbits;
+        let nchunks = inode.size().div_ceil(chunk_size) as usize;
         let inode_offset = self.nid_to_offset(nid);
         let header_size = inode.header_size() + inode.xattr_size();
-        let ci_offset = inode_offset + round_up(header_size, EROFS_CHUNK_INDEX_SIZE);
-        let ci_total = nchunks * EROFS_CHUNK_INDEX_SIZE;
-        self.mmap_slice(ci_offset, ci_total)
+        let index_offset = inode_offset + round_up(header_size, EROFS_CHUNK_INDEX_SIZE);
+        let index_total = nchunks * EROFS_CHUNK_INDEX_SIZE;
+        self.mmap_slice(index_offset, index_total)
     }
 
-    fn chunk_index_at(ci_data: &[u8], i: usize) -> &ErofsChunkIndex {
+    fn chunk_index_entry_at(index_bytes: &[u8], i: usize) -> &ErofsChunkIndex {
         let off = i * EROFS_CHUNK_INDEX_SIZE;
-        cast_ref::<ErofsChunkIndex>(&ci_data[off..])
+        cast_ref::<ErofsChunkIndex>(&index_bytes[off..])
     }
 
-    pub fn read_chunk_indexes(
+    pub fn read_chunk_index_entries(
         &self,
         nid: u64,
         inode: &ErofsInode<'_>,
@@ -57,15 +57,15 @@ impl ErofsReader {
         }
 
         let chunkbits = self.chunkbits(inode);
-        let chunksize = 1u64 << chunkbits;
-        let ci_data = self.chunk_indexes(nid, inode)?;
-        let nchunks = inode.size().div_ceil(chunksize) as usize;
+        let chunk_size = 1u64 << chunkbits;
+        let index_bytes = self.chunk_index_bytes(nid, inode)?;
+        let nchunks = inode.size().div_ceil(chunk_size) as usize;
         let mut result = Vec::with_capacity(nchunks);
         for index in 0..nchunks {
-            let ci = Self::chunk_index_at(ci_data, index);
+            let entry = Self::chunk_index_entry_at(index_bytes, index);
             result.push(ChunkIndex {
-                blkaddr: ci.blkaddr(),
-                device_id: ci.device_id(),
+                blkaddr: entry.blkaddr(),
+                device_id: entry.device_id(),
             });
         }
         Ok(result)
@@ -113,14 +113,7 @@ impl ErofsReader {
     ) -> io::Result<usize> {
         let layout = inode.data_layout();
         if layout == EROFS_INODE_FLAT_INLINE {
-            let file_size = inode.size() as usize;
-            let blk_sz = EROFS_BLOCK_SIZE as usize;
-            let tail_size = if file_size % blk_sz == 0 && file_size > 0 {
-                0
-            } else {
-                file_size % blk_sz
-            };
-            let blocks_size = file_size - tail_size;
+            let blocks_size = Self::inline_blocks_size(inode);
 
             if blocks_size > 0
                 && (offset as usize) < blocks_size
@@ -156,25 +149,25 @@ impl ErofsReader {
         w: &mut dyn Write,
     ) -> io::Result<usize> {
         let chunkbits = self.chunkbits(inode);
-        let chunksize = 1u64 << chunkbits;
-        let ci_data = self.chunk_indexes(nid, inode)?;
-        let nchunks = inode.size().div_ceil(chunksize) as usize;
+        let chunk_size = 1u64 << chunkbits;
+        let index_bytes = self.chunk_index_bytes(nid, inode)?;
+        let nchunks = inode.size().div_ceil(chunk_size) as usize;
         let blob_layout = self.blob_infos()?;
 
         let mut remaining = size;
         let mut file_pos = offset;
 
         while remaining > 0 {
-            let chunk_index = (file_pos / chunksize) as usize;
-            let chunk_off = file_pos % chunksize;
-            let to_read = std::cmp::min(remaining, (chunksize - chunk_off) as usize);
+            let chunk_index = (file_pos / chunk_size) as usize;
+            let chunk_off = file_pos % chunk_size;
+            let to_read = std::cmp::min(remaining, (chunk_size - chunk_off) as usize);
 
             if chunk_index >= nchunks {
                 break;
             }
 
-            let ci = Self::chunk_index_at(ci_data, chunk_index);
-            let blkaddr = ci.blkaddr();
+            let entry = Self::chunk_index_entry_at(index_bytes, chunk_index);
+            let blkaddr = entry.blkaddr();
             if blkaddr == EROFS_NULL_ADDR {
                 // Hole — write zeros (use small stack buffer to avoid large alloc)
                 let zeros = [0u8; 4096];
@@ -184,10 +177,10 @@ impl ErofsReader {
                     w.write_all(&zeros[..n])?;
                     left -= n;
                 }
-            } else if ci.device_id() > 0 {
+            } else if entry.device_id() > 0 {
                 // Legacy separate-blob layout: blob-relative address.
                 self.write_blob_to(
-                    ci.device_id(),
+                    entry.device_id(),
                     blkaddr * EROFS_BLOCK_SIZE as u64,
                     chunk_off,
                     to_read,
@@ -213,10 +206,10 @@ impl ErofsReader {
     }
 
     // ------------------------------------------------------------------
-    // File data read — sync (kept for compatibility)
+    // File data read
     // ------------------------------------------------------------------
 
-    pub fn read_file_data_sync(
+    pub fn read_file_data(
         &self,
         nid: u64,
         inode: &ErofsInode<'_>,
@@ -233,39 +226,7 @@ impl ErofsReader {
             EROFS_INODE_FLAT_PLAIN | EROFS_INODE_FLAT_INLINE => {
                 self.read_flat_data_vec(nid, inode, offset, actual_size)
             }
-            EROFS_INODE_CHUNK_BASED => self.read_chunk_data_sync(nid, inode, offset, actual_size),
-            _ => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("unsupported data layout: {layout}"),
-            )),
-        }
-    }
-
-    // ------------------------------------------------------------------
-    // File data read — async
-    // ------------------------------------------------------------------
-
-    pub async fn read_file_data(
-        &self,
-        nid: u64,
-        inode: &ErofsInode<'_>,
-        offset: u64,
-        size: u32,
-    ) -> io::Result<Vec<u8>> {
-        if offset >= inode.size() {
-            return Ok(Vec::new());
-        }
-        let actual_size = std::cmp::min(size as u64, inode.size() - offset) as usize;
-        let layout = inode.data_layout();
-
-        match layout {
-            EROFS_INODE_FLAT_PLAIN | EROFS_INODE_FLAT_INLINE => {
-                self.read_flat_data_vec(nid, inode, offset, actual_size)
-            }
-            EROFS_INODE_CHUNK_BASED => {
-                self.read_chunk_data_async(nid, inode, offset, actual_size)
-                    .await
-            }
+            EROFS_INODE_CHUNK_BASED => self.read_chunk_data(nid, inode, offset, actual_size),
             _ => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("unsupported data layout: {layout}"),
@@ -277,7 +238,7 @@ impl ErofsReader {
     // Chunk data — sync
     // ------------------------------------------------------------------
 
-    fn read_chunk_data_sync(
+    fn read_chunk_data(
         &self,
         nid: u64,
         inode: &ErofsInode<'_>,
@@ -285,9 +246,9 @@ impl ErofsReader {
         size: usize,
     ) -> io::Result<Vec<u8>> {
         let chunkbits = self.chunkbits(inode);
-        let chunksize = 1u64 << chunkbits;
-        let ci_data = self.chunk_indexes(nid, inode)?;
-        let nchunks = inode.size().div_ceil(chunksize) as usize;
+        let chunk_size = 1u64 << chunkbits;
+        let index_bytes = self.chunk_index_bytes(nid, inode)?;
+        let nchunks = inode.size().div_ceil(chunk_size) as usize;
         let blob_layout = self.blob_infos()?;
 
         let mut result = vec![0u8; size];
@@ -296,18 +257,18 @@ impl ErofsReader {
         let mut buf_pos = 0;
 
         while remaining > 0 {
-            let chunk_index = (file_pos / chunksize) as usize;
-            let chunk_off = file_pos % chunksize;
-            let to_read = std::cmp::min(remaining, (chunksize - chunk_off) as usize);
+            let chunk_index = (file_pos / chunk_size) as usize;
+            let chunk_off = file_pos % chunk_size;
+            let to_read = std::cmp::min(remaining, (chunk_size - chunk_off) as usize);
 
             if chunk_index >= nchunks {
                 break;
             }
 
-            let ci = Self::chunk_index_at(ci_data, chunk_index);
+            let entry = Self::chunk_index_entry_at(index_bytes, chunk_index);
             self.read_chunk_slice(
                 &blob_layout,
-                ci,
+                entry,
                 chunk_off,
                 &mut result[buf_pos..buf_pos + to_read],
             )?;
@@ -320,52 +281,6 @@ impl ErofsReader {
         Ok(result)
     }
 
-    // ------------------------------------------------------------------
-    // Chunk data — async
-    // ------------------------------------------------------------------
-
-    async fn read_chunk_data_async(
-        &self,
-        nid: u64,
-        inode: &ErofsInode<'_>,
-        offset: u64,
-        size: usize,
-    ) -> io::Result<Vec<u8>> {
-        let chunkbits = self.chunkbits(inode);
-        let chunksize = 1u64 << chunkbits;
-        let ci_data = self.chunk_indexes(nid, inode)?;
-        let nchunks = inode.size().div_ceil(chunksize) as usize;
-        let blob_layout = self.blob_infos()?;
-
-        let mut result = vec![0u8; size];
-        let mut remaining = size;
-        let mut file_pos = offset;
-        let mut buf_pos = 0;
-
-        while remaining > 0 {
-            let chunk_index = (file_pos / chunksize) as usize;
-            let chunk_off = file_pos % chunksize;
-            let to_read = std::cmp::min(remaining, (chunksize - chunk_off) as usize);
-
-            if chunk_index >= nchunks {
-                break;
-            }
-
-            let ci = Self::chunk_index_at(ci_data, chunk_index);
-            self.read_chunk_slice(
-                &blob_layout,
-                ci,
-                chunk_off,
-                &mut result[buf_pos..buf_pos + to_read],
-            )?;
-
-            file_pos += to_read as u64;
-            buf_pos += to_read;
-            remaining -= to_read;
-        }
-
-        Ok(result)
-    }
 
     /// Resolve one chunk's data into `dst`. Handles holes, the legacy
     /// separate-blob layout (non-zero device_id, blob-relative address) and the
@@ -374,20 +289,20 @@ impl ErofsReader {
     fn read_chunk_slice(
         &self,
         blob_layout: &[RawBlobInfo],
-        ci: &ErofsChunkIndex,
+        entry: &ErofsChunkIndex,
         chunk_off: u64,
         dst: &mut [u8],
     ) -> io::Result<()> {
-        let blkaddr = ci.blkaddr();
+        let blkaddr = entry.blkaddr();
         if blkaddr == EROFS_NULL_ADDR {
             // Hole — zero the destination explicitly rather than relying on
             // callers to hand in a fresh zeroed buffer.
             dst.fill(0);
             return Ok(());
         }
-        if ci.device_id() > 0 {
+        if entry.device_id() > 0 {
             return self.read_blob_into(
-                ci.device_id(),
+                entry.device_id(),
                 blkaddr * EROFS_BLOCK_SIZE as u64,
                 chunk_off,
                 dst,

--- a/nydus-core/src/fs/meta.rs
+++ b/nydus-core/src/fs/meta.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use crate::metadata::*;
 
-use super::{ErofsReader, RawDirEntry, RawNameDirEntry};
+use super::{ErofsReader, RawDirEntry};
 
 impl ErofsReader {
     /// Get a zero-copy inode view from the mmap.
@@ -10,6 +10,18 @@ impl ErofsReader {
         let offset = self.nid_to_offset(nid);
         let data = self.mmap_slice(offset, EROFS_INODE_EXTENDED_SIZE)?;
         ErofsInode::parse(data)
+    }
+
+    /// Size of a FLAT_INLINE inode's full-block region; bytes past it live in
+    /// the inline tail. A file ending exactly on a block boundary has no tail.
+    pub(crate) fn inline_blocks_size(inode: &ErofsInode<'_>) -> usize {
+        let file_size = inode.size() as usize;
+        let blk_sz = EROFS_BLOCK_SIZE as usize;
+        if file_size % blk_sz == 0 && file_size > 0 {
+            file_size
+        } else {
+            file_size - file_size % blk_sz
+        }
     }
 
     /// Iterate directory entries without materializing the whole directory in memory.
@@ -41,25 +53,6 @@ impl ErofsReader {
         let mut entries = Vec::new();
         self.for_each_dir_entry(nid, inode, |entry_nid, file_type, name| {
             entries.push(RawDirEntry {
-                nid: entry_nid,
-                file_type,
-                name: name.to_vec(),
-            });
-            Ok(true)
-        })?;
-        Ok(entries)
-    }
-
-    /// Read directory entries with owned raw names, for FUSE directory
-    /// handle caching.
-    pub fn read_dir_raw(
-        &self,
-        nid: u64,
-        inode: &ErofsInode<'_>,
-    ) -> io::Result<Vec<RawNameDirEntry>> {
-        let mut entries = Vec::new();
-        self.for_each_dir_entry(nid, inode, |entry_nid, file_type, name| {
-            entries.push(RawNameDirEntry {
                 nid: entry_nid,
                 file_type,
                 name: name.to_vec(),
@@ -139,14 +132,7 @@ impl ErofsReader {
                 self.mmap_slice(data_offset, size)
             }
             EROFS_INODE_FLAT_INLINE => {
-                let file_size = inode.size() as usize;
-                let blk_sz = EROFS_BLOCK_SIZE as usize;
-                let tail_size = if file_size % blk_sz == 0 && file_size > 0 {
-                    0
-                } else {
-                    file_size % blk_sz
-                };
-                let blocks_size = file_size - tail_size;
+                let blocks_size = Self::inline_blocks_size(inode);
 
                 if blocks_size == 0 {
                     // All data is inline (small file/dir)
@@ -193,14 +179,7 @@ impl ErofsReader {
     ) -> io::Result<Vec<u8>> {
         let layout = inode.data_layout();
         if layout == EROFS_INODE_FLAT_INLINE {
-            let file_size = inode.size() as usize;
-            let blk_sz = EROFS_BLOCK_SIZE as usize;
-            let tail_size = if file_size % blk_sz == 0 && file_size > 0 {
-                0
-            } else {
-                file_size % blk_sz
-            };
-            let blocks_size = file_size - tail_size;
+            let blocks_size = Self::inline_blocks_size(inode);
 
             // Check if read spans block+inline boundary
             if blocks_size > 0

--- a/nydus-core/src/fs/mod.rs
+++ b/nydus-core/src/fs/mod.rs
@@ -24,14 +24,6 @@ pub struct RawDirEntry {
     pub name: Vec<u8>,
 }
 
-/// Directory entry with an owned raw name, cached by directory handles in
-/// FUSE frontends (see the `fuse` module in the `nydus` crate).
-pub struct RawNameDirEntry {
-    pub nid: u64,
-    pub file_type: u8,
-    pub name: Vec<u8>,
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RawBlobInfo {
     /// 1-based index of the blob in the bootstrap device table.
@@ -281,27 +273,10 @@ impl ErofsReader {
         Ok(cast_ref::<ErofsSuperblock>(&mmap[sb_offset..]))
     }
 
-    /// Validate the superblock magic and reject images declaring incompat
-    /// features this reader does not implement (the standard EROFS incompat
-    /// contract: unknown bits mean the image cannot be read correctly).
+    /// Validate the superblock; see [`crate::metadata::validate_superblock`]
+    /// for the supported-incompat contract (single source of truth).
     fn validate_superblock(sb: &ErofsSuperblock) -> io::Result<()> {
-        if sb.magic() != EROFS_SUPER_MAGIC_V1 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("bad EROFS magic: 0x{:08X}", sb.magic()),
-            ));
-        }
-        const SUPPORTED_INCOMPAT: u32 = EROFS_FEATURE_INCOMPAT_CHUNKED_FILE
-            | EROFS_FEATURE_INCOMPAT_DEVICE_TABLE
-            | EROFS_FEATURE_INCOMPAT_48BIT;
-        let unknown = sb.feature_incompat() & !SUPPORTED_INCOMPAT;
-        if unknown != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("unsupported EROFS incompat features: {unknown:#x}"),
-            ));
-        }
-        Ok(())
+        crate::metadata::validate_superblock(sb)
     }
 
     fn blob_infos_from(mmap: &[u8], sb_offset: usize) -> io::Result<Vec<RawBlobInfo>> {
@@ -400,7 +375,7 @@ impl ErofsReader {
         // cache directory: with many identical instances cold-starting on one
         // node, only the lock owner streams from the backend while the others
         // wait and then find the work already done through the shared
-        // groupmap. On-demand reads never pass through here, so they are
+        // group_map. On-demand reads never pass through here, so they are
         // never delayed by the lock. Held (via the guard's file descriptor)
         // until this function returns.
         let _prefetch_lock = cache.prefetch_lock();
@@ -443,7 +418,7 @@ impl ErofsReader {
     ) -> io::Result<()> {
         // A redirect group is already done when its bytes are resident in the
         // source blob's cache (readiness is shared across processes through
-        // the source groupmap). Segments made entirely of done groups are not
+        // the source group_map). Segments made entirely of done groups are not
         // fetched, so re-running the warmup behind another process's progress
         // does close to zero backend work.
         let skip = |group: &BlobMetaGroup| -> bool {

--- a/nydus-core/src/lib.rs
+++ b/nydus-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod utils;
 pub use config::Config;
 pub use core::{
     BlobId, BlobInfo, Blobs, DirEntry, FdRange, FileType, Fs, FsEntry, Metadata, NydusCore,
+    ResolveMode,
 };
 pub use metadata::{
     is_rafs_v7_bootstrap, BlobMeta, BlobMetaChunk, BlobMetaGroup, BlobMetaHeader,

--- a/nydus-core/src/metadata/blob_footer.rs
+++ b/nydus-core/src/metadata/blob_footer.rs
@@ -9,7 +9,7 @@ use crate::utils::le::{read_u32_at, read_u64_at, write_u32_at, write_u64_at};
 
 /// On-disk magic: 8 raw ASCII bytes, written as-is so a hexdump of the
 /// footer starts with the readable string. Same style and `magic + version +
-/// flags` header prefix as the blob meta (`LPBLMETA`) and groupmap
+/// flags` header prefix as the blob meta (`LPBLMETA`) and group_map
 /// (`LPGRPMAP`) sidecars.
 pub const NYDUS_BLOB_FOOTER_MAGIC: [u8; 8] = *b"LPFOOTER";
 /// On-disk format generation, informational only: readers do not gate on it.

--- a/nydus-core/src/metadata/blob_meta.rs
+++ b/nydus-core/src/metadata/blob_meta.rs
@@ -251,7 +251,8 @@ impl BlobMetaHeader {
     }
 
     pub fn metadata_size(&self) -> u64 {
-        align_to_block(self.records_end())
+        crate::utils::align_up(self.records_end(), EROFS_BLOCK_SIZE as u64)
+            .expect("blob meta size overflowed")
     }
 
     fn set_counts_and_offsets(&mut self, chunk_count: u32, group_count: u32) -> Result<()> {
@@ -332,11 +333,11 @@ impl BlobMetaHeader {
     }
 
     fn write_to_with_crc32(&self, writer: &mut dyn Write, crc32: u32) -> Result<()> {
-        writer.write_all(&self.as_bytes_with_crc32(crc32))?;
+        writer.write_all(&self.to_bytes_with_crc32(crc32))?;
         Ok(())
     }
 
-    fn as_bytes_with_crc32(&self, crc32: u32) -> [u8; BLOB_META_HEADER_SIZE as usize] {
+    fn to_bytes_with_crc32(&self, crc32: u32) -> [u8; BLOB_META_HEADER_SIZE as usize] {
         let mut data = [0u8; BLOB_META_HEADER_SIZE as usize];
         data[0..8].copy_from_slice(&self.magic);
         data[8..12].copy_from_slice(&self.version.to_le_bytes());
@@ -834,7 +835,7 @@ impl BlobMeta {
     }
 
     fn compute_crc32(&self) -> u32 {
-        let mut crc32 = crc32c_append(0, &self.header.as_bytes_with_crc32(0));
+        let mut crc32 = crc32c_append(0, &self.header.to_bytes_with_crc32(0));
         for chunk in self.chunks() {
             crc32 = crc32c_append(crc32, &chunk.to_bytes());
         }
@@ -873,18 +874,13 @@ impl BlobMeta {
         Ok(())
     }
 
-    pub fn from_bytes_with_blob_id(data: &[u8], blob_id: [u8; EROFS_BLOB_ID_SIZE]) -> Result<Self> {
-        Self::from_bytes_with_blob_id_inner(data, blob_id, false)
+    /// Start configuring a blob meta read; finish with
+    /// [`load`](BlobMetaLoader::load) or [`from_bytes`](BlobMetaLoader::from_bytes).
+    pub fn loader() -> BlobMetaLoader {
+        BlobMetaLoader::default()
     }
 
-    pub fn from_bytes_checked_crc32_with_blob_id(
-        data: &[u8],
-        blob_id: [u8; EROFS_BLOB_ID_SIZE],
-    ) -> Result<Self> {
-        Self::from_bytes_with_blob_id_inner(data, blob_id, true)
-    }
-
-    fn from_bytes_with_blob_id_inner(
+    fn from_bytes_inner(
         data: &[u8],
         blob_id: [u8; EROFS_BLOB_ID_SIZE],
         check_crc32: bool,
@@ -936,10 +932,6 @@ impl BlobMeta {
         Self::load_inner(path, false)
     }
 
-    pub fn load_checked_crc32(path: &Path) -> Result<Self> {
-        Self::load_inner(path, true)
-    }
-
     fn load_inner(path: &Path, check_crc32: bool) -> Result<Self> {
         let file = File::open(path)
             .with_context(|| format!("failed to open blob meta: {}", path.display()))?;
@@ -974,19 +966,46 @@ impl BlobMeta {
         })
     }
 
-    pub fn load_with_blob_id(path: &Path, blob_id: [u8; EROFS_BLOB_ID_SIZE]) -> Result<Self> {
-        let mut blob_meta = Self::load(path)?;
-        blob_meta.blob_id = blob_id;
+}
+
+/// Options for reading a [`BlobMeta`], created via [`BlobMeta::loader`].
+/// The two orthogonal knobs (CRC32 verification, attached blob id) replace
+/// the previous per-combination constructors.
+#[derive(Default, Clone, Copy)]
+pub struct BlobMetaLoader {
+    verify_crc32: bool,
+    blob_id: Option<[u8; EROFS_BLOB_ID_SIZE]>,
+}
+
+impl BlobMetaLoader {
+    /// Verify the header CRC32 over the full metadata during the read.
+    pub fn verify_crc32(mut self) -> Self {
+        self.verify_crc32 = true;
+        self
+    }
+
+    /// Attach the owning blob id to the loaded metadata.
+    pub fn blob_id(mut self, blob_id: [u8; EROFS_BLOB_ID_SIZE]) -> Self {
+        self.blob_id = Some(blob_id);
+        self
+    }
+
+    /// Read blob metadata from a file (mmap-backed).
+    pub fn load(self, path: &Path) -> Result<BlobMeta> {
+        let mut blob_meta = BlobMeta::load_inner(path, self.verify_crc32)?;
+        if let Some(blob_id) = self.blob_id {
+            blob_meta.blob_id = blob_id;
+        }
         Ok(blob_meta)
     }
 
-    pub fn load_checked_crc32_with_blob_id(
-        path: &Path,
-        blob_id: [u8; EROFS_BLOB_ID_SIZE],
-    ) -> Result<Self> {
-        let mut blob_meta = Self::load_checked_crc32(path)?;
-        blob_meta.blob_id = blob_id;
-        Ok(blob_meta)
+    /// Read blob metadata from an in-memory byte slice.
+    pub fn from_bytes(self, data: &[u8]) -> Result<BlobMeta> {
+        BlobMeta::from_bytes_inner(
+            data,
+            self.blob_id.unwrap_or([0u8; EROFS_BLOB_ID_SIZE]),
+            self.verify_crc32,
+        )
     }
 }
 
@@ -1002,11 +1021,6 @@ fn block_count_to_bits(blocks: u32, what: &str) -> Result<u8> {
         bail!("blob meta {what} block count too large: {blocks}");
     }
     Ok(bits)
-}
-
-pub fn align_to_block(value: u64) -> u64 {
-    let block_size = EROFS_BLOCK_SIZE as u64;
-    value.div_ceil(block_size) * block_size
 }
 
 fn validate_padding(data: &[u8], header: &BlobMetaHeader) -> Result<()> {
@@ -1312,13 +1326,10 @@ mod tests {
                 .unwrap(),
         );
 
-        let loaded = BlobMeta::from_bytes_with_blob_id(&raw, [0u8; EROFS_BLOB_ID_SIZE]).unwrap();
+        let loaded = BlobMeta::loader().from_bytes(&raw).unwrap();
 
         assert_eq!(loaded.header().crc32(), corrupted_crc32);
-        let err = match BlobMeta::from_bytes_checked_crc32_with_blob_id(
-            &raw,
-            [0u8; EROFS_BLOB_ID_SIZE],
-        ) {
+        let err = match BlobMeta::loader().verify_crc32().from_bytes(&raw) {
             Ok(_) => panic!("corrupted blob meta crc32 should be rejected"),
             Err(err) => err,
         };
@@ -1365,7 +1376,7 @@ mod tests {
         // A future format generation is readable: version is informational.
         let mut future = raw.clone();
         future[8..12].copy_from_slice(&(BLOB_META_VERSION + 1).to_le_bytes());
-        let loaded = BlobMeta::from_bytes_with_blob_id(&future, [0u8; EROFS_BLOB_ID_SIZE])
+        let loaded = BlobMeta::loader().from_bytes(&future)
             .expect("future version must be readable");
         assert_eq!(loaded.header().version(), BLOB_META_VERSION + 1);
 
@@ -1373,14 +1384,14 @@ mod tests {
         let mut compat = raw.clone();
         let flags = u32::from_le_bytes(compat[12..16].try_into().unwrap()) | (1 << 31);
         compat[12..16].copy_from_slice(&flags.to_le_bytes());
-        BlobMeta::from_bytes_with_blob_id(&compat, [0u8; EROFS_BLOB_ID_SIZE])
+        BlobMeta::loader().from_bytes(&compat)
             .expect("unknown compat flag must be ignored");
 
         // An unknown incompat (low-half) flag bit rejects the file.
         let mut incompat = raw;
         let flags = u32::from_le_bytes(incompat[12..16].try_into().unwrap()) | (1 << 15);
         incompat[12..16].copy_from_slice(&flags.to_le_bytes());
-        let err = match BlobMeta::from_bytes_with_blob_id(&incompat, [0u8; EROFS_BLOB_ID_SIZE]) {
+        let err = match BlobMeta::loader().from_bytes(&incompat) {
             Ok(_) => panic!("unknown incompat flag should be rejected"),
             Err(err) => err,
         };
@@ -1406,12 +1417,9 @@ mod tests {
         // sealed over a zero tail.
         raw[BLOB_META_HEADER_SIZE as usize - 1] = 0xff;
 
-        BlobMeta::from_bytes_with_blob_id(&raw, [0u8; EROFS_BLOB_ID_SIZE])
+        BlobMeta::loader().from_bytes(&raw)
             .expect("nonzero reserved tail must be ignored");
-        let err = match BlobMeta::from_bytes_checked_crc32_with_blob_id(
-            &raw,
-            [0u8; EROFS_BLOB_ID_SIZE],
-        ) {
+        let err = match BlobMeta::loader().verify_crc32().from_bytes(&raw) {
             Ok(_) => panic!("crc check should catch the unsealed tail change"),
             Err(err) => err,
         };

--- a/nydus-core/src/metadata/blob_meta.rs
+++ b/nydus-core/src/metadata/blob_meta.rs
@@ -337,7 +337,7 @@ impl BlobMetaHeader {
         Ok(())
     }
 
-    fn to_bytes_with_crc32(&self, crc32: u32) -> [u8; BLOB_META_HEADER_SIZE as usize] {
+    fn to_bytes_with_crc32(self, crc32: u32) -> [u8; BLOB_META_HEADER_SIZE as usize] {
         let mut data = [0u8; BLOB_META_HEADER_SIZE as usize];
         data[0..8].copy_from_slice(&self.magic);
         data[8..12].copy_from_slice(&self.version.to_le_bytes());

--- a/nydus-core/src/metadata/blob_meta.rs
+++ b/nydus-core/src/metadata/blob_meta.rs
@@ -965,7 +965,6 @@ impl BlobMeta {
             storage: BlobMetaStorage::Mapped(mmap),
         })
     }
-
 }
 
 /// Options for reading a [`BlobMeta`], created via [`BlobMeta::loader`].
@@ -1376,7 +1375,8 @@ mod tests {
         // A future format generation is readable: version is informational.
         let mut future = raw.clone();
         future[8..12].copy_from_slice(&(BLOB_META_VERSION + 1).to_le_bytes());
-        let loaded = BlobMeta::loader().from_bytes(&future)
+        let loaded = BlobMeta::loader()
+            .from_bytes(&future)
             .expect("future version must be readable");
         assert_eq!(loaded.header().version(), BLOB_META_VERSION + 1);
 
@@ -1384,7 +1384,8 @@ mod tests {
         let mut compat = raw.clone();
         let flags = u32::from_le_bytes(compat[12..16].try_into().unwrap()) | (1 << 31);
         compat[12..16].copy_from_slice(&flags.to_le_bytes());
-        BlobMeta::loader().from_bytes(&compat)
+        BlobMeta::loader()
+            .from_bytes(&compat)
             .expect("unknown compat flag must be ignored");
 
         // An unknown incompat (low-half) flag bit rejects the file.
@@ -1417,7 +1418,8 @@ mod tests {
         // sealed over a zero tail.
         raw[BLOB_META_HEADER_SIZE as usize - 1] = 0xff;
 
-        BlobMeta::loader().from_bytes(&raw)
+        BlobMeta::loader()
+            .from_bytes(&raw)
             .expect("nonzero reserved tail must be ignored");
         let err = match BlobMeta::loader().verify_crc32().from_bytes(&raw) {
             Ok(_) => panic!("crc check should catch the unsealed tail change"),

--- a/nydus-core/src/metadata/inode.rs
+++ b/nydus-core/src/metadata/inode.rs
@@ -1,6 +1,4 @@
-use std::fs;
 use std::mem;
-use std::os::unix::fs::MetadataExt;
 
 use super::*;
 
@@ -461,11 +459,8 @@ pub fn erofs_xattr_icount(xattr_ibody_size: usize) -> u16 {
 /// - uid / gid  <= u16::MAX
 /// - nlink == 1 (hardlinks need a real link count)
 /// - no per-inode mtime (falls back to the global build time)
-pub fn needs_erofs_extended_inode(meta: &fs::Metadata) -> bool {
-    meta.size() > u32::MAX as u64
-        || meta.uid() > u16::MAX as u32
-        || meta.gid() > u16::MAX as u32
-        || meta.nlink() > 1
+pub fn needs_erofs_extended_inode(size: u64, uid: u32, gid: u32, nlink: u64) -> bool {
+    size > u32::MAX as u64 || uid > u16::MAX as u32 || gid > u16::MAX as u32 || nlink > 1
 }
 
 /// Check if an xattr name (as bytes) is a Nydus internal xattr (starts with "trusted.nydus.").

--- a/nydus-core/src/metadata/mod.rs
+++ b/nydus-core/src/metadata/mod.rs
@@ -108,17 +108,11 @@ pub fn cast_ref<T>(data: &[u8]) -> &T {
     unsafe { &*(data.as_ptr() as *const T) }
 }
 
-/// Cast a mutable byte slice to a mutable reference of `T`.
-#[inline]
-pub fn cast_mut<T>(data: &mut [u8]) -> &mut T {
-    assert!(data.len() >= mem::size_of::<T>());
-    unsafe { &mut *(data.as_mut_ptr() as *mut T) }
-}
-
 /// Round `val` up to the next multiple of `align` (power of two).
+/// Unchecked builder-path twin of [`crate::utils::align_up`]; panics on overflow.
 #[inline]
 pub fn round_up(val: usize, align: usize) -> usize {
-    (val + align - 1) & !(align - 1)
+    crate::utils::align_up(val as u64, align as u64).expect("size rounding overflowed") as usize
 }
 
 #[cfg(test)]

--- a/nydus-core/src/metadata/superblock.rs
+++ b/nydus-core/src/metadata/superblock.rs
@@ -137,6 +137,17 @@ pub fn is_rafs_v7_bootstrap(path: &Path) -> io::Result<bool> {
     // EROFS_SB_BASE_SIZE bytes, and valid for any bit pattern.
     let sb: &ErofsSuperblock = unsafe { &*(buf.as_ptr() as *const ErofsSuperblock) };
 
+    validate_superblock(sb)?;
+    Ok(sb.feature_compat() & EROFS_FEATURE_COMPAT_RAFS_V6 == 0)
+}
+
+/// Validate the superblock magic and reject images declaring incompat
+/// features this reader does not implement (the standard EROFS incompat
+/// contract: unknown bits mean the image cannot be read correctly).
+///
+/// The single source of truth for the supported-incompat feature set —
+/// extend the list here when a new feature bit is implemented.
+pub fn validate_superblock(sb: &ErofsSuperblock) -> io::Result<()> {
     if sb.magic() != EROFS_SUPER_MAGIC_V1 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -153,7 +164,7 @@ pub fn is_rafs_v7_bootstrap(path: &Path) -> io::Result<bool> {
             format!("unsupported EROFS incompat features: {unknown:#x}"),
         ));
     }
-    Ok(sb.feature_compat() & EROFS_FEATURE_COMPAT_RAFS_V6 == 0)
+    Ok(())
 }
 
 #[cfg(test)]

--- a/nydus-core/src/metrics/mod.rs
+++ b/nydus-core/src/metrics/mod.rs
@@ -457,12 +457,10 @@ pub fn track_blob_groups(cache_key: [u8; EROFS_BLOB_ID_SIZE], group_count: u64) 
         Ok(tracked) => tracked,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let entry = tracked
-        .entry(cache_key)
-        .or_insert(TrackedBlob {
-            group_count,
-            holder_count: 0,
-        });
+    let entry = tracked.entry(cache_key).or_insert(TrackedBlob {
+        group_count,
+        holder_count: 0,
+    });
     entry.holder_count += 1;
     if entry.holder_count == 1 {
         METRICS.cache_total_group.add(entry.group_count as i64);

--- a/nydus-core/src/metrics/mod.rs
+++ b/nydus-core/src/metrics/mod.rs
@@ -446,23 +446,26 @@ static TRACKED_BLOBS: LazyLock<Mutex<HashMap<[u8; EROFS_BLOB_ID_SIZE], TrackedBl
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 struct TrackedBlob {
-    groups: u64,
-    caches: usize,
+    group_count: u64,
+    holder_count: usize,
 }
 
 /// Count `groups` towards the total-groups gauge for the blob `cache_key`,
 /// unless another cache already counted it.
-pub fn track_blob_groups(cache_key: [u8; EROFS_BLOB_ID_SIZE], groups: u64) {
+pub fn track_blob_groups(cache_key: [u8; EROFS_BLOB_ID_SIZE], group_count: u64) {
     let mut tracked = match TRACKED_BLOBS.lock() {
         Ok(tracked) => tracked,
         Err(poisoned) => poisoned.into_inner(),
     };
     let entry = tracked
         .entry(cache_key)
-        .or_insert(TrackedBlob { groups, caches: 0 });
-    entry.caches += 1;
-    if entry.caches == 1 {
-        METRICS.cache_total_group.add(entry.groups as i64);
+        .or_insert(TrackedBlob {
+            group_count,
+            holder_count: 0,
+        });
+    entry.holder_count += 1;
+    if entry.holder_count == 1 {
+        METRICS.cache_total_group.add(entry.group_count as i64);
     }
 }
 
@@ -476,9 +479,9 @@ pub fn untrack_blob_groups(cache_key: &[u8; EROFS_BLOB_ID_SIZE]) {
     let Some(entry) = tracked.get_mut(cache_key) else {
         return;
     };
-    entry.caches -= 1;
-    if entry.caches == 0 {
-        METRICS.cache_total_group.sub(entry.groups as i64);
+    entry.holder_count -= 1;
+    if entry.holder_count == 0 {
+        METRICS.cache_total_group.sub(entry.group_count as i64);
         tracked.remove(cache_key);
     }
 }
@@ -530,7 +533,7 @@ fn tracked_blob_refs(cache_key: &[u8; EROFS_BLOB_ID_SIZE]) -> Option<usize> {
         Ok(tracked) => tracked,
         Err(poisoned) => poisoned.into_inner(),
     };
-    tracked.get(cache_key).map(|entry| entry.caches)
+    tracked.get(cache_key).map(|entry| entry.holder_count)
 }
 
 /// A serializable view over the live prometheus registry.

--- a/nydus-core/src/metrics/trace.rs
+++ b/nydus-core/src/metrics/trace.rs
@@ -13,13 +13,13 @@ use std::collections::HashSet;
 use std::sync::LazyLock;
 use std::sync::Mutex;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Version of the serialized trace document, bumped on incompatible changes.
 pub const TRACE_DOCUMENT_VERSION: u32 = 1;
 
 /// A single group access in the on-demand trace.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TraceEntry {
     /// Device/blob index in the merged image (external blobs are 1-based;
     /// device 0 is the primary bootstrap image and never produces group reads).
@@ -32,7 +32,7 @@ pub struct TraceEntry {
 /// explicit format version lets future fields be added (or the pattern shape
 /// change) without breaking consumers, and keeps the document self-describing
 /// wherever it travels (files, HTTP bodies, embedding hosts).
-#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TraceDocument {
     pub version: u32,
     pub patterns: Vec<TraceEntry>,

--- a/nydus-core/src/storage/backend/local.rs
+++ b/nydus-core/src/storage/backend/local.rs
@@ -179,7 +179,10 @@ impl BlobBackend for LocalBackend {
     fn blob_meta(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE]) -> io::Result<BlobMeta> {
         let source = self.resolve_source(blob_id)?;
         let data = self.read_blob_meta_bytes(&source)?;
-        BlobMeta::loader().blob_id(*blob_id).from_bytes(&data).map_err(io::Error::other)
+        BlobMeta::loader()
+            .blob_id(*blob_id)
+            .from_bytes(&data)
+            .map_err(io::Error::other)
     }
 
     fn blob_meta_to(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE], dst: &Path) -> io::Result<()> {

--- a/nydus-core/src/storage/backend/local.rs
+++ b/nydus-core/src/storage/backend/local.rs
@@ -176,30 +176,18 @@ impl BlobBackend for LocalBackend {
         Ok(self.resolve_source(blob_id)?.cache_key)
     }
 
-    fn load_blob_meta(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE]) -> io::Result<BlobMeta> {
+    fn blob_meta(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE]) -> io::Result<BlobMeta> {
         let source = self.resolve_source(blob_id)?;
         let data = self.read_blob_meta_bytes(&source)?;
-        BlobMeta::from_bytes_with_blob_id(&data, *blob_id).map_err(io::Error::other)
+        BlobMeta::loader().blob_id(*blob_id).from_bytes(&data).map_err(io::Error::other)
     }
 
-    fn download_blob_meta(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE], dst: &Path) -> io::Result<()> {
+    fn blob_meta_to(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE], dst: &Path) -> io::Result<()> {
         let source = self.resolve_source(blob_id)?;
         let data = self.read_blob_meta_bytes(&source)?;
         let mut file = File::create(dst)?;
         file.write_all(&data)?;
         file.flush()
-    }
-
-    fn read_range(
-        &self,
-        blob_id: &[u8; EROFS_BLOB_ID_SIZE],
-        offset: u64,
-        len: u32,
-        ctx: ReadContext,
-    ) -> io::Result<Vec<u8>> {
-        let mut buf = vec![0u8; len as usize];
-        self.read_range_into(blob_id, offset, &mut buf, ctx)?;
-        Ok(buf)
     }
 
     fn read_range_into(
@@ -260,14 +248,14 @@ mod tests {
         .unwrap()
     }
 
-    use crate::storage::test_util::write_full_blob;
+    use crate::storage::test_util::write_minimal_full_blob;
 
     #[test]
     fn local_backend_reads_full_blob_file_and_sidecar_meta() {
         let dir = tempdir().unwrap();
         let payload = vec![0xabu8; 4096];
         let data_blob_id = sha256_bytes(&payload);
-        let full_blob_id = write_full_blob(
+        let full_blob_id = write_minimal_full_blob(
             dir.path(),
             &payload,
             &blob_meta(data_blob_id, &payload),
@@ -275,7 +263,7 @@ mod tests {
         );
 
         let backend = LocalBackend::new(dir.path().to_path_buf());
-        let blob_meta = backend.load_blob_meta(&full_blob_id).unwrap();
+        let blob_meta = backend.blob_meta(&full_blob_id).unwrap();
         let data = backend
             .read_range(&full_blob_id, 0, 4096, ReadContext::raw(ReadKind::OnDemand))
             .unwrap();
@@ -289,7 +277,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let payload = vec![0xcdu8; 4096];
         let data_blob_id = sha256_bytes(&payload);
-        let full_blob_id = write_full_blob(
+        let full_blob_id = write_minimal_full_blob(
             dir.path(),
             &payload,
             &blob_meta(data_blob_id, &payload),
@@ -297,13 +285,13 @@ mod tests {
         );
         let backend = LocalBackend::new(dir.path().to_path_buf());
 
-        let blob_meta = backend.load_blob_meta(&full_blob_id).unwrap();
+        let blob_meta = backend.blob_meta(&full_blob_id).unwrap();
         let data = backend
             .read_range(&full_blob_id, 0, 4096, ReadContext::raw(ReadKind::OnDemand))
             .unwrap();
 
         assert_eq!(blob_meta.header().chunk_count(), 1);
         assert_eq!(data, payload);
-        assert!(backend.load_blob_meta(&data_blob_id).is_err());
+        assert!(backend.blob_meta(&data_blob_id).is_err());
     }
 }

--- a/nydus-core/src/storage/backend/mod.rs
+++ b/nydus-core/src/storage/backend/mod.rs
@@ -78,10 +78,10 @@ pub trait BlobBackend: Send + Sync {
         Ok(*blob_id)
     }
 
-    fn load_blob_meta(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE]) -> io::Result<BlobMeta>;
+    fn blob_meta(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE]) -> io::Result<BlobMeta>;
 
-    fn download_blob_meta(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE], dst: &Path) -> io::Result<()> {
-        let blob_meta = self.load_blob_meta(blob_id)?;
+    fn blob_meta_to(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE], dst: &Path) -> io::Result<()> {
+        let blob_meta = self.blob_meta(blob_id)?;
         blob_meta.save(dst).map_err(io::Error::other)
     }
 
@@ -91,17 +91,7 @@ pub trait BlobBackend: Send + Sync {
         offset: u64,
         dst: &mut [u8],
         ctx: ReadContext,
-    ) -> io::Result<()> {
-        let data = self.read_range(blob_id, offset, dst.len() as u32, ctx)?;
-        if data.len() != dst.len() {
-            return Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "backend returned short range",
-            ));
-        }
-        dst.copy_from_slice(&data);
-        Ok(())
-    }
+    ) -> io::Result<()>;
 
     fn read_range(
         &self,
@@ -109,7 +99,11 @@ pub trait BlobBackend: Send + Sync {
         offset: u64,
         len: u32,
         ctx: ReadContext,
-    ) -> io::Result<Vec<u8>>;
+    ) -> io::Result<Vec<u8>> {
+        let mut buf = vec![0u8; len as usize];
+        self.read_range_into(blob_id, offset, &mut buf, ctx)?;
+        Ok(buf)
+    }
 }
 
 /// Wrap `backend` so every read it serves reports to [`crate::metrics`].
@@ -158,12 +152,12 @@ impl BlobBackend for MeteredBackend {
         self.inner.cache_key(blob_id)
     }
 
-    fn load_blob_meta(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE]) -> io::Result<BlobMeta> {
-        self.inner.load_blob_meta(blob_id)
+    fn blob_meta(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE]) -> io::Result<BlobMeta> {
+        self.inner.blob_meta(blob_id)
     }
 
-    fn download_blob_meta(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE], dst: &Path) -> io::Result<()> {
-        self.inner.download_blob_meta(blob_id, dst)
+    fn blob_meta_to(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE], dst: &Path) -> io::Result<()> {
+        self.inner.blob_meta_to(blob_id, dst)
     }
 
     fn read_range_into(

--- a/nydus-core/src/storage/backend/registry/mod.rs
+++ b/nydus-core/src/storage/backend/registry/mod.rs
@@ -528,7 +528,9 @@ impl Registry {
             ReadContext::raw(ReadKind::OnDemand),
         )?;
 
-        BlobMeta::loader().blob_id(*blob_id).from_bytes(&blob_meta_bytes)
+        BlobMeta::loader()
+            .blob_id(*blob_id)
+            .from_bytes(&blob_meta_bytes)
             .map_err(|e| RegistryError::Io(io::Error::other(e.to_string())))
     }
 
@@ -674,7 +676,6 @@ impl BlobBackend for Registry {
         }
         Ok(())
     }
-
 }
 
 fn is_redirect(status: StatusCode) -> bool {

--- a/nydus-core/src/storage/backend/registry/mod.rs
+++ b/nydus-core/src/storage/backend/registry/mod.rs
@@ -6,7 +6,7 @@
 //! meta. [`read_range`](BlobBackend::read_range) fetches data ranges; blob meta
 //! is normally hydrated from the cache directory (the bootstrap layer ships a
 //! `<full-blob>.blob.meta` per layer), and otherwise
-//! [`load_blob_meta`](BlobBackend::load_blob_meta) recovers it from the blob's
+//! [`blob_meta`](BlobBackend::blob_meta) recovers it from the blob's
 //! trailing footer via range reads.
 //!
 //! The HTTP transport stack (connection, DNS, HTTP proxy, request routing) lives
@@ -528,7 +528,7 @@ impl Registry {
             ReadContext::raw(ReadKind::OnDemand),
         )?;
 
-        BlobMeta::from_bytes_with_blob_id(&blob_meta_bytes, *blob_id)
+        BlobMeta::loader().blob_id(*blob_id).from_bytes(&blob_meta_bytes)
             .map_err(|e| RegistryError::Io(io::Error::other(e.to_string())))
     }
 
@@ -650,7 +650,7 @@ impl BlobBackend for Registry {
         self.target
     }
 
-    fn load_blob_meta(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE]) -> io::Result<BlobMeta> {
+    fn blob_meta(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE]) -> io::Result<BlobMeta> {
         self.fetch_blob_meta(blob_id).map_err(io::Error::from)
     }
 
@@ -675,17 +675,6 @@ impl BlobBackend for Registry {
         Ok(())
     }
 
-    fn read_range(
-        &self,
-        blob_id: &[u8; EROFS_BLOB_ID_SIZE],
-        offset: u64,
-        len: u32,
-        ctx: ReadContext,
-    ) -> io::Result<Vec<u8>> {
-        let mut buf = vec![0u8; len as usize];
-        self.read_range_into(blob_id, offset, &mut buf, ctx)?;
-        Ok(buf)
-    }
 }
 
 fn is_redirect(status: StatusCode) -> bool {

--- a/nydus-core/src/storage/cache/local.rs
+++ b/nydus-core/src/storage/cache/local.rs
@@ -84,7 +84,7 @@ pub struct LocalBlobCache {
     /// Device/blob index in the merged image, used to attribute on-demand group
     /// accesses in the access trace.
     blob_index: u32,
-    groupmap: GroupMap,
+    group_map: GroupMap,
     blob_meta: BlobMeta,
     cache_blob_path: PathBuf,
     prefetch_lock_path: PathBuf,
@@ -119,23 +119,23 @@ impl LocalBlobCache {
         let cache_key = backend.cache_key(&blob_id)?;
         let cache_key_hex = hex_string(&cache_key);
         let blob_meta_path = cache_dir.join(format!("{cache_key_hex}.blob.meta"));
-        let blob_meta = load_cached_blob_meta(blob_id, cache_dir, &blob_meta_path, &backend)?;
+        let blob_meta = cached_blob_meta(blob_id, cache_dir, &blob_meta_path, &backend)?;
         crate::metrics::track_blob_groups(cache_key, blob_meta.group_count() as u64);
 
         let cache_blob_path = cache_dir.join(format!("{cache_key_hex}.blob.data"));
 
         let groupmap_path = cache_dir.join(format!("{cache_key_hex}.group.map"));
-        // The groupmap is only meaningful together with the cache data file it
-        // describes: a leftover groupmap whose data file has been removed
+        // The group_map is only meaningful together with the cache data file it
+        // describes: a leftover group_map whose data file has been removed
         // would claim groups are ready while reads hit sparse zeros. Note this
         // before creating the data file below, which would otherwise mask it.
         // (Removing the map while keeping the data is the safe direction and
         // needs no handling.)
         let stale_groupmap = groupmap_path.exists() && !cache_blob_path.exists();
 
-        // Create the cache data file eagerly, before the groupmap, so that
-        // "groupmap file exists => data file exists" holds and the check above
-        // can only fire for a genuinely orphaned groupmap.
+        // Create the cache data file eagerly, before the group_map, so that
+        // "group_map file exists => data file exists" holds and the check above
+        // can only fire for a genuinely orphaned group_map.
         let data_file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -145,14 +145,14 @@ impl LocalBlobCache {
         data_file.set_len(blob_meta.total_uncompressed_size())?;
         drop(data_file);
 
-        let groupmap = GroupMap::open(&groupmap_path, blob_meta.group_count())?;
+        let group_map = GroupMap::open(&groupmap_path, blob_meta.group_count())?;
         if stale_groupmap {
             // Reset in place rather than unlinking: handles already mapping
             // this file observe the reset, whereas a replacement inode would
             // split them off with their readiness invisible to each other.
-            groupmap.reset()?;
+            group_map.reset()?;
             warn!(
-                "stale groupmap without cache data file, reset: {}",
+                "stale group_map without cache data file, reset: {}",
                 groupmap_path.display()
             );
         }
@@ -164,7 +164,7 @@ impl LocalBlobCache {
             blob_id,
             cache_key,
             blob_index,
-            groupmap,
+            group_map,
             blob_meta,
             cache_blob_path,
             prefetch_lock_path,
@@ -205,7 +205,7 @@ impl LocalBlobCache {
     ///
     /// The descriptor keeps an unlinked inode alive, so writes through it
     /// still succeed — but they land somewhere nobody else can reach, while
-    /// the shared groupmap goes on advertising those groups as ready. Better
+    /// the shared group_map goes on advertising those groups as ready. Better
     /// to stop than to publish readiness for bytes other processes cannot see.
     fn ensure_data_file_linked(&self, cache_file: &File) -> io::Result<()> {
         if cache_file.metadata()?.nlink() == 0 {
@@ -226,7 +226,7 @@ impl LocalBlobCache {
         group: &BlobMetaGroup,
         cache_file: &File,
     ) -> io::Result<()> {
-        if self.groupmap.is_ready(group_index)? {
+        if self.group_map.is_ready(group_index)? {
             crate::metrics::inc_cache_hit_group();
             return Ok(());
         }
@@ -261,7 +261,7 @@ impl LocalBlobCache {
         };
 
         let result = (|| {
-            if self.groupmap.is_ready(group_index)? {
+            if self.group_map.is_ready(group_index)? {
                 crate::metrics::inc_cache_hit_group();
                 return Ok(());
             }
@@ -278,7 +278,7 @@ impl LocalBlobCache {
             // so the re-check below is what actually removes the duplicate
             // backend traffic.
             let _claim = self.group_locks.acquire(group_index);
-            if self.groupmap.is_ready(group_index)? {
+            if self.group_map.is_ready(group_index)? {
                 crate::metrics::inc_cache_hit_group();
                 return Ok(());
             }
@@ -293,7 +293,7 @@ impl LocalBlobCache {
                 ReadKind::OnDemand,
             )?;
             write_all_at(cache_file, group.uncompressed_byte_offset(), decoded)?;
-            self.groupmap.set_ready(group_index)?;
+            self.group_map.set_ready(group_index)?;
             crate::metrics::inc_cache_ondemand_fill_group();
             Ok(())
         })();
@@ -324,7 +324,7 @@ impl LocalBlobCache {
 
         // Fast path: the sticky all-ready flag says every group is already
         // decoded into the cache file, so skip the per-group walk entirely.
-        if self.groupmap.is_all_ready() {
+        if self.group_map.is_all_ready() {
             crate::metrics::inc_cache_hit_group();
             return Ok(());
         }
@@ -350,21 +350,21 @@ impl LocalBlobCache {
         Ok(())
     }
 
-    /// Fetch one redirect-blob segment (a contiguous range of groups) in a
+    /// Fetch one redirect-blob batch (a contiguous range of groups) in a
     /// single backend read, then decode and hand each group to `cb`. `window`
     /// and `decoded` are caller-owned scratch buffers so a worker thread can
-    /// reuse them across segments. Per-group decode/CRC failures are skipped
+    /// reuse them across batches. Per-group decode/CRC failures are skipped
     /// with a warning; `cb` errors propagate to abort the stream.
-    fn stream_redirect_segment(
+    fn stream_redirect_batch(
         &self,
         groups: &[BlobMetaGroup],
-        segment: std::ops::Range<usize>,
+        batch: std::ops::Range<usize>,
         window: &mut Vec<u8>,
         decoded: &mut Vec<u8>,
         cb: &(dyn Fn(&BlobMetaGroup, &[u8]) -> io::Result<()> + Sync),
     ) -> io::Result<()> {
-        let window_base = groups[segment.start].compressed_byte_offset();
-        let window_end = groups[segment.end - 1].compressed_byte_end();
+        let window_base = groups[batch.start].compressed_byte_offset();
+        let window_end = groups[batch.end - 1].compressed_byte_end();
         let window_len = usize::try_from(window_end - window_base).map_err(|_| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -372,15 +372,15 @@ impl LocalBlobCache {
             )
         })?;
         window.resize(window_len, 0);
-        let uncompressed_offset = groups[segment.start].uncompressed_byte_offset();
+        let uncompressed_offset = groups[batch.start].uncompressed_byte_offset();
         let uncompressed_size =
-            groups[segment.end - 1].uncompressed_byte_end() - uncompressed_offset;
+            groups[batch.end - 1].uncompressed_byte_end() - uncompressed_offset;
         let ctx = ReadContext::group(ReadKind::Prefetch, uncompressed_offset, uncompressed_size);
         self.backend
             .read_range_into(&self.blob_id, window_base, window, ctx)?;
         crate::metrics::record_backend_redirect_read(window_len as u64);
 
-        for index in segment {
+        for index in batch {
             let group = &groups[index];
             if let Err(err) =
                 decode_group_from_window(&self.blob_meta, group, window_base, window, decoded)
@@ -422,7 +422,7 @@ impl BlobCache for LocalBlobCache {
         }
         // Fast path: another process (or an earlier run) already decoded every
         // group; skip the batch planning and per-group readiness scan.
-        if !self.blob_meta.is_redirect_blob() && self.groupmap.is_all_ready() {
+        if !self.blob_meta.is_redirect_blob() && self.group_map.is_all_ready() {
             return Ok(());
         }
 
@@ -431,7 +431,7 @@ impl BlobCache for LocalBlobCache {
         // make sure the file it fills is still the one other processes read.
         self.ensure_data_file_linked(&cache_file)?;
         // Prefetch owns its decode buffers and does not take `fetch_lock`, so it
-        // never blocks on-demand FUSE reads. The groupmap is internally locked
+        // never blocks on-demand FUSE reads. The group_map is internally locked
         // and `set_ready` is idempotent, so racing with a read at worst decodes
         // the same group twice into identical bytes at the same cache offset.
         let mut decoded = Vec::new();
@@ -440,7 +440,7 @@ impl BlobCache for LocalBlobCache {
         for batch in plan_prefetch_batches(groups, BLOB_META_DEFAULT_CHUNK_SIZE as u64) {
             if batch
                 .clone()
-                .map(|index| self.groupmap.is_ready(index))
+                .map(|index| self.group_map.is_ready(index))
                 .collect::<io::Result<Vec<_>>>()?
                 .into_iter()
                 .all(|ready| ready)
@@ -468,7 +468,7 @@ impl BlobCache for LocalBlobCache {
                 .read_range_into(&self.blob_id, window_base, &mut window, ctx)?;
 
             for index in batch {
-                if self.groupmap.is_ready(index)? {
+                if self.group_map.is_ready(index)? {
                     continue;
                 }
                 let group = &groups[index];
@@ -489,7 +489,7 @@ impl BlobCache for LocalBlobCache {
                     group.uncompressed_byte_offset(),
                     &decoded,
                 )?;
-                self.groupmap.set_ready(index)?;
+                self.group_map.set_ready(index)?;
                 crate::metrics::inc_cache_fill_group();
             }
         }
@@ -500,9 +500,9 @@ impl BlobCache for LocalBlobCache {
         // normally latches it through the shared ready counter, but a
         // historical writer crash between its bit and counter updates leaves
         // the counter short forever; the authoritative bitmap scan inside
-        // check_all_ready() latches the flag regardless.
+        // latch_all_ready() latches the flag regardless.
         if !self.blob_meta.is_redirect_blob() {
-            self.groupmap.check_all_ready();
+            self.group_map.latch_all_ready();
         }
 
         Ok(())
@@ -557,7 +557,7 @@ impl BlobCache for LocalBlobCache {
             .group_index_for_byte_offset(end - 1)
             .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "blob meta group not found"))?;
 
-        self.groupmap
+        self.group_map
             .ready_ranges(first, last)?
             .into_iter()
             .map(|groups| {
@@ -582,7 +582,7 @@ impl BlobCache for LocalBlobCache {
     /// prefetcher: locking failures degrade to prefetching without the lock
     /// rather than failing the prefetch, and the guard is released when the
     /// returned file is dropped — including on process death, so a crashed
-    /// owner's lock is taken over and the groupmap-driven skip logic resumes
+    /// owner's lock is taken over and the group_map-driven skip logic resumes
     /// where it left off.
     fn prefetch_lock(&self) -> Option<File> {
         let file = match OpenOptions::new()
@@ -619,11 +619,11 @@ impl BlobCache for LocalBlobCache {
                 return None;
             }
             // Another process is prefetching this blob. For a regular blob the
-            // shared groupmap tells us when the owner has finished everything,
+            // shared group_map tells us when the owner has finished everything,
             // so we can stop waiting; the caller's prefetch then reduces to a
             // cheap all-ready scan. A redirect blob never marks its own map,
-            // so keep waiting for the lock and rely on segment skipping.
-            if !self.blob_meta.is_redirect_blob() && self.groupmap.check_all_ready() {
+            // so keep waiting for the lock and rely on batch skipping.
+            if !self.blob_meta.is_redirect_blob() && self.group_map.latch_all_ready() {
                 return None;
             }
             if !contention_logged {
@@ -638,13 +638,13 @@ impl BlobCache for LocalBlobCache {
     }
 
     fn group_ready(&self, group_index: usize) -> bool {
-        self.groupmap.is_ready(group_index).unwrap_or(false)
+        self.group_map.is_ready(group_index).unwrap_or(false)
     }
 
     fn is_all_ready(&self) -> bool {
-        // A redirect blob never marks its own groupmap (its groups fill other
+        // A redirect blob never marks its own group_map (its groups fill other
         // blobs' caches), so the flag is meaningless there.
-        !self.blob_meta.is_redirect_blob() && self.groupmap.is_all_ready()
+        !self.blob_meta.is_redirect_blob() && self.group_map.is_all_ready()
     }
 
     fn stream_redirect(
@@ -715,43 +715,43 @@ impl BlobCache for LocalBlobCache {
         // Segments whose groups are all already done (per `skip`, typically
         // backed by the shared source groupmaps) are not fetched at all, so a
         // process re-running the warmup behind another one does close to zero
-        // backend work. Partially-done segments are still fetched whole to
+        // backend work. Partially-done batches are still fetched whole to
         // keep the backend reads contiguous.
-        let segment_done = |segment: &std::ops::Range<usize>| -> bool {
-            segment.clone().all(|index| skip(&groups[index]))
+        let batch_done = |batch: &std::ops::Range<usize>| -> bool {
+            batch.clone().all(|index| skip(&groups[index]))
         };
 
-        // A small ondemand blob (fits in one segment) or a single worker is
-        // streamed sequentially with default-sized segments: segmentation and
+        // A small ondemand blob (fits in one batch) or a single worker is
+        // streamed sequentially with default-sized batches: batching and
         // extra registry connections would add overhead without overlapping any
         // work.
         let total_uncompressed: u64 = groups
             .iter()
             .map(|group| group.uncompressed_byte_size())
             .sum();
-        if threads <= 1 || total_uncompressed <= super::REDIRECT_PREFETCH_SEGMENT_SIZE {
+        if threads <= 1 || total_uncompressed <= super::REDIRECT_PREFETCH_BATCH_SIZE {
             let mut window = Vec::new();
             let mut decoded = Vec::new();
-            for segment in plan_prefetch_batches(groups, super::REDIRECT_PREFETCH_SEGMENT_SIZE) {
-                if segment_done(&segment) {
+            for batch in plan_prefetch_batches(groups, super::REDIRECT_PREFETCH_BATCH_SIZE) {
+                if batch_done(&batch) {
                     continue;
                 }
-                self.stream_redirect_segment(groups, segment, &mut window, &mut decoded, cb)?;
+                self.stream_redirect_batch(groups, batch, &mut window, &mut decoded, cb)?;
             }
             return Ok(());
         }
 
-        // Larger blob: fetch segments concurrently. The earliest groups are
-        // emitted one per segment (a "ramp") so they land in the first wave of
+        // Larger blob: fetch batches concurrently. The earliest groups are
+        // emitted one per batch (a "ramp") so they land in the first wave of
         // workers within a single round trip, ahead of the workload's first
-        // faults; the rest are bundled into REDIRECT_PREFETCH_SEGMENT_SIZE
-        // segments for throughput.
-        let segments = super::plan_redirect_segments(
+        // faults; the rest are bundled into REDIRECT_PREFETCH_BATCH_SIZE
+        // batches for throughput.
+        let batches = super::plan_redirect_batches(
             groups,
-            super::REDIRECT_PREFETCH_SEGMENT_SIZE,
+            super::REDIRECT_PREFETCH_BATCH_SIZE,
             super::REDIRECT_PREFETCH_RAMP_GROUPS,
         );
-        let worker_count = threads.min(segments.len());
+        let worker_count = threads.min(batches.len());
         let next = AtomicUsize::new(0);
         let first_err: Mutex<Option<io::Error>> = Mutex::new(None);
         std::thread::scope(|scope| {
@@ -764,15 +764,15 @@ impl BlobCache for LocalBlobCache {
                             break;
                         }
                         let idx = next.fetch_add(1, Ordering::Relaxed);
-                        let Some(segment) = segments.get(idx) else {
+                        let Some(batch) = batches.get(idx) else {
                             break;
                         };
-                        if segment_done(segment) {
+                        if batch_done(batch) {
                             continue;
                         }
-                        if let Err(err) = self.stream_redirect_segment(
+                        if let Err(err) = self.stream_redirect_batch(
                             groups,
-                            segment.clone(),
+                            batch.clone(),
                             &mut window,
                             &mut decoded,
                             cb,
@@ -798,7 +798,7 @@ impl BlobCache for LocalBlobCache {
                 "redirect fill group index out of range",
             )
         })?;
-        if self.groupmap.is_ready(group_index)? {
+        if self.group_map.is_ready(group_index)? {
             crate::metrics::inc_cache_hit_group();
             return Ok(());
         }
@@ -813,13 +813,13 @@ impl BlobCache for LocalBlobCache {
             group.uncompressed_byte_offset(),
             decoded,
         )?;
-        self.groupmap.set_ready(group_index)?;
+        self.group_map.set_ready(group_index)?;
         crate::metrics::inc_cache_redirect_fill_group();
         Ok(())
     }
 }
 
-fn load_cached_blob_meta(
+fn cached_blob_meta(
     blob_id: [u8; EROFS_BLOB_ID_SIZE],
     cache_dir: &Path,
     blob_meta_path: &Path,
@@ -832,14 +832,14 @@ fn load_cached_blob_meta(
             .prefix(".blob-meta-")
             .suffix(".tmp")
             .tempfile_in(cache_dir)?;
-        backend.download_blob_meta(&blob_id, tmp.path())?;
-        if let Err(err) = BlobMeta::load_checked_crc32_with_blob_id(tmp.path(), blob_id) {
+        backend.blob_meta_to(&blob_id, tmp.path())?;
+        if let Err(err) = BlobMeta::loader().verify_crc32().blob_id(blob_id).load(tmp.path()) {
             return Err(io::Error::other(err));
         }
         tmp.persist(blob_meta_path).map_err(|err| err.error)?;
     }
 
-    BlobMeta::load_checked_crc32_with_blob_id(blob_meta_path, blob_id).map_err(io::Error::other)
+    BlobMeta::loader().verify_crc32().blob_id(blob_id).load(blob_meta_path).map_err(io::Error::other)
 }
 
 /// Drop guard that ensures a leader always signals its flight and cleans up
@@ -905,10 +905,10 @@ mod tests {
         .unwrap()
     }
 
-    use crate::storage::test_util::write_full_blob;
+    use crate::storage::test_util::write_minimal_full_blob;
 
     /// Wraps a real backend and counts data-range reads, so tests can assert
-    /// that cross-process sharing (groupmap + prefetch lock + segment skip)
+    /// that cross-process sharing (group_map + prefetch lock + batch skip)
     /// actually eliminates duplicate backend traffic.
     struct CountingBackend {
         inner: LocalBackend,
@@ -929,19 +929,19 @@ mod tests {
     }
 
     impl BlobBackend for CountingBackend {
-        fn load_blob_meta(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE]) -> io::Result<BlobMeta> {
-            self.inner.load_blob_meta(blob_id)
+        fn blob_meta(&self, blob_id: &[u8; EROFS_BLOB_ID_SIZE]) -> io::Result<BlobMeta> {
+            self.inner.blob_meta(blob_id)
         }
 
-        fn read_range(
+        fn read_range_into(
             &self,
             blob_id: &[u8; EROFS_BLOB_ID_SIZE],
             offset: u64,
-            len: u32,
+            dst: &mut [u8],
             ctx: ReadContext,
-        ) -> io::Result<Vec<u8>> {
+        ) -> io::Result<()> {
             self.reads.fetch_add(1, Ordering::SeqCst);
-            self.inner.read_range(blob_id, offset, len, ctx)
+            self.inner.read_range_into(blob_id, offset, dst, ctx)
         }
     }
 
@@ -952,7 +952,7 @@ mod tests {
         let payload = vec![0xceu8; 4096];
         let data_blob_id = sha256_bytes(&payload);
         let meta = blob_meta(data_blob_id, &payload);
-        let full_blob_id = write_full_blob(backend_dir.path(), &payload, &meta, true);
+        let full_blob_id = write_minimal_full_blob(backend_dir.path(), &payload, &meta, true);
 
         let backend: Arc<dyn BlobBackend> =
             Arc::new(LocalBackend::new(backend_dir.path().to_path_buf()));
@@ -962,7 +962,7 @@ mod tests {
         cached.read_at(512, &mut buf).unwrap();
 
         assert_eq!(buf, payload[512..1536]);
-        assert!(cached.groupmap.is_ready(0).unwrap());
+        assert!(cached.group_map.is_ready(0).unwrap());
     }
 
     #[test]
@@ -972,7 +972,7 @@ mod tests {
         let payload = vec![0x3du8; 4096];
         let data_blob_id = sha256_bytes(&payload);
         let meta = blob_meta(data_blob_id, &payload);
-        let full_blob_id = write_full_blob(backend_dir.path(), &payload, &meta, true);
+        let full_blob_id = write_minimal_full_blob(backend_dir.path(), &payload, &meta, true);
         let backend: Arc<dyn BlobBackend> =
             Arc::new(LocalBackend::new(backend_dir.path().to_path_buf()));
 
@@ -983,19 +983,19 @@ mod tests {
                 LocalBlobCache::open(full_blob_id, 1, cache_dir.path(), backend.clone()).unwrap();
             let mut buf = vec![0u8; 1024];
             cached.read_at(0, &mut buf).unwrap();
-            assert!(cached.groupmap.is_all_ready());
+            assert!(cached.group_map.is_all_ready());
         }
 
         // Model the operational accident: the data file is removed while the
-        // groupmap survives. Reopening must reset the groupmap instead of
+        // group_map survives. Reopening must reset the group_map instead of
         // trusting ready bits that now point at sparse holes.
         let cache_key = backend.cache_key(&full_blob_id).unwrap();
         let prefix = hex_string(&cache_key);
         fs::remove_file(cache_dir.path().join(format!("{prefix}.blob.data"))).unwrap();
 
         let reopened = LocalBlobCache::open(full_blob_id, 1, cache_dir.path(), backend).unwrap();
-        assert!(!reopened.groupmap.is_ready(0).unwrap());
-        assert!(!reopened.groupmap.is_all_ready());
+        assert!(!reopened.group_map.is_ready(0).unwrap());
+        assert!(!reopened.group_map.is_all_ready());
 
         // The blob still reads correctly end-to-end after the reset.
         let mut buf = vec![0u8; 1024];
@@ -1012,17 +1012,17 @@ mod tests {
         let payload = vec![0x2eu8; 4096];
         let data_blob_id = sha256_bytes(&payload);
         let meta = blob_meta(data_blob_id, &payload);
-        let full_blob_id = write_full_blob(backend_dir.path(), &payload, &meta, true);
+        let full_blob_id = write_minimal_full_blob(backend_dir.path(), &payload, &meta, true);
         let backend: Arc<dyn BlobBackend> =
             Arc::new(LocalBackend::new(backend_dir.path().to_path_buf()));
 
-        // A live handle keeps the groupmap mapped throughout, standing in for
+        // A live handle keeps the group_map mapped throughout, standing in for
         // a process that is already running when the accident happens.
         let live =
             LocalBlobCache::open(full_blob_id, 1, cache_dir.path(), backend.clone()).unwrap();
         let mut buf = vec![0u8; 1024];
         live.read_at(0, &mut buf).unwrap();
-        assert!(live.groupmap.is_ready(0).unwrap());
+        assert!(live.group_map.is_ready(0).unwrap());
 
         let cache_key = backend.cache_key(&full_blob_id).unwrap();
         let prefix = hex_string(&cache_key);
@@ -1034,14 +1034,14 @@ mod tests {
         assert_eq!(
             fs::metadata(&groupmap_path).unwrap().ino(),
             before,
-            "the reset must not replace the groupmap file"
+            "the reset must not replace the group_map file"
         );
 
         // Because the inode is unchanged, the reset is visible through the
         // mapping the live handle already holds; a replacement inode would
         // have left it advertising readiness nobody else can see.
-        assert!(!live.groupmap.is_ready(0).unwrap());
-        assert!(!reopened.groupmap.is_ready(0).unwrap());
+        assert!(!live.group_map.is_ready(0).unwrap());
+        assert!(!reopened.group_map.is_ready(0).unwrap());
     }
 
     #[test]
@@ -1051,7 +1051,7 @@ mod tests {
         let payload = vec![0x5au8; 4096];
         let data_blob_id = sha256_bytes(&payload);
         let meta = blob_meta(data_blob_id, &payload);
-        let full_blob_id = write_full_blob(backend_dir.path(), &payload, &meta, true);
+        let full_blob_id = write_minimal_full_blob(backend_dir.path(), &payload, &meta, true);
 
         let backend: Arc<dyn BlobBackend> =
             Arc::new(LocalBackend::new(backend_dir.path().to_path_buf()));
@@ -1065,9 +1065,9 @@ mod tests {
         let guard = owner.prefetch_lock().expect("first handle takes the lock");
 
         // The owner finished all groups: the contender must give up on the
-        // lock (returning None) instead of waiting, since the shared groupmap
+        // lock (returning None) instead of waiting, since the shared group_map
         // already reports everything ready.
-        owner.groupmap.set_ready(0).unwrap();
+        owner.group_map.set_ready(0).unwrap();
         assert!(waiter.prefetch_lock().is_none());
         assert!(waiter.group_ready(0));
 
@@ -1083,7 +1083,7 @@ mod tests {
         let payload = vec![0x21u8; 4096];
         let data_blob_id = sha256_bytes(&payload);
         let meta = blob_meta(data_blob_id, &payload);
-        let full_blob_id = write_full_blob(backend_dir.path(), &payload, &meta, true);
+        let full_blob_id = write_minimal_full_blob(backend_dir.path(), &payload, &meta, true);
 
         let backend: Arc<dyn BlobBackend> =
             Arc::new(LocalBackend::new(backend_dir.path().to_path_buf()));
@@ -1106,7 +1106,7 @@ mod tests {
         let payload = vec![0x77u8; 4096];
         let data_blob_id = sha256_bytes(&payload);
         let meta = blob_meta(data_blob_id, &payload);
-        let full_blob_id = write_full_blob(backend_dir.path(), &payload, &meta, true);
+        let full_blob_id = write_minimal_full_blob(backend_dir.path(), &payload, &meta, true);
 
         let backend: Arc<dyn BlobBackend> =
             Arc::new(LocalBackend::new(backend_dir.path().to_path_buf()));
@@ -1130,7 +1130,7 @@ mod tests {
         let payload = vec![0x42u8; 4096];
         let data_blob_id = sha256_bytes(&payload);
         let meta = blob_meta(data_blob_id, &payload);
-        let full_blob_id = write_full_blob(backend_dir.path(), &payload, &meta, true);
+        let full_blob_id = write_minimal_full_blob(backend_dir.path(), &payload, &meta, true);
 
         let backend = CountingBackend::new(backend_dir.path());
         let first = LocalBlobCache::open(
@@ -1155,7 +1155,7 @@ mod tests {
         assert!(after_owner > 0, "owner must stream from the backend");
 
         // While the owner still holds the lock, a contending instance sees
-        // every group ready through the shared groupmap and gives up on the
+        // every group ready through the shared group_map and gives up on the
         // lock (None) instead of waiting.
         assert!(second.prefetch_lock().is_none());
         drop(guard);
@@ -1173,7 +1173,7 @@ mod tests {
     }
 
     #[test]
-    fn redirect_stream_skips_fully_done_segments() {
+    fn redirect_stream_skips_fully_done_batches() {
         let backend_dir = tempdir().unwrap();
         let payload = vec![0x9cu8; 4096];
         let crc32 = crc32c::crc32c(&payload);
@@ -1188,7 +1188,7 @@ mod tests {
         )
         .unwrap();
         assert!(redirect_meta.is_redirect_blob());
-        let redirect_blob_id = write_full_blob(backend_dir.path(), &payload, &redirect_meta, true);
+        let redirect_blob_id = write_minimal_full_blob(backend_dir.path(), &payload, &redirect_meta, true);
 
         let run = |skip_all: bool| -> (usize, usize) {
             let cache_dir = tempdir().unwrap();
@@ -1213,7 +1213,7 @@ mod tests {
             (backend.reads() - baseline, delivered.load(Ordering::SeqCst))
         };
 
-        // Nothing done yet: the segment is fetched and the group delivered.
+        // Nothing done yet: the batch is fetched and the group delivered.
         let (reads, delivered) = run(false);
         assert!(reads > 0);
         assert_eq!(delivered, 1);
@@ -1221,7 +1221,7 @@ mod tests {
         // Every group reported done (e.g. resident in the source caches of a
         // faster sibling instance): no backend fetch, no callback at all.
         let (reads, delivered) = run(true);
-        assert_eq!(reads, 0, "fully-done segment must not be fetched");
+        assert_eq!(reads, 0, "fully-done batch must not be fetched");
         assert_eq!(delivered, 0);
     }
 
@@ -1232,7 +1232,7 @@ mod tests {
         let payload = vec![0xbdu8; 4096];
         let data_blob_id = sha256_bytes(&payload);
         let meta = blob_meta(data_blob_id, &payload);
-        let full_blob_id = write_full_blob(backend_dir.path(), &payload, &meta, true);
+        let full_blob_id = write_minimal_full_blob(backend_dir.path(), &payload, &meta, true);
         let blob_meta_path = backend_dir
             .path()
             .join(format!("{}.blob.meta", hex_string(&full_blob_id)));
@@ -1267,7 +1267,7 @@ mod tests {
             &payload,
             crc32c::crc32c(&payload).wrapping_add(1),
         );
-        let full_blob_id = write_full_blob(backend_dir.path(), &payload, &meta, true);
+        let full_blob_id = write_minimal_full_blob(backend_dir.path(), &payload, &meta, true);
 
         let backend: Arc<dyn BlobBackend> =
             Arc::new(LocalBackend::new(backend_dir.path().to_path_buf()));
@@ -1278,7 +1278,7 @@ mod tests {
 
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         assert!(err.to_string().contains("crc32"));
-        assert!(!cached.groupmap.is_ready(0).unwrap());
+        assert!(!cached.group_map.is_ready(0).unwrap());
     }
 
     #[test]
@@ -1288,7 +1288,7 @@ mod tests {
         let payload = vec![0x3du8; 4096];
         let data_blob_id = sha256_bytes(&payload);
         let meta = blob_meta(data_blob_id, &payload);
-        let full_blob_id = write_full_blob(backend_dir.path(), &payload, &meta, false);
+        let full_blob_id = write_minimal_full_blob(backend_dir.path(), &payload, &meta, false);
 
         let backend: Arc<dyn BlobBackend> =
             Arc::new(LocalBackend::new(backend_dir.path().to_path_buf()));
@@ -1298,7 +1298,7 @@ mod tests {
         cached.read_at(256, &mut buf).unwrap();
 
         assert_eq!(buf, payload[256..768]);
-        assert!(cached.groupmap.is_ready(0).unwrap());
+        assert!(cached.group_map.is_ready(0).unwrap());
         assert!(cache_dir
             .path()
             .join(format!("{}.blob.data", hex_string(&full_blob_id)))
@@ -1324,7 +1324,7 @@ mod tests {
         let payload = vec![0x6eu8; 4096];
         let data_blob_id = sha256_bytes(&payload);
         let meta = blob_meta(data_blob_id, &payload);
-        let full_blob_id = write_full_blob(backend_dir.path(), &payload, &meta, true);
+        let full_blob_id = write_minimal_full_blob(backend_dir.path(), &payload, &meta, true);
 
         let backend: Arc<dyn BlobBackend> =
             Arc::new(LocalBackend::new(backend_dir.path().to_path_buf()));
@@ -1336,18 +1336,18 @@ mod tests {
             .fill_group_from_redirect(0, &payload[..1024])
             .unwrap_err();
         assert!(err.to_string().contains("length mismatch"));
-        assert!(!cached.groupmap.is_ready(0).unwrap());
+        assert!(!cached.group_map.is_ready(0).unwrap());
 
         // Corrupted bytes fail the CRC cross-check.
         let mut corrupted = payload.clone();
         corrupted[0] ^= 0xff;
         let err = cached.fill_group_from_redirect(0, &corrupted).unwrap_err();
         assert!(super::super::is_group_crc_mismatch(&err));
-        assert!(!cached.groupmap.is_ready(0).unwrap());
+        assert!(!cached.group_map.is_ready(0).unwrap());
 
         // Valid bytes are cached, marked ready, and served without the backend.
         cached.fill_group_from_redirect(0, &payload).unwrap();
-        assert!(cached.groupmap.is_ready(0).unwrap());
+        assert!(cached.group_map.is_ready(0).unwrap());
         let mut buf = vec![0u8; 1024];
         cached.read_at(512, &mut buf).unwrap();
         assert_eq!(buf, payload[512..1536]);

--- a/nydus-core/src/storage/cache/local.rs
+++ b/nydus-core/src/storage/cache/local.rs
@@ -373,8 +373,7 @@ impl LocalBlobCache {
         })?;
         window.resize(window_len, 0);
         let uncompressed_offset = groups[batch.start].uncompressed_byte_offset();
-        let uncompressed_size =
-            groups[batch.end - 1].uncompressed_byte_end() - uncompressed_offset;
+        let uncompressed_size = groups[batch.end - 1].uncompressed_byte_end() - uncompressed_offset;
         let ctx = ReadContext::group(ReadKind::Prefetch, uncompressed_offset, uncompressed_size);
         self.backend
             .read_range_into(&self.blob_id, window_base, window, ctx)?;
@@ -833,13 +832,21 @@ fn cached_blob_meta(
             .suffix(".tmp")
             .tempfile_in(cache_dir)?;
         backend.blob_meta_to(&blob_id, tmp.path())?;
-        if let Err(err) = BlobMeta::loader().verify_crc32().blob_id(blob_id).load(tmp.path()) {
+        if let Err(err) = BlobMeta::loader()
+            .verify_crc32()
+            .blob_id(blob_id)
+            .load(tmp.path())
+        {
             return Err(io::Error::other(err));
         }
         tmp.persist(blob_meta_path).map_err(|err| err.error)?;
     }
 
-    BlobMeta::loader().verify_crc32().blob_id(blob_id).load(blob_meta_path).map_err(io::Error::other)
+    BlobMeta::loader()
+        .verify_crc32()
+        .blob_id(blob_id)
+        .load(blob_meta_path)
+        .map_err(io::Error::other)
 }
 
 /// Drop guard that ensures a leader always signals its flight and cleans up
@@ -1188,7 +1195,8 @@ mod tests {
         )
         .unwrap();
         assert!(redirect_meta.is_redirect_blob());
-        let redirect_blob_id = write_minimal_full_blob(backend_dir.path(), &payload, &redirect_meta, true);
+        let redirect_blob_id =
+            write_minimal_full_blob(backend_dir.path(), &payload, &redirect_meta, true);
 
         let run = |skip_all: bool| -> (usize, usize) {
             let cache_dir = tempdir().unwrap();

--- a/nydus-core/src/storage/cache/mod.rs
+++ b/nydus-core/src/storage/cache/mod.rs
@@ -109,9 +109,9 @@ pub trait BlobCache: Send + Sync {
     }
 
     /// Like [`stream_redirect`], but split the redirect blob's groups into
-    /// fixed-size segments and fetch/decode them concurrently with up to
-    /// `threads` worker threads. A blob small enough to fit in a single segment
-    /// (or `threads <= 1`) is streamed sequentially, since segmentation would
+    /// fixed-size batches and fetch/decode them concurrently with up to
+    /// `threads` worker threads. A blob small enough to fit in a single batch
+    /// (or `threads <= 1`) is streamed sequentially, since batching would
     /// add registry connections without overlapping any work. Segments whose
     /// groups are all reported done by `skip` are not fetched at all, so a
     /// process re-running the warmup behind another one's progress does close
@@ -145,17 +145,17 @@ pub trait BlobCache: Send + Sync {
     }
 }
 
-/// Target uncompressed size of one redirect-prefetch segment. The ondemand
-/// (redirect) blob's groups are split into segments of about this size and
+/// Target uncompressed size of one redirect-prefetch batch. The ondemand
+/// (redirect) blob's groups are split into batches of about this size and
 /// fetched concurrently by [`BlobCache::stream_redirect_parallel`]; a blob that
-/// fits within a single segment is streamed sequentially instead.
-pub(crate) const REDIRECT_PREFETCH_SEGMENT_SIZE: u64 = 16 * 1024 * 1024;
+/// fits within a single batch is streamed sequentially instead.
+pub(crate) const REDIRECT_PREFETCH_BATCH_SIZE: u64 = 16 * 1024 * 1024;
 
 /// Number of earliest (access-ordered) groups the parallel redirect prefetch
-/// fetches one-per-segment instead of bundling into full segments. These are
+/// fetches one-per-batch instead of bundling into full batches. These are
 /// the most latency-critical groups — the workload faults them first — so a
 /// small, single-group read lands them within roughly one round trip in the
-/// first wave of workers, rather than waiting for a whole segment-sized read.
+/// first wave of workers, rather than waiting for a whole batch-sized read.
 pub(crate) const REDIRECT_PREFETCH_RAMP_GROUPS: usize = 16;
 
 /// Group together consecutive groups whose accumulated uncompressed size reaches
@@ -180,23 +180,23 @@ pub(crate) fn plan_prefetch_batches(
     batches
 }
 
-/// Plan the segments for a parallel redirect prefetch: the first `ramp_groups`
-/// access-ordered groups are emitted one per segment (small, fast reads that
+/// Plan the batches for a parallel redirect prefetch: the first `ramp_groups`
+/// access-ordered groups are emitted one per batch (small, fast reads that
 /// land the earliest groups within a single round trip), and the remaining
-/// groups are bundled into `target_uncompressed`-sized segments for throughput.
-pub(crate) fn plan_redirect_segments(
+/// groups are bundled into `target_uncompressed`-sized batches for throughput.
+pub(crate) fn plan_redirect_batches(
     groups: &[BlobMetaGroup],
     target_uncompressed: u64,
     ramp_groups: usize,
 ) -> Vec<Range<usize>> {
     let ramp = ramp_groups.min(groups.len());
-    let mut segments: Vec<Range<usize>> = (0..ramp).map(|i| i..i + 1).collect();
+    let mut batches: Vec<Range<usize>> = (0..ramp).map(|i| i..i + 1).collect();
     if ramp < groups.len() {
         for batch in plan_prefetch_batches(&groups[ramp..], target_uncompressed) {
-            segments.push((ramp + batch.start)..(ramp + batch.end));
+            batches.push((ramp + batch.start)..(ramp + batch.end));
         }
     }
-    segments
+    batches
 }
 
 /// Decode and validate a single group from an in-memory window of compressed

--- a/nydus-core/src/storage/group_map.rs
+++ b/nydus-core/src/storage/group_map.rs
@@ -12,28 +12,28 @@ use memmap2::MmapRaw;
 /// as-is so a hexdump of the file starts with the readable string. Same magic
 /// style as the blob meta header (`LPBLMETA`); the format version is a
 /// separate field instead of being baked into the magic.
-const GROUPMAP_MAGIC: [u8; 8] = *b"LPGRPMAP";
+const GROUP_MAP_MAGIC: [u8; 8] = *b"LPGRPMAP";
 /// On-disk format generation, informational only: readers do not gate on it.
-/// A groupmap is local mutable state — its `flags` word carries runtime state
+/// A group_map is local mutable state — its `flags` word carries runtime state
 /// bits (not format features), and unknown state bits are simply ignored.
-const GROUPMAP_VERSION: u32 = 1;
+const GROUP_MAP_VERSION: u32 = 1;
 /// Fixed header size: one block-sized page, matching the blob meta header
 /// (`BLOB_META_HEADER_SIZE`) for a uniform sidecar format family. The bitmap
 /// starts on a page boundary and the unused header tail is reserved for
 /// future fields.
-const GROUPMAP_HEADER_SIZE: usize = crate::metadata::EROFS_BLOCK_SIZE as usize;
+const GROUP_MAP_HEADER_SIZE: usize = crate::metadata::EROFS_BLOCK_SIZE as usize;
 
 /// Byte offsets of the header fields after magic and version. `flags` and
 /// `ready_count` are mutable at runtime, updated atomically through the
 /// shared mapping (unlike magic/version/group count, which are written once
 /// at creation). The `magic + version + flags` prefix matches the blob meta
 /// header layout.
-const GROUPMAP_FLAGS_OFFSET: usize = 12;
-const GROUPMAP_GROUP_COUNT_OFFSET: usize = 16;
-const GROUPMAP_READY_COUNT_OFFSET: usize = 20;
+const GROUP_MAP_FLAGS_OFFSET: usize = 12;
+const GROUP_MAP_GROUP_COUNT_OFFSET: usize = 16;
+const GROUP_MAP_READY_COUNT_OFFSET: usize = 20;
 /// `flags` bit: every group of this blob is ready. Sticky — ready bits are
 /// never cleared, so once set it stays set for the lifetime of the file.
-const GROUPMAP_FLAG_ALL_READY: u32 = 1;
+const GROUP_MAP_FLAG_ALL_READY: u32 = 1;
 
 /// Holds `flock(LOCK_EX)` on a file for the guard's lifetime.
 struct FileLock<'a> {
@@ -60,7 +60,7 @@ impl Drop for FileLock<'_> {
 /// The on-disk layout is a 4096-byte header (magic, version, flags, group
 /// count, ready count) followed by one bit per group. The whole file is
 /// mapped `MAP_SHARED` and the bits are accessed with atomic operations, so
-/// every process (or thread) that opens the same groupmap file observes
+/// every process (or thread) that opens the same group_map file observes
 /// `set_ready` updates from all the others through the shared page cache —
 /// this is what lets concurrent nydus instances on one node share a single
 /// warmed cache. Persistence across reboots is provided by regular kernel
@@ -81,7 +81,7 @@ pub struct GroupMap {
 impl GroupMap {
     pub fn open(path: &Path, group_count: usize) -> io::Result<Self> {
         let bytes_len = group_count.div_ceil(8);
-        let expected_len = (GROUPMAP_HEADER_SIZE + bytes_len) as u64;
+        let expected_len = (GROUP_MAP_HEADER_SIZE + bytes_len) as u64;
 
         let file = OpenOptions::new()
             .read(true)
@@ -100,7 +100,7 @@ impl GroupMap {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
-                    "groupmap {} size mismatch: expected {}, got {}",
+                    "group_map {} size mismatch: expected {}, got {}",
                     path.display(),
                     expected_len,
                     file_len
@@ -112,7 +112,7 @@ impl GroupMap {
         if map.len() < expected_len as usize {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("groupmap {} mapping size mismatch", path.display()),
+                format!("group_map {} mapping size mismatch", path.display()),
             ));
         }
 
@@ -122,21 +122,21 @@ impl GroupMap {
         // header bytes; anything else is a corrupt or foreign file. The
         // mutable fields (flags, ready count) cannot have been touched in
         // that window: no process can update them before a successful open.
-        let header = unsafe { std::slice::from_raw_parts(map.as_ptr(), GROUPMAP_HEADER_SIZE) };
-        if header[..GROUPMAP_MAGIC.len()] != GROUPMAP_MAGIC {
+        let header = unsafe { std::slice::from_raw_parts(map.as_ptr(), GROUP_MAP_HEADER_SIZE) };
+        if header[..GROUP_MAP_MAGIC.len()] != GROUP_MAP_MAGIC {
             if header.iter().all(|byte| *byte == 0) {
                 file.write_all_at(&header_bytes(group_count), 0)?;
             } else {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!("invalid groupmap magic: {}", path.display()),
+                    format!("invalid group_map magic: {}", path.display()),
                 ));
             }
         } else {
             // `version` (offset 8) is informational and not gated on, matching
             // the other sidecar formats.
             let existing = u32::from_le_bytes(
-                header[GROUPMAP_GROUP_COUNT_OFFSET..GROUPMAP_GROUP_COUNT_OFFSET + 4]
+                header[GROUP_MAP_GROUP_COUNT_OFFSET..GROUP_MAP_GROUP_COUNT_OFFSET + 4]
                     .try_into()
                     .unwrap(),
             ) as usize;
@@ -144,7 +144,7 @@ impl GroupMap {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!(
-                        "groupmap {} group count mismatch: expected {}, got {}",
+                        "group_map {} group count mismatch: expected {}, got {}",
                         path.display(),
                         group_count,
                         existing
@@ -153,7 +153,7 @@ impl GroupMap {
             }
         }
 
-        let groupmap = Self {
+        let group_map = Self {
             map,
             group_count,
             _file: file,
@@ -163,15 +163,15 @@ impl GroupMap {
         // setting the last bit and bumping the ready count, and marks
         // fully-warmed blobs (including empty ones) at open time so readers
         // start on the fast path immediately.
-        if !groupmap.is_all_ready() && groupmap.scan_all_ready() {
-            groupmap.mark_all_ready();
+        if !group_map.is_all_ready() && group_map.scan_all_ready() {
+            group_map.mark_all_ready();
         }
-        Ok(groupmap)
+        Ok(group_map)
     }
 
     /// Atomic view of the byte holding the ready bit for `index`.
     fn bit_byte(&self, index: usize) -> &AtomicU8 {
-        let offset = GROUPMAP_HEADER_SIZE + index / 8;
+        let offset = GROUP_MAP_HEADER_SIZE + index / 8;
         // Safety: `offset` is within the mapping (checked against the file
         // size derived from `group_count` in `open`), and `AtomicU8` has the
         // same layout as `u8` with no alignment requirement beyond 1.
@@ -180,7 +180,7 @@ impl GroupMap {
 
     /// Atomic view of a mutable u32 header field at `offset`.
     fn header_u32(&self, offset: usize) -> &AtomicU32 {
-        debug_assert!(offset % 4 == 0 && offset + 4 <= GROUPMAP_HEADER_SIZE);
+        debug_assert!(offset % 4 == 0 && offset + 4 <= GROUP_MAP_HEADER_SIZE);
         // Safety: the mapping is page aligned and at least one header page
         // long, and `offset` is a 4-byte-aligned position inside the header,
         // satisfying AtomicU32's alignment and size requirements.
@@ -206,10 +206,10 @@ impl GroupMap {
         for index in (0..self.group_count).step_by(8) {
             self.bit_byte(index).store(0, Ordering::Release);
         }
-        self.header_u32(GROUPMAP_READY_COUNT_OFFSET)
+        self.header_u32(GROUP_MAP_READY_COUNT_OFFSET)
             .store(0, Ordering::Release);
-        self.header_u32(GROUPMAP_FLAGS_OFFSET)
-            .fetch_and(!GROUPMAP_FLAG_ALL_READY, Ordering::AcqRel);
+        self.header_u32(GROUP_MAP_FLAGS_OFFSET)
+            .fetch_and(!GROUP_MAP_FLAG_ALL_READY, Ordering::AcqRel);
         Ok(())
     }
 
@@ -256,7 +256,7 @@ impl GroupMap {
             // per group), so it owns bumping the shared ready count. When the
             // count reaches the total, latch the sticky ALL_READY flag.
             let count = self
-                .header_u32(GROUPMAP_READY_COUNT_OFFSET)
+                .header_u32(GROUP_MAP_READY_COUNT_OFFSET)
                 .fetch_add(1, Ordering::AcqRel)
                 + 1;
             if count as usize >= self.group_count {
@@ -272,9 +272,9 @@ impl GroupMap {
     /// per-fault handlers (uffd, fanotify, FUSE reads) can consult it on
     /// every event at effectively zero cost.
     pub fn is_all_ready(&self) -> bool {
-        self.header_u32(GROUPMAP_FLAGS_OFFSET)
+        self.header_u32(GROUP_MAP_FLAGS_OFFSET)
             .load(Ordering::Acquire)
-            & GROUPMAP_FLAG_ALL_READY
+            & GROUP_MAP_FLAG_ALL_READY
             != 0
     }
 
@@ -282,7 +282,7 @@ impl GroupMap {
     /// first; otherwise scans the shared bitmap and latches the flag when the
     /// scan proves completion (also healing any ready-count skew left by a
     /// crashed writer). The answer reflects updates from other processes.
-    pub fn check_all_ready(&self) -> bool {
+    pub fn latch_all_ready(&self) -> bool {
         if self.is_all_ready() {
             return true;
         }
@@ -315,27 +315,27 @@ impl GroupMap {
         // latched from a bitmap scan (heal path), the counter may still be
         // short from a crashed writer. Every bit is set at this point, so no
         // concurrent 0→1 increment can race with this store.
-        self.header_u32(GROUPMAP_READY_COUNT_OFFSET)
+        self.header_u32(GROUP_MAP_READY_COUNT_OFFSET)
             .store(self.group_count as u32, Ordering::Release);
-        self.header_u32(GROUPMAP_FLAGS_OFFSET)
-            .fetch_or(GROUPMAP_FLAG_ALL_READY, Ordering::AcqRel);
+        self.header_u32(GROUP_MAP_FLAGS_OFFSET)
+            .fetch_or(GROUP_MAP_FLAG_ALL_READY, Ordering::AcqRel);
     }
 
     /// Number of groups currently marked ready (advisory shared counter,
     /// exact once ALL_READY is latched).
     pub fn ready_count(&self) -> usize {
-        self.header_u32(GROUPMAP_READY_COUNT_OFFSET)
+        self.header_u32(GROUP_MAP_READY_COUNT_OFFSET)
             .load(Ordering::Acquire) as usize
     }
 }
 
-fn header_bytes(group_count: usize) -> [u8; GROUPMAP_HEADER_SIZE] {
-    let mut header = [0u8; GROUPMAP_HEADER_SIZE];
-    header[..8].copy_from_slice(&GROUPMAP_MAGIC);
-    header[8..12].copy_from_slice(&GROUPMAP_VERSION.to_le_bytes());
+fn header_bytes(group_count: usize) -> [u8; GROUP_MAP_HEADER_SIZE] {
+    let mut header = [0u8; GROUP_MAP_HEADER_SIZE];
+    header[..8].copy_from_slice(&GROUP_MAP_MAGIC);
+    header[8..12].copy_from_slice(&GROUP_MAP_VERSION.to_le_bytes());
     // flags (12..16) and ready count (20..24) start at zero; the remaining
     // header tail is reserved and stays zero.
-    header[GROUPMAP_GROUP_COUNT_OFFSET..GROUPMAP_GROUP_COUNT_OFFSET + 4]
+    header[GROUP_MAP_GROUP_COUNT_OFFSET..GROUP_MAP_GROUP_COUNT_OFFSET + 4]
         .copy_from_slice(&(group_count as u32).to_le_bytes());
     header
 }
@@ -397,12 +397,12 @@ mod tests {
         assert!(!observer.is_ready(7).unwrap());
         writer.set_ready(7).unwrap();
         assert!(observer.is_ready(7).unwrap());
-        assert!(!observer.check_all_ready());
+        assert!(!observer.latch_all_ready());
 
         for index in 0..20 {
             writer.set_ready(index).unwrap();
         }
-        assert!(observer.check_all_ready());
+        assert!(observer.latch_all_ready());
     }
 
     #[test]
@@ -438,7 +438,7 @@ mod tests {
         // `set_len` but has not written the header yet, so we map a fully
         // sized, all-zero file. Open must heal the header and proceed.
         let group_count = 10usize;
-        let expected_len = (GROUPMAP_HEADER_SIZE + group_count.div_ceil(8)) as u64;
+        let expected_len = (GROUP_MAP_HEADER_SIZE + group_count.div_ceil(8)) as u64;
         let file = OpenOptions::new()
             .write(true)
             .create(true)
@@ -464,7 +464,7 @@ mod tests {
         // Correctly sized file with non-zero garbage: not a race window,
         // must be rejected instead of silently reinitialized.
         let garbage = dir.path().join("garbage.group.map");
-        let expected_len = GROUPMAP_HEADER_SIZE + 10usize.div_ceil(8);
+        let expected_len = GROUP_MAP_HEADER_SIZE + 10usize.div_ceil(8);
         std::fs::write(&garbage, vec![0xABu8; expected_len]).unwrap();
         assert!(GroupMap::open(&garbage, 10).is_err());
 
@@ -493,7 +493,7 @@ mod tests {
         // a concurrent observer see it without any bitmap scan or reopen.
         assert!(writer.is_all_ready());
         assert!(observer.is_all_ready());
-        assert!(observer.check_all_ready());
+        assert!(observer.latch_all_ready());
 
         // ready_ranges collapses to the whole span on the fast path.
         assert_eq!(observer.ready_ranges(0, 8).unwrap(), vec![0..9]);
@@ -517,14 +517,14 @@ mod tests {
             drop(map);
         }
         let file = OpenOptions::new().write(true).open(&path).unwrap();
-        file.write_all_at(&[0xFF, 0x03], GROUPMAP_HEADER_SIZE as u64)
+        file.write_all_at(&[0xFF, 0x03], GROUP_MAP_HEADER_SIZE as u64)
             .unwrap();
         drop(file);
 
         // Open reconciles the flag from the authoritative bitmap.
         let map = GroupMap::open(&path, group_count).unwrap();
         assert!(map.is_all_ready());
-        assert!(map.check_all_ready());
+        assert!(map.latch_all_ready());
         // The heal path also corrects the advisory ready counter.
         assert_eq!(map.ready_count(), group_count);
     }
@@ -536,7 +536,7 @@ mod tests {
 
         let map = GroupMap::open(&path, 0).unwrap();
         assert!(map.is_all_ready());
-        assert!(map.check_all_ready());
+        assert!(map.latch_all_ready());
     }
 
     #[test]
@@ -545,7 +545,7 @@ mod tests {
         let path = dir.path().join("blob.group.map");
 
         // 9 groups spill into a second bitmap byte; exercise both byte
-        // boundaries and the partial final byte in check_all_ready().
+        // boundaries and the partial final byte in latch_all_ready().
         let map = GroupMap::open(&path, 9).unwrap();
         for index in [0usize, 7, 8] {
             assert!(!map.is_ready(index).unwrap());
@@ -555,11 +555,11 @@ mod tests {
         for index in [1usize, 6] {
             assert!(!map.is_ready(index).unwrap(), "neighbor bit {index} leaked");
         }
-        assert!(!map.check_all_ready());
+        assert!(!map.latch_all_ready());
         for index in 0..9 {
             map.set_ready(index).unwrap();
         }
-        assert!(map.check_all_ready());
+        assert!(map.latch_all_ready());
 
         // Out-of-range indexes are rejected, not silently wrapped.
         assert_eq!(
@@ -600,7 +600,7 @@ mod tests {
         for index in 0..group_count {
             assert!(verify.is_ready(index).unwrap(), "lost update at {index}");
         }
-        assert!(verify.check_all_ready());
+        assert!(verify.latch_all_ready());
     }
 
     #[test]
@@ -620,13 +620,13 @@ mod tests {
         for index in 0..group_count {
             assert!(map.is_ready(index).unwrap());
         }
-        assert!(map.check_all_ready());
+        assert!(map.latch_all_ready());
         let elapsed = start.elapsed();
         // Generous bound (debug builds included): catches only pathological
         // regressions such as reintroducing per-bit file I/O.
         assert!(
             elapsed < std::time::Duration::from_secs(5),
-            "groupmap operations too slow: {elapsed:?}"
+            "group_map operations too slow: {elapsed:?}"
         );
     }
 }

--- a/nydus-core/src/storage/mod.rs
+++ b/nydus-core/src/storage/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod test_util {
     /// Assemble a minimal full blob (`payload + trivial bootstrap + blob meta
     /// + footer`) into `dir`, named by its full SHA256, optionally with a
     /// `.blob.meta` sidecar. Returns the full blob id.
-    pub(crate) fn write_full_blob(
+    pub(crate) fn write_minimal_full_blob(
         dir: &Path,
         payload: &[u8],
         blob_meta: &BlobMeta,

--- a/nydus-core/tests/common/mod.rs
+++ b/nydus-core/tests/common/mod.rs
@@ -54,7 +54,9 @@ pub fn assemble_full_blob(
     let mut full_blob = std::fs::File::create(&full_blob_path).expect("create full blob");
     full_blob.write_all(data).expect("write data");
     write_zero_padding(&mut full_blob, data_size, bootstrap_offset).expect("pad data");
-    full_blob.write_all(bootstrap_bytes).expect("write bootstrap");
+    full_blob
+        .write_all(bootstrap_bytes)
+        .expect("write bootstrap");
     write_zero_padding(
         &mut full_blob,
         bootstrap_offset + bootstrap_bytes.len() as u64,

--- a/nydus-core/tests/common/mod.rs
+++ b/nydus-core/tests/common/mod.rs
@@ -19,3 +19,54 @@ pub fn write_zero_padding(
 ) -> std::io::Result<()> {
     nydus_core::utils::write_zero_padding(writer, current, aligned)
 }
+
+/// Assemble a footer-based full blob (`data | pad | bootstrap | pad |
+/// blob meta | footer`) in `blob_dir`, rename it to its hex digest, and
+/// return the digest.
+#[allow(dead_code)]
+pub fn assemble_full_blob(
+    blob_dir: &std::path::Path,
+    data: &[u8],
+    bootstrap_bytes: &[u8],
+    blob_meta: &nydus_core::metadata::BlobMeta,
+) -> [u8; nydus_core::metadata::EROFS_BLOB_ID_SIZE] {
+    use nydus_core::metadata::{BlobFooter, NYDUS_BLOB_FOOTER_ALIGNMENT};
+
+    let data_size = data.len() as u64;
+    let bootstrap_offset = align_up(data_size, NYDUS_BLOB_FOOTER_ALIGNMENT);
+    let bootstrap_blocks = bytes_to_blocks(bootstrap_bytes.len() as u64);
+    let blob_meta_offset = align_up(
+        bootstrap_offset + bootstrap_bytes.len() as u64,
+        NYDUS_BLOB_FOOTER_ALIGNMENT,
+    );
+    let blob_meta_blocks = bytes_to_blocks(blob_meta.metadata_size());
+    let footer = BlobFooter::new(
+        0,
+        data_size,
+        bootstrap_offset,
+        bootstrap_blocks,
+        blob_meta_offset,
+        blob_meta_blocks,
+    )
+    .expect("footer");
+
+    let full_blob_path = blob_dir.join("full.blob");
+    let mut full_blob = std::fs::File::create(&full_blob_path).expect("create full blob");
+    full_blob.write_all(data).expect("write data");
+    write_zero_padding(&mut full_blob, data_size, bootstrap_offset).expect("pad data");
+    full_blob.write_all(bootstrap_bytes).expect("write bootstrap");
+    write_zero_padding(
+        &mut full_blob,
+        bootstrap_offset + bootstrap_bytes.len() as u64,
+        blob_meta_offset,
+    )
+    .expect("pad bootstrap");
+    blob_meta.write_to(&mut full_blob).expect("write blob meta");
+    footer.write_to(&mut full_blob).expect("write footer");
+    drop(full_blob);
+
+    let full_blob_id = nydus_core::utils::sha256_file(&full_blob_path).expect("hash full blob");
+    let final_path = blob_dir.join(nydus_core::utils::hex_string(&full_blob_id));
+    std::fs::rename(&full_blob_path, final_path).expect("rename full blob");
+    full_blob_id
+}

--- a/nydus-core/tests/core.rs
+++ b/nydus-core/tests/core.rs
@@ -4,7 +4,6 @@
 
 mod common;
 
-use common::{align_up, bytes_to_blocks, write_zero_padding};
 
 use std::collections::HashMap;
 use std::os::fd::AsRawFd;
@@ -19,14 +18,13 @@ use nydus::build::inode::{build_tree, set_root_prefetch_blobs_xattr};
 use nydus_core::config::Config;
 use nydus_core::fs::ErofsReader;
 use nydus_core::metadata::{
-    BlobFooter, BlobMetaCompressor, ErofsDeviceSlot, NYDUS_BLOB_FOOTER_ALIGNMENT,
+    BlobMetaCompressor, ErofsDeviceSlot,
 };
 use nydus_core::metadata::{EROFS_BLOB_ID_SIZE, EROFS_BLOCK_SIZE};
-use nydus_core::utils::{hex_string, sha256_file};
+use nydus_core::utils::hex_string;
 use nydus_core::{BlobId, FileType, NydusCore};
 use std::collections::HashSet;
 use std::fs;
-use std::io::Write;
 use std::os::unix::fs::symlink;
 use tempfile::tempdir;
 
@@ -167,42 +165,7 @@ fn write_full_blob(
     blob_meta: &nydus_core::metadata::BlobMeta,
 ) -> [u8; EROFS_BLOB_ID_SIZE] {
     let data = fs::read(data_path).unwrap();
-    let data_size = data.len() as u64;
-    let bootstrap_offset = align_up(data_size, NYDUS_BLOB_FOOTER_ALIGNMENT);
-    let bootstrap_blocks = bytes_to_blocks(bootstrap_bytes.len() as u64);
-    let blob_meta_offset = align_up(
-        bootstrap_offset + bootstrap_bytes.len() as u64,
-        NYDUS_BLOB_FOOTER_ALIGNMENT,
-    );
-    let blob_meta_blocks = bytes_to_blocks(blob_meta.metadata_size());
-    let footer = BlobFooter::new(
-        0,
-        data_size,
-        bootstrap_offset,
-        bootstrap_blocks,
-        blob_meta_offset,
-        blob_meta_blocks,
-    )
-    .unwrap();
-
-    let full_blob_path = blob_dir.join("full.blob");
-    let mut full_blob = fs::File::create(&full_blob_path).unwrap();
-    full_blob.write_all(&data).unwrap();
-    write_zero_padding(&mut full_blob, data_size, bootstrap_offset).unwrap();
-    full_blob.write_all(bootstrap_bytes).unwrap();
-    write_zero_padding(
-        &mut full_blob,
-        bootstrap_offset + bootstrap_bytes.len() as u64,
-        blob_meta_offset,
-    )
-    .unwrap();
-    blob_meta.write_to(&mut full_blob).unwrap();
-    footer.write_to(&mut full_blob).unwrap();
-    drop(full_blob);
-
-    let full_blob_id = sha256_file(&full_blob_path).unwrap();
-    let final_blob_path = blob_dir.join(hex_string(&full_blob_id));
-    fs::rename(&full_blob_path, &final_blob_path).unwrap();
+    let full_blob_id = common::assemble_full_blob(blob_dir, &data, bootstrap_bytes, blob_meta);
     blob_meta
         .save(&blob_dir.join(format!("{}.blob.meta", hex_string(&full_blob_id))))
         .unwrap();

--- a/nydus-core/tests/core.rs
+++ b/nydus-core/tests/core.rs
@@ -4,7 +4,6 @@
 
 mod common;
 
-
 use std::collections::HashMap;
 use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
@@ -17,9 +16,7 @@ use nydus::build::bootstrap::{
 use nydus::build::inode::{build_tree, set_root_prefetch_blobs_xattr};
 use nydus_core::config::Config;
 use nydus_core::fs::ErofsReader;
-use nydus_core::metadata::{
-    BlobMetaCompressor, ErofsDeviceSlot,
-};
+use nydus_core::metadata::{BlobMetaCompressor, ErofsDeviceSlot};
 use nydus_core::metadata::{EROFS_BLOB_ID_SIZE, EROFS_BLOCK_SIZE};
 use nydus_core::utils::hex_string;
 use nydus_core::{BlobId, FileType, NydusCore};

--- a/nydus-core/tests/erofs_reader.rs
+++ b/nydus-core/tests/erofs_reader.rs
@@ -4,7 +4,6 @@
 
 mod common;
 
-
 use std::collections::HashSet;
 use std::fs;
 use std::io::Write;
@@ -16,8 +15,8 @@ use nydus::build::bootstrap::render_bootstrap;
 use nydus::build::inode::{build_tree, DirEntry as BuildDirEntry, InodeData, InodeInfo};
 use nydus_core::fs::ErofsReader;
 use nydus_core::metadata::{
-    erofs_xattr_ibody_size, ChunkIndex, ErofsDeviceSlot, EROFS_BLKSZBITS,
-    EROFS_BLOCK_SIZE, EROFS_FT_REG_FILE, EROFS_XATTR_INDEX_USER,
+    erofs_xattr_ibody_size, ChunkIndex, ErofsDeviceSlot, EROFS_BLKSZBITS, EROFS_BLOCK_SIZE,
+    EROFS_FT_REG_FILE, EROFS_XATTR_INDEX_USER,
 };
 use nydus_core::utils::sha256_file;
 
@@ -155,7 +154,8 @@ fn reads_chunk_data_from_footer_based_full_blob() {
     let blob_meta = blob_writer.blob_meta(data_blob_id, 0).expect("blob meta");
 
     let data = fs::read(&data_path).expect("read data blob");
-    let full_blob_id = common::assemble_full_blob(dir.path(), &data, &embedded_bootstrap, &blob_meta);
+    let full_blob_id =
+        common::assemble_full_blob(dir.path(), &data, &embedded_bootstrap, &blob_meta);
 
     let standalone_device_slots = [ErofsDeviceSlot::with_blob_id(
         blob_writer.total_blocks(),

--- a/nydus-core/tests/erofs_reader.rs
+++ b/nydus-core/tests/erofs_reader.rs
@@ -4,7 +4,6 @@
 
 mod common;
 
-use common::{align_up, bytes_to_blocks, write_zero_padding};
 
 use std::collections::HashSet;
 use std::fs;
@@ -17,8 +16,8 @@ use nydus::build::bootstrap::render_bootstrap;
 use nydus::build::inode::{build_tree, DirEntry as BuildDirEntry, InodeData, InodeInfo};
 use nydus_core::fs::ErofsReader;
 use nydus_core::metadata::{
-    erofs_xattr_ibody_size, BlobFooter, ChunkIndex, ErofsDeviceSlot, EROFS_BLKSZBITS,
-    EROFS_BLOCK_SIZE, EROFS_FT_REG_FILE, EROFS_XATTR_INDEX_USER, NYDUS_BLOB_FOOTER_ALIGNMENT,
+    erofs_xattr_ibody_size, ChunkIndex, ErofsDeviceSlot, EROFS_BLKSZBITS,
+    EROFS_BLOCK_SIZE, EROFS_FT_REG_FILE, EROFS_XATTR_INDEX_USER,
 };
 use nydus_core::utils::sha256_file;
 
@@ -73,7 +72,7 @@ fn reads_large_xattrs_and_chunk_indexes_after_large_ibody() {
             meta_offset: 0,
             is_extended: false,
             data: InodeData::RegularFile {
-                chunk_indexes: vec![
+                chunk_index_entries: vec![
                     ChunkIndex {
                         blkaddr: 11,
                         device_id: 0,
@@ -112,14 +111,14 @@ fn reads_large_xattrs_and_chunk_indexes_after_large_ibody() {
         assert_eq!(value, expected_value);
     }
 
-    let chunk_indexes = reader
-        .read_chunk_indexes(file_nid, &inode)
+    let chunk_index_entries = reader
+        .read_chunk_index_entries(file_nid, &inode)
         .expect("read chunk indexes");
-    assert_eq!(chunk_indexes.len(), 2);
-    assert_eq!(chunk_indexes[0].blkaddr, 11);
-    assert_eq!(chunk_indexes[0].device_id, 0);
-    assert_eq!(chunk_indexes[1].blkaddr, 22);
-    assert_eq!(chunk_indexes[1].device_id, 0);
+    assert_eq!(chunk_index_entries.len(), 2);
+    assert_eq!(chunk_index_entries[0].blkaddr, 11);
+    assert_eq!(chunk_index_entries[0].device_id, 0);
+    assert_eq!(chunk_index_entries[1].blkaddr, 22);
+    assert_eq!(chunk_index_entries[1].device_id, 0);
 }
 
 #[test]
@@ -155,47 +154,8 @@ fn reads_chunk_data_from_footer_based_full_blob() {
     .expect("render embedded bootstrap");
     let blob_meta = blob_writer.blob_meta(data_blob_id, 0).expect("blob meta");
 
-    let data_size = fs::metadata(&data_path).expect("stat data blob").len();
-    let bootstrap_offset = align_up(data_size, NYDUS_BLOB_FOOTER_ALIGNMENT);
-    let bootstrap_blocks = bytes_to_blocks(embedded_bootstrap.len() as u64);
-    let blob_meta_offset = align_up(
-        bootstrap_offset + embedded_bootstrap.len() as u64,
-        NYDUS_BLOB_FOOTER_ALIGNMENT,
-    );
-    let blob_meta_blocks = bytes_to_blocks(blob_meta.metadata_size());
-    let footer = BlobFooter::new(
-        0,
-        data_size,
-        bootstrap_offset,
-        bootstrap_blocks,
-        blob_meta_offset,
-        blob_meta_blocks,
-    )
-    .expect("footer");
-
-    let full_blob_path = dir.path().join("full.blob");
-    let mut full_blob = fs::File::create(&full_blob_path).expect("create full blob");
     let data = fs::read(&data_path).expect("read data blob");
-    full_blob.write_all(&data).expect("write data blob");
-    write_zero_padding(&mut full_blob, data_size, bootstrap_offset).expect("pad data");
-    full_blob
-        .write_all(&embedded_bootstrap)
-        .expect("write bootstrap");
-    write_zero_padding(
-        &mut full_blob,
-        bootstrap_offset + embedded_bootstrap.len() as u64,
-        blob_meta_offset,
-    )
-    .expect("pad bootstrap");
-    blob_meta.write_to(&mut full_blob).expect("write blob meta");
-    footer.write_to(&mut full_blob).expect("write footer");
-    drop(full_blob);
-
-    let full_blob_id = sha256_file(&full_blob_path).expect("hash full blob");
-    let final_full_blob_path = dir
-        .path()
-        .join(nydus_core::utils::hex_string(&full_blob_id));
-    fs::rename(&full_blob_path, final_full_blob_path).expect("rename full blob");
+    let full_blob_id = common::assemble_full_blob(dir.path(), &data, &embedded_bootstrap, &blob_meta);
 
     let standalone_device_slots = [ErofsDeviceSlot::with_blob_id(
         blob_writer.total_blocks(),
@@ -230,7 +190,7 @@ fn reads_chunk_data_from_footer_based_full_blob() {
         .nid;
     let inode = reader.inode(file_nid).expect("file inode");
     let data = reader
-        .read_file_data_sync(file_nid, &inode, 0, inode.size() as u32)
+        .read_file_data(file_nid, &inode, 0, inode.size() as u32)
         .expect("read file data");
 
     assert_eq!(data, b"hello nydus\n");

--- a/nydus/src/bin/nydus/build.rs
+++ b/nydus/src/bin/nydus/build.rs
@@ -1,6 +1,6 @@
+use crate::cli_common;
 use anyhow::{bail, Context, Result};
 use clap::{Args, ValueEnum};
-use crate::cli_common;
 use nydus::build::blob_chunk::BlobWriter;
 use nydus::build::bootstrap::{render_bootstrap, render_flattened_bootstrap};
 use nydus::build::inode::{build_tree, set_root_prefetch_blobs_xattr};

--- a/nydus/src/bin/nydus/build.rs
+++ b/nydus/src/bin/nydus/build.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Context, Result};
 use clap::{Args, ValueEnum};
+use crate::cli_common;
 use nydus::build::blob_chunk::BlobWriter;
 use nydus::build::bootstrap::{render_bootstrap, render_flattened_bootstrap};
 use nydus::build::inode::{build_tree, set_root_prefetch_blobs_xattr};
@@ -14,7 +15,6 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufWriter, Write};
 use std::os::unix::fs::FileTypeExt;
 use std::path::{Path, PathBuf};
-use tracing::Level;
 
 const MIB: u32 = 1_048_576;
 const DEFAULT_CHUNK_SIZE: u32 = MIB;
@@ -82,21 +82,8 @@ pub struct BuildArgs {
     #[arg(long, value_enum, default_value_t = Compressor::Zstd)]
     pub compressor: Compressor,
 
-    #[arg(
-        short = 'l',
-        long,
-        default_value = "info",
-        help = "Specify the logging level [trace, debug, info, warn, error]"
-    )]
-    pub log_level: Level,
-
-    #[arg(
-        long,
-        hide = true,
-        default_value_t = true,
-        help = "Specify whether to print log"
-    )]
-    pub console: bool,
+    #[command(flatten)]
+    pub log: cli_common::CommandLogArgs,
 
     /// Absolute or current-working-directory-relative paths to exclude.
     /// May be specified multiple times. Entries inside the source tree are
@@ -111,9 +98,9 @@ pub fn run_build(args: BuildArgs) -> Result<()> {
         args.conversion_type == ConversionType::NydusTar && args.output == Path::new("-");
     // Logging to stdout would corrupt a tar stream written to stdout.
     let _guards = if tar_to_stdout {
-        init_command_tracing_stderr(args.log_level, args.console)
+        init_command_tracing_stderr(args.log.log_level, args.log.console)
     } else {
-        init_command_tracing(args.log_level, args.console)
+        init_command_tracing(args.log.log_level, args.log.console)
     };
 
     match args.conversion_type {
@@ -161,20 +148,20 @@ fn run_dir_to_nydus(args: BuildArgs) -> Result<()> {
         }
     }
 
-    // Validate EROFS file chunksize. BlobMeta groups are formed separately and
+    // Validate EROFS file chunk size. BlobMeta groups are formed separately and
     // are at least 1MiB even when file chunk indexes are smaller.
     if args.chunk_size < EROFS_BLOCK_SIZE {
         bail!(
-            "chunksize {} must be >= block size {}",
+            "chunk size {} must be >= block size {}",
             args.chunk_size,
             EROFS_BLOCK_SIZE
         );
     }
     if !args.chunk_size.is_power_of_two() {
-        bail!("chunksize {} must be a power of two", args.chunk_size);
+        bail!("chunk size {} must be a power of two", args.chunk_size);
     }
     if args.chunk_size % EROFS_BLOCK_SIZE != 0 {
-        bail!("chunksize {} must be block aligned", args.chunk_size);
+        bail!("chunk size {} must be block aligned", args.chunk_size);
     }
     let chunkbits = args.chunk_size.trailing_zeros();
 
@@ -597,8 +584,10 @@ mod tests {
             chunk_size: DEFAULT_CHUNK_SIZE,
             compress_size: DEFAULT_COMPRESS_SIZE,
             compressor: Compressor::Zstd,
-            log_level: Level::ERROR,
-            console: false,
+            log: crate::cli_common::CommandLogArgs {
+                log_level: tracing::Level::ERROR,
+                console: false,
+            },
             exclude: Vec::new(),
         })
         .unwrap();
@@ -743,8 +732,10 @@ mod tests {
             chunk_size: DEFAULT_CHUNK_SIZE,
             compress_size: DEFAULT_COMPRESS_SIZE,
             compressor: Compressor::Zstd,
-            log_level: Level::ERROR,
-            console: false,
+            log: crate::cli_common::CommandLogArgs {
+                log_level: tracing::Level::ERROR,
+                console: false,
+            },
             exclude: Vec::new(),
         })
         .unwrap_err();
@@ -763,8 +754,10 @@ mod tests {
             chunk_size: EROFS_BLOCK_SIZE,
             compress_size: MIB,
             compressor: Compressor::Zstd,
-            log_level: Level::ERROR,
-            console: false,
+            log: crate::cli_common::CommandLogArgs {
+                log_level: tracing::Level::ERROR,
+                console: false,
+            },
             exclude: Vec::new(),
         })
         .unwrap();
@@ -779,8 +772,10 @@ mod tests {
             chunk_size: DEFAULT_CHUNK_SIZE,
             compress_size: DEFAULT_COMPRESS_SIZE,
             compressor: Compressor::Zstd,
-            log_level: Level::ERROR,
-            console: false,
+            log: crate::cli_common::CommandLogArgs {
+                log_level: tracing::Level::ERROR,
+                console: false,
+            },
             exclude: Vec::new(),
         })
         .unwrap();

--- a/nydus/src/bin/nydus/check.rs
+++ b/nydus/src/bin/nydus/check.rs
@@ -354,11 +354,11 @@ fn walk_inode(
                     stats.chunked_files += 1;
                     let chunk_size = 1u64 << chunkbits(reader, &inode);
                     stats.chunk_sizes.insert(chunk_size);
-                    let chunk_indexes = reader.read_chunk_indexes(nid, &inode)?;
-                    stats.total_chunks += chunk_indexes.len() as u64;
+                    let chunk_index_entries = reader.read_chunk_index_entries(nid, &inode)?;
+                    stats.total_chunks += chunk_index_entries.len() as u64;
                     stats.total_logical_bytes += inode.size();
 
-                    for (index, chunk) in chunk_indexes.iter().enumerate() {
+                    for (index, chunk) in chunk_index_entries.iter().enumerate() {
                         let remaining = inode.size().saturating_sub(index as u64 * chunk_size);
                         let logical_bytes = remaining.min(chunk_size);
                         // Hole chunks reference no blob at all (their on-disk
@@ -535,7 +535,7 @@ fn inspect_blob(path: &Path) -> Result<Option<BlobInspection>> {
 }
 
 fn blob_meta_summary_from_bytes(data: &[u8]) -> Result<BlobMetaSummary> {
-    let blob_meta = BlobMeta::from_bytes_with_blob_id(data, [0u8; EROFS_BLOB_ID_SIZE])?;
+    let blob_meta = BlobMeta::loader().from_bytes(data)?;
     Ok(BlobMetaSummary {
         chunk_count: blob_meta.chunk_count(),
         group_count: blob_meta.group_count(),

--- a/nydus/src/bin/nydus/cli_common.rs
+++ b/nydus/src/bin/nydus/cli_common.rs
@@ -1,0 +1,86 @@
+//! Shared CLI plumbing for the `nydus` subcommands: the log flag blocks that
+//! every command repeats, and the daemon startup preamble (signal
+//! registration + tracing + storage config).
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::Args;
+use nydus::config::Config;
+use nydus::tracing::init_tracing;
+use signal_hook::consts::{signal::SIGHUP, TERM_SIGNALS};
+use signal_hook::iterator::Signals;
+use tracing::Level;
+use tracing_appender::non_blocking::WorkerGuard;
+
+/// Log flags shared by the long-running daemon subcommands
+/// (fuse/fanotify/nbd/ublk/uffd). Flatten with `#[command(flatten)]`.
+#[derive(Args)]
+pub struct DaemonLogArgs {
+    #[arg(
+        short = 'l',
+        long,
+        default_value = "info",
+        help = "Specify the logging level [trace, debug, info, warn, error]"
+    )]
+    pub log_level: Level,
+
+    #[arg(
+        long,
+        default_value_os_t = PathBuf::from("/var/log/nydus/"),
+        help = "Specify the log directory"
+    )]
+    pub log_dir: PathBuf,
+
+    #[arg(
+        long,
+        default_value_t = 6,
+        help = "Specify the max number of log files"
+    )]
+    pub log_max_files: usize,
+
+    #[arg(long, hide = true, default_value_t = true)]
+    pub console: bool,
+}
+
+/// Log flags shared by the one-shot commands (build/merge/optimize/check),
+/// which log to the console only.
+#[derive(Args)]
+pub struct CommandLogArgs {
+    #[arg(
+        short = 'l',
+        long,
+        default_value = "info",
+        help = "Specify the logging level [trace, debug, info, warn, error]"
+    )]
+    pub log_level: Level,
+
+    #[arg(
+        long,
+        hide = true,
+        default_value_t = true,
+        help = "Specify whether to print log"
+    )]
+    pub console: bool,
+}
+
+/// The daemon startup preamble shared by uffd/nbd/ublk/fanotify: register
+/// termination signals (TERM set + SIGHUP), initialize file tracing, and load
+/// the storage config. The returned guards must stay alive for the daemon's
+/// lifetime or file logging stops.
+pub fn daemon_preamble(
+    log: &DaemonLogArgs,
+    config_path: &Path,
+) -> Result<(Signals, Vec<WorkerGuard>, Config)> {
+    let signals = Signals::new(TERM_SIGNALS.iter().copied().chain([SIGHUP]))
+        .context("failed to register termination signals")?;
+    let guards = init_tracing(
+        "nydus",
+        log.log_dir.clone(),
+        log.log_level,
+        log.log_max_files,
+        log.console,
+    );
+    let config = Config::from_file(config_path).context("failed to load storage config")?;
+    Ok((signals, guards, config))
+}

--- a/nydus/src/bin/nydus/fanotify.rs
+++ b/nydus/src/bin/nydus/fanotify.rs
@@ -6,12 +6,11 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use clap::Args;
-use nydus::config::Config;
-use nydus::fanotify::{mount_erofs, unmount_erofs, FanotifyCore, FanotifyService};
-use nydus::tracing::init_tracing;
-use signal_hook::consts::{signal::SIGHUP, TERM_SIGNALS};
-use signal_hook::iterator::Signals;
-use tracing::{debug, error, info, warn, Level};
+
+use crate::cli_common;
+use nydus::fanotify::{mount_erofs, FanotifyCore, FanotifyService};
+use nydus::utils::unmount;
+use tracing::{debug, error, info, warn};
 
 const STOP_WAKE_BYTES: usize = 1;
 
@@ -43,30 +42,8 @@ pub struct FanotifyArgs {
     #[arg(long, default_value_t = default_fetch_concurrency())]
     pub fetch_concurrency: NonZeroUsize,
 
-    #[arg(
-        short = 'l',
-        long,
-        default_value = "info",
-        help = "Specify the logging level [trace, debug, info, warn, error]"
-    )]
-    pub log_level: Level,
-
-    #[arg(
-        long,
-        default_value_os_t = PathBuf::from("/var/log/nydus/"),
-        help = "Specify the log directory"
-    )]
-    pub log_dir: PathBuf,
-
-    #[arg(
-        long,
-        default_value_t = 6,
-        help = "Specify the max number of log files"
-    )]
-    pub log_max_files: usize,
-
-    #[arg(long, hide = true, default_value_t = true)]
-    pub console: bool,
+    #[command(flatten)]
+    pub log: cli_common::DaemonLogArgs,
 }
 
 fn default_fetch_concurrency() -> NonZeroUsize {
@@ -109,21 +86,10 @@ fn raise_nofile_limit() {
 }
 
 pub fn run_fanotify(args: FanotifyArgs) -> Result<()> {
-    let mut signals = Signals::new(TERM_SIGNALS.iter().copied().chain([SIGHUP]))
-        .context("failed to register termination signals")?;
+    let (mut signals, _guards, config) = cli_common::daemon_preamble(&args.log, &args.config)?;
     let signal_handle = signals.handle();
 
-    let _guards = init_tracing(
-        "nydus",
-        args.log_dir.clone(),
-        args.log_level,
-        args.log_max_files,
-        args.console,
-    );
-
     raise_nofile_limit();
-
-    let config = Config::from_file(&args.config).context("failed to load storage config")?;
     let core = std::sync::Arc::new(
         FanotifyCore::new(&args.bootstrap, config).context("failed to build fanotify core")?,
     );
@@ -233,7 +199,7 @@ pub fn run_fanotify(args: FanotifyArgs) -> Result<()> {
     // racing the shutdown gets EPERM (fail-closed) instead of blocking forever
     // and wedging the unmount.
     for attempt in 1..=UNMOUNT_RETRY_ATTEMPTS {
-        match unmount_erofs(&mountpoint) {
+        match unmount(&mountpoint) {
             Ok(()) => {
                 info!("unmounted {}", mountpoint.display());
                 break;

--- a/nydus/src/bin/nydus/fuse.rs
+++ b/nydus/src/bin/nydus/fuse.rs
@@ -1,5 +1,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use clap::Args;
+
+use crate::cli_common;
 use fuser::{Config as FuseConfig, MountOption, Session, SessionACL};
 use nydus::config::Config;
 use nydus::fs::ErofsReader;
@@ -15,7 +17,7 @@ use std::sync::mpsc;
 use std::sync::Arc;
 use std::thread::available_parallelism;
 use std::time::Duration;
-use tracing::{error, info, warn, Level};
+use tracing::{error, info, warn};
 
 struct TermSignalMask {
     mask: libc::sigset_t,
@@ -236,35 +238,8 @@ pub struct FuseArgs {
     #[arg(long)]
     pub apiserver: Option<String>,
 
-    #[arg(
-        short = 'l',
-        long,
-        default_value = "info",
-        help = "Specify the logging level [trace, debug, info, warn, error]"
-    )]
-    pub log_level: Level,
-
-    #[arg(
-        long,
-        default_value_os_t = PathBuf::from("/var/log/nydus/"),
-        help = "Specify the log directory"
-    )]
-    pub log_dir: PathBuf,
-
-    #[arg(
-        long,
-        default_value_t = 6,
-        help = "Specify the max number of log files"
-    )]
-    pub log_max_files: usize,
-
-    #[arg(
-        long,
-        hide = true,
-        default_value_t = true,
-        help = "Specify whether to print log"
-    )]
-    pub console: bool,
+    #[command(flatten)]
+    pub log: cli_common::DaemonLogArgs,
 }
 
 /// Determine the default number of worker threads for FUSE mounting, clamped to a reasonable
@@ -282,10 +257,10 @@ pub fn run_fuse(args: FuseArgs) -> Result<()> {
 
     let _guards = init_tracing(
         "nydus",
-        args.log_dir.clone(),
-        args.log_level,
-        args.log_max_files,
-        args.console,
+        args.log.log_dir.clone(),
+        args.log.log_level,
+        args.log.log_max_files,
+        args.log.console,
     );
 
     let mountpoint = &args.mountpoint;

--- a/nydus/src/bin/nydus/main.rs
+++ b/nydus/src/bin/nydus/main.rs
@@ -1,9 +1,9 @@
 // nydus — single CLI for nydus image creation, merge and mounting.
 
 mod api_server;
-mod cli_common;
 mod build;
 mod check;
+mod cli_common;
 #[cfg(feature = "fanotify")]
 mod fanotify;
 mod fuse;

--- a/nydus/src/bin/nydus/main.rs
+++ b/nydus/src/bin/nydus/main.rs
@@ -1,6 +1,7 @@
 // nydus — single CLI for nydus image creation, merge and mounting.
 
 mod api_server;
+mod cli_common;
 mod build;
 mod check;
 #[cfg(feature = "fanotify")]

--- a/nydus/src/bin/nydus/merge.rs
+++ b/nydus/src/bin/nydus/merge.rs
@@ -1,11 +1,11 @@
 use anyhow::{Context, Result};
 use clap::{Args, ValueEnum};
+use crate::cli_common;
 use nydus::merge::{merge_sources_to_bootstrap_bytes, WhiteoutSpec as MergeWhiteoutSpec};
 use nydus::tracing::init_command_tracing;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
-use tracing::Level;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
 pub enum WhiteoutSpec {
@@ -26,20 +26,12 @@ pub struct MergeArgs {
     #[arg(long, value_enum, default_value_t = WhiteoutSpec::Oci)]
     pub whiteout_spec: WhiteoutSpec,
 
-    #[arg(
-        short = 'l',
-        long,
-        default_value = "info",
-        help = "Specify the logging level [trace, debug, info, warn, error]"
-    )]
-    pub log_level: Level,
-
-    #[arg(long, hide = true, default_value_t = true)]
-    pub console: bool,
+    #[command(flatten)]
+    pub log: cli_common::CommandLogArgs,
 }
 
 pub fn run_merge(args: MergeArgs) -> Result<()> {
-    let _guards = init_command_tracing(args.log_level, args.console);
+    let _guards = init_command_tracing(args.log.log_level, args.log.console);
 
     let whiteout_spec = match args.whiteout_spec {
         WhiteoutSpec::Oci => MergeWhiteoutSpec::Oci,

--- a/nydus/src/bin/nydus/merge.rs
+++ b/nydus/src/bin/nydus/merge.rs
@@ -1,6 +1,6 @@
+use crate::cli_common;
 use anyhow::{Context, Result};
 use clap::{Args, ValueEnum};
-use crate::cli_common;
 use nydus::merge::{merge_sources_to_bootstrap_bytes, WhiteoutSpec as MergeWhiteoutSpec};
 use nydus::tracing::init_command_tracing;
 use std::fs::File;

--- a/nydus/src/bin/nydus/nbd.rs
+++ b/nydus/src/bin/nydus/nbd.rs
@@ -4,12 +4,11 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use clap::Args;
-use nydus::config::Config;
-use nydus::nbd::{mount_nbd, unmount_nbd, NbdCore, NbdService};
-use nydus::tracing::init_tracing;
-use signal_hook::consts::{signal::SIGHUP, TERM_SIGNALS};
-use signal_hook::iterator::Signals;
-use tracing::{debug, error, info, warn, Level};
+
+use crate::cli_common;
+use nydus::nbd::{mount_nbd, NbdCore, NbdService};
+use nydus::utils::unmount;
+use tracing::{debug, error, info, warn};
 
 /// EBUSY is expected while readers still hold files open, so keep trying for a
 /// bounded window before giving up — mirrors the fanotify shutdown ordering.
@@ -54,30 +53,8 @@ pub struct NbdArgs {
     #[arg(long)]
     pub mountpoint: Option<PathBuf>,
 
-    #[arg(
-        short = 'l',
-        long,
-        default_value = "info",
-        help = "Specify the logging level [trace, debug, info, warn, error]"
-    )]
-    pub log_level: Level,
-
-    #[arg(
-        long,
-        default_value_os_t = PathBuf::from("/var/log/nydus/"),
-        help = "Specify the log directory"
-    )]
-    pub log_dir: PathBuf,
-
-    #[arg(
-        long,
-        default_value_t = 6,
-        help = "Specify the max number of log files"
-    )]
-    pub log_max_files: usize,
-
-    #[arg(long, hide = true, default_value_t = true)]
-    pub console: bool,
+    #[command(flatten)]
+    pub log: cli_common::DaemonLogArgs,
 }
 
 /// Default worker-thread cap: connection-level parallelism saturates well
@@ -103,19 +80,8 @@ fn is_not_mounted(err: &anyhow::Error) -> bool {
 }
 
 pub fn run_nbd(args: NbdArgs) -> Result<()> {
-    let mut signals = Signals::new(TERM_SIGNALS.iter().copied().chain([SIGHUP]))
-        .context("failed to register termination signals")?;
+    let (mut signals, _guards, config) = cli_common::daemon_preamble(&args.log, &args.config)?;
     let signal_handle = signals.handle();
-
-    let _guards = init_tracing(
-        "nydus",
-        args.log_dir.clone(),
-        args.log_level,
-        args.log_max_files,
-        args.console,
-    );
-
-    let config = Config::from_file(&args.config).context("failed to load storage config")?;
     let core = Arc::new(NbdCore::new(&args.bootstrap, config).context("failed to build nbd core")?);
     let service = Arc::new(NbdService::new(
         core.clone(),
@@ -165,7 +131,7 @@ pub fn run_nbd(args: NbdArgs) -> Result<()> {
                     info!("received signal {signal}, stopping nydus nbd service");
                     if let Some(mp) = &signal_mountpoint {
                         for attempt in 1..=UNMOUNT_RETRY_ATTEMPTS {
-                            match unmount_nbd(mp) {
+                            match unmount(mp) {
                                 Ok(()) => {
                                     info!("unmounted {}", mp.display());
                                     break;
@@ -228,7 +194,7 @@ pub fn run_nbd(args: NbdArgs) -> Result<()> {
                 // The signal path already unmounted on a signal-driven
                 // shutdown; if the session self-exited the mount is still up
                 // over a dead device, so try a final best-effort umount.
-                if let Err(err) = unmount_nbd(&mp) {
+                if let Err(err) = unmount(&mp) {
                     debug!("post-join unmount of {}: {err:#}", mp.display());
                 }
                 joined

--- a/nydus/src/bin/nydus/optimize.rs
+++ b/nydus/src/bin/nydus/optimize.rs
@@ -2,17 +2,17 @@ use anyhow::{bail, Context, Result};
 use clap::Args;
 
 use crate::cli_common;
+use nydus::build::blob_chunk::compression_is_worthwhile;
 use nydus::config::Config;
 use nydus::fs::{ErofsReader, RawBlobInfo};
-use nydus::{TraceDocument, TraceEntry};
-use nydus::metrics::trace::TRACE_DOCUMENT_VERSION;
-use nydus::build::blob_chunk::compression_is_worthwhile;
 use nydus::merge::rewrite_bootstrap_with_ondemand_blob;
 use nydus::metadata::*;
+use nydus::metrics::trace::TRACE_DOCUMENT_VERSION;
 use nydus::storage::backend::build_backend;
 use nydus::storage::cache::{BlobCache, LocalBlobCache};
 use nydus::tracing::init_command_tracing;
 use nydus::utils::{align_up, hex_string};
+use nydus::{TraceDocument, TraceEntry};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fs;
@@ -20,7 +20,7 @@ use std::io::{Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::time::Duration;
-use tracing::{info};
+use tracing::info;
 
 #[derive(Args)]
 pub struct OptimizeArgs {

--- a/nydus/src/bin/nydus/optimize.rs
+++ b/nydus/src/bin/nydus/optimize.rs
@@ -1,14 +1,18 @@
 use anyhow::{bail, Context, Result};
 use clap::Args;
+
+use crate::cli_common;
 use nydus::config::Config;
 use nydus::fs::{ErofsReader, RawBlobInfo};
+use nydus::{TraceDocument, TraceEntry};
+use nydus::metrics::trace::TRACE_DOCUMENT_VERSION;
+use nydus::build::blob_chunk::compression_is_worthwhile;
 use nydus::merge::rewrite_bootstrap_with_ondemand_blob;
 use nydus::metadata::*;
 use nydus::storage::backend::build_backend;
 use nydus::storage::cache::{BlobCache, LocalBlobCache};
 use nydus::tracing::init_command_tracing;
 use nydus::utils::{align_up, hex_string};
-use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fs;
@@ -16,9 +20,7 @@ use std::io::{Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::time::Duration;
-use tracing::{info, Level};
-
-const MAX_COMPRESSED_SIZE_PERCENT: u128 = 70;
+use tracing::{info};
 
 #[derive(Args)]
 pub struct OptimizeArgs {
@@ -53,41 +55,13 @@ pub struct OptimizeArgs {
     #[arg(long)]
     pub config: PathBuf,
 
-    #[arg(
-        short = 'l',
-        long,
-        default_value = "info",
-        help = "Specify the logging level [trace, debug, info, warn, error]"
-    )]
-    pub log_level: Level,
-
-    #[arg(
-        long,
-        hide = true,
-        default_value_t = true,
-        help = "Specify whether to print log"
-    )]
-    pub console: bool,
+    #[command(flatten)]
+    pub log: cli_common::CommandLogArgs,
 }
-
-#[derive(Deserialize)]
-struct TraceEnvelope {
-    version: u32,
-    patterns: Vec<TraceEntry>,
-}
-
-#[derive(Deserialize)]
-struct TraceEntry {
-    blob_index: u32,
-    group_index: u32,
-}
-
-/// Supported trace document version (see `metrics::trace::TRACE_DOCUMENT_VERSION`).
-const TRACE_DOCUMENT_VERSION: u32 = 1;
 
 /// Parse the versioned trace document `{"version":1,"patterns":[...]}`.
 fn parse_trace_document(raw: &[u8]) -> Result<Vec<(u16, u32)>> {
-    let envelope: TraceEnvelope =
+    let envelope: TraceDocument =
         serde_json::from_slice(raw).context("failed to parse trace document")?;
     if envelope.version != TRACE_DOCUMENT_VERSION {
         bail!("unsupported trace document version: {}", envelope.version);
@@ -99,7 +73,7 @@ fn parse_trace_document(raw: &[u8]) -> Result<Vec<(u16, u32)>> {
 /// the bootstrap so the runtime prefetches it first, warming the source blobs'
 /// caches in recorded access order before on-demand reads arrive.
 pub fn run_optimize(args: OptimizeArgs) -> Result<()> {
-    let _guards = init_command_tracing(args.log_level, args.console);
+    let _guards = init_command_tracing(args.log.log_level, args.log.console);
 
     if args.parent_bootstrap == args.bootstrap {
         bail!("--parent-bootstrap and --bootstrap must point to different files");
@@ -388,10 +362,6 @@ fn assemble_artifact(data: &[u8], blob_meta: &BlobMeta) -> Result<(Vec<u8>, [u8;
     let mut digest = [0u8; 32];
     digest.copy_from_slice(&hasher.finalize());
     Ok((artifact, digest, footer))
-}
-
-fn compression_is_worthwhile(compressed_len: usize, uncompressed_len: usize) -> bool {
-    (compressed_len as u128) * 100 <= (uncompressed_len as u128) * MAX_COMPRESSED_SIZE_PERCENT
 }
 
 #[cfg(test)]

--- a/nydus/src/bin/nydus/ublk.rs
+++ b/nydus/src/bin/nydus/ublk.rs
@@ -3,14 +3,12 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use clap::Args;
-use nydus::config::Config;
-use nydus::tracing::init_tracing;
+
+use crate::cli_common;
 use nydus::ublk::{
     default_queues, UblkCore, UblkOptions, UblkService, DEFAULT_IO_BUF_BYTES, DEFAULT_QUEUE_DEPTH,
 };
-use signal_hook::consts::{signal::SIGHUP, TERM_SIGNALS};
-use signal_hook::iterator::Signals;
-use tracing::{info, Level};
+use tracing::{info};
 
 #[derive(Args)]
 pub struct UblkArgs {
@@ -45,30 +43,8 @@ pub struct UblkArgs {
     #[arg(long)]
     pub unprivileged: bool,
 
-    #[arg(
-        short = 'l',
-        long,
-        default_value = "info",
-        help = "Specify the logging level [trace, debug, info, warn, error]"
-    )]
-    pub log_level: Level,
-
-    #[arg(
-        long,
-        default_value_os_t = PathBuf::from("/var/log/nydus/"),
-        help = "Specify the log directory"
-    )]
-    pub log_dir: PathBuf,
-
-    #[arg(
-        long,
-        default_value_t = 6,
-        help = "Specify the max number of log files"
-    )]
-    pub log_max_files: usize,
-
-    #[arg(long, hide = true, default_value_t = true)]
-    pub console: bool,
+    #[command(flatten)]
+    pub log: cli_common::DaemonLogArgs,
 }
 
 /// Serve a nydus image as a read-only ublk block device.
@@ -80,19 +56,8 @@ pub struct UblkArgs {
 /// device. Otherwise the unmount triggered while the daemon exits flushes I/O
 /// to a device that is no longer being served, and both sides deadlock.
 pub fn run_ublk(args: UblkArgs) -> Result<()> {
-    let mut signals = Signals::new(TERM_SIGNALS.iter().copied().chain([SIGHUP]))
-        .context("failed to register termination signals")?;
+    let (mut signals, _guards, config) = cli_common::daemon_preamble(&args.log, &args.config)?;
     let signal_handle = signals.handle();
-
-    let _guards = init_tracing(
-        "nydus",
-        args.log_dir.clone(),
-        args.log_level,
-        args.log_max_files,
-        args.console,
-    );
-
-    let config = Config::from_file(&args.config).context("failed to load storage config")?;
     let core = Arc::new(UblkCore::new(&args.bootstrap, config)?);
     info!(
         "serving {} as a {} byte block device",

--- a/nydus/src/bin/nydus/ublk.rs
+++ b/nydus/src/bin/nydus/ublk.rs
@@ -8,7 +8,7 @@ use crate::cli_common;
 use nydus::ublk::{
     default_queues, UblkCore, UblkOptions, UblkService, DEFAULT_IO_BUF_BYTES, DEFAULT_QUEUE_DEPTH,
 };
-use tracing::{info};
+use tracing::info;
 
 #[derive(Args)]
 pub struct UblkArgs {

--- a/nydus/src/bin/nydus/uffd.rs
+++ b/nydus/src/bin/nydus/uffd.rs
@@ -4,12 +4,9 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use clap::Args;
-use nydus::config::Config;
-use nydus::tracing::init_tracing;
+
+use crate::cli_common;
 use nydus::uffd::{UffdCore, UffdService};
-use signal_hook::consts::{signal::SIGHUP, TERM_SIGNALS};
-use signal_hook::iterator::Signals;
-use tracing::Level;
 
 #[derive(Args)]
 pub struct UffdArgs {
@@ -29,46 +26,13 @@ pub struct UffdArgs {
     #[arg(long)]
     pub threads: Option<NonZeroUsize>,
 
-    #[arg(
-        short = 'l',
-        long,
-        default_value = "info",
-        help = "Specify the logging level [trace, debug, info, warn, error]"
-    )]
-    pub log_level: Level,
-
-    #[arg(
-        long,
-        default_value_os_t = PathBuf::from("/var/log/nydus/"),
-        help = "Specify the log directory"
-    )]
-    pub log_dir: PathBuf,
-
-    #[arg(
-        long,
-        default_value_t = 6,
-        help = "Specify the max number of log files"
-    )]
-    pub log_max_files: usize,
-
-    #[arg(long, hide = true, default_value_t = true)]
-    pub console: bool,
+    #[command(flatten)]
+    pub log: cli_common::DaemonLogArgs,
 }
 
 pub fn run_uffd(args: UffdArgs) -> Result<()> {
-    let mut signals = Signals::new(TERM_SIGNALS.iter().copied().chain([SIGHUP]))
-        .context("failed to register termination signals")?;
+    let (mut signals, _guards, config) = cli_common::daemon_preamble(&args.log, &args.config)?;
     let signal_handle = signals.handle();
-
-    let _guards = init_tracing(
-        "nydus",
-        args.log_dir.clone(),
-        args.log_level,
-        args.log_max_files,
-        args.console,
-    );
-
-    let config = Config::from_file(&args.config).context("failed to load storage config")?;
     let core = Arc::new(UffdCore::new(&args.bootstrap, config)?);
     let service = Arc::new(UffdService::new(core, args.socket));
     let signal_service = service.clone();

--- a/nydus/src/build/blob_chunk.rs
+++ b/nydus/src/build/blob_chunk.rs
@@ -29,8 +29,8 @@ pub struct BlobWriter {
 const MAX_COMPRESSED_SIZE_PERCENT: u128 = 70;
 
 impl BlobWriter {
-    pub fn new(path: &Path, chunksize: u32) -> Result<Self> {
-        Self::new_with_compressor(path, chunksize, BlobMetaCompressor::None)
+    pub fn new(path: &Path, chunk_size: u32) -> Result<Self> {
+        Self::new_with_compressor(path, chunk_size, BlobMetaCompressor::None)
     }
 
     pub fn new_with_compressor(
@@ -39,10 +39,10 @@ impl BlobWriter {
         compressor: BlobMetaCompressor,
     ) -> Result<Self> {
         if file_chunk_size < EROFS_BLOCK_SIZE {
-            bail!("blob writer file chunksize must be at least one EROFS block");
+            bail!("blob writer file chunk size must be at least one EROFS block");
         }
         if !file_chunk_size.is_power_of_two() || file_chunk_size % EROFS_BLOCK_SIZE != 0 {
-            bail!("blob writer file chunksize must be power-of-two and block-aligned");
+            bail!("blob writer file chunk size must be power-of-two and block-aligned");
         }
 
         let file = File::create(path)
@@ -58,10 +58,10 @@ impl BlobWriter {
         compressor: BlobMetaCompressor,
     ) -> Result<Self> {
         if file_chunk_size < EROFS_BLOCK_SIZE {
-            bail!("blob writer file chunksize must be at least one EROFS block");
+            bail!("blob writer file chunk size must be at least one EROFS block");
         }
         if !file_chunk_size.is_power_of_two() || file_chunk_size % EROFS_BLOCK_SIZE != 0 {
-            bail!("blob writer file chunksize must be power-of-two and block-aligned");
+            bail!("blob writer file chunk size must be power-of-two and block-aligned");
         }
         if group_size < file_chunk_size {
             bail!("blob writer group size must be at least the file chunk size");
@@ -292,7 +292,10 @@ impl BlobWriter {
     }
 }
 
-fn compression_is_worthwhile(compressed_len: usize, uncompressed_len: usize) -> bool {
+/// Format-compatibility policy shared by build and `nydus optimize`: a group
+/// is stored compressed only when it saves at least 30% — both paths must
+/// agree or an optimized blob would encode groups differently from its source.
+pub fn compression_is_worthwhile(compressed_len: usize, uncompressed_len: usize) -> bool {
     (compressed_len as u128) * 100 <= (uncompressed_len as u128) * MAX_COMPRESSED_SIZE_PERCENT
 }
 

--- a/nydus/src/build/bootstrap.rs
+++ b/nydus/src/build/bootstrap.rs
@@ -5,8 +5,7 @@ use crate::build::image::{
     device_table_meta_blkaddr, write_erofs_superblock_checksum, write_image,
 };
 use crate::build::inode::{
-    erofs_inode_size, serialize_inode, symlink_is_inline, InodeData,
-    InodeInfo,
+    erofs_inode_size, serialize_inode, symlink_is_inline, InodeData, InodeInfo,
 };
 use crate::metadata::layout::MetadataLayout;
 use crate::metadata::*;

--- a/nydus/src/build/bootstrap.rs
+++ b/nydus/src/build/bootstrap.rs
@@ -5,7 +5,7 @@ use crate::build::image::{
     device_table_meta_blkaddr, write_erofs_superblock_checksum, write_image,
 };
 use crate::build::inode::{
-    erofs_inode_has_inline, erofs_inode_size, serialize_inode, symlink_is_inline, InodeData,
+    erofs_inode_size, serialize_inode, symlink_is_inline, InodeData,
     InodeInfo,
 };
 use crate::metadata::layout::MetadataLayout;
@@ -124,7 +124,7 @@ fn render_bootstrap_inner(
             inode.is_extended = true;
         }
         let inode_size = erofs_inode_size(inode, chunkbits, blkszbits);
-        let has_inline = erofs_inode_has_inline(inode);
+        let has_inline = symlink_is_inline(inode);
         let (offset, nid) = layout.alloc_inode(inode_size, has_inline);
         inode.meta_offset = offset;
         inode.nid = nid;

--- a/nydus/src/build/inode.rs
+++ b/nydus/src/build/inode.rs
@@ -128,7 +128,10 @@ pub fn erofs_inode_size(inode: &InodeInfo, _chunk_bits: u32, _blksz_bits: u32) -
 
     let xattr_isize = erofs_xattr_ibody_size(&inode.xattrs);
     match &inode.data {
-        InodeData::RegularFile { chunk_index_entries, .. } => {
+        InodeData::RegularFile {
+            chunk_index_entries,
+            ..
+        } => {
             if chunk_index_entries.is_empty() {
                 inode_isize + xattr_isize
             } else {

--- a/nydus/src/build/inode.rs
+++ b/nydus/src/build/inode.rs
@@ -54,7 +54,7 @@ pub enum InodeData {
     /// Regular file: chunk indexes for chunk-based layout.
     RegularFile {
         /// List of chunk indexes (EROFS_CHUNK_INDEX_SIZE bytes each) for the file's data chunks.
-        chunk_indexes: Vec<ChunkIndex>,
+        chunk_index_entries: Vec<ChunkIndex>,
 
         /// Number of bits for the chunk size (e.g. 12 for 4KB chunks).
         chunk_size_bits: u32,
@@ -128,12 +128,12 @@ pub fn erofs_inode_size(inode: &InodeInfo, _chunk_bits: u32, _blksz_bits: u32) -
 
     let xattr_isize = erofs_xattr_ibody_size(&inode.xattrs);
     match &inode.data {
-        InodeData::RegularFile { chunk_indexes, .. } => {
-            if chunk_indexes.is_empty() {
+        InodeData::RegularFile { chunk_index_entries, .. } => {
+            if chunk_index_entries.is_empty() {
                 inode_isize + xattr_isize
             } else {
                 round_up(inode_isize + xattr_isize, EROFS_CHUNK_INDEX_SIZE)
-                    + chunk_indexes.len() * EROFS_CHUNK_INDEX_SIZE
+                    + chunk_index_entries.len() * EROFS_CHUNK_INDEX_SIZE
             }
         }
         InodeData::Directory { .. } => inode_isize + xattr_isize,
@@ -169,13 +169,6 @@ pub fn symlink_is_inline(inode: &InodeInfo) -> bool {
         ),
         _ => false,
     }
-}
-
-/// Whether the inode stores tail-packed data inline behind its header
-/// (`EROFS_INODE_FLAT_INLINE`), which the kernel requires to stay within the
-/// inode's own metadata block.
-pub fn erofs_inode_has_inline(inode: &InodeInfo) -> bool {
-    symlink_is_inline(inode)
 }
 
 /// Set the root directory's trusted.nydus.prefetch_blobs xattr to a comma-separated list of
@@ -289,7 +282,7 @@ fn build_tree_recursive(
 
     *inode_counter += 1;
     let ino = *inode_counter;
-    let is_extended = needs_erofs_extended_inode(&meta);
+    let is_extended = needs_erofs_extended_inode(meta.size(), meta.uid(), meta.gid(), meta.nlink());
     let xattrs = read_xattrs_from_path(path);
     if ft.is_dir() {
         let inode_index = inodes.len();
@@ -372,7 +365,7 @@ fn build_tree_recursive(
         Ok(inode_index)
     } else if ft.is_file() {
         let file_size = meta.size();
-        let chunk_indexes = blob_writer.write_file_chunks(path, file_size)?;
+        let chunk_index_entries = blob_writer.write_file_chunks(path, file_size)?;
         let inode_index = inodes.len();
         inodes.push(InodeInfo {
             mode,
@@ -387,7 +380,7 @@ fn build_tree_recursive(
             meta_offset: 0,
             is_extended,
             data: InodeData::RegularFile {
-                chunk_indexes,
+                chunk_index_entries,
                 chunk_size_bits: chunk_size.trailing_zeros(),
             },
             xattrs,
@@ -461,7 +454,7 @@ pub fn serialize_inode(inode: &InodeInfo, epoch: u64) -> Vec<u8> {
 
     match &inode.data {
         InodeData::RegularFile {
-            chunk_indexes,
+            chunk_index_entries,
             chunk_size_bits,
         } => {
             let datalayout = EROFS_INODE_CHUNK_BASED;
@@ -509,8 +502,8 @@ pub fn serialize_inode(inode: &InodeInfo, epoch: u64) -> Vec<u8> {
                 EROFS_INODE_COMPACT_SIZE
             };
             let extent_offset = round_up(base + xattr_size, EROFS_CHUNK_INDEX_SIZE);
-            for (i, ci) in chunk_indexes.iter().enumerate() {
-                let index = ErofsChunkIndex::new(ci.blkaddr, ci.device_id);
+            for (i, entry) in chunk_index_entries.iter().enumerate() {
+                let index = ErofsChunkIndex::new(entry.blkaddr, entry.device_id);
                 let off = extent_offset + i * EROFS_CHUNK_INDEX_SIZE;
                 buf[off..off + EROFS_CHUNK_INDEX_SIZE].copy_from_slice(index.as_bytes());
             }

--- a/nydus/src/fanotify/core.rs
+++ b/nydus/src/fanotify/core.rs
@@ -378,8 +378,7 @@ pub(crate) fn align_fetch_range(
     let end = raw_end.min(cache_size);
 
     let aligned_off = offset & !(BLOCK_SIZE - 1);
-    let aligned_end =
-        crate::utils::align_up(end, BLOCK_SIZE).ok_or(RangeError::Overflow)?;
+    let aligned_end = crate::utils::align_up(end, BLOCK_SIZE).ok_or(RangeError::Overflow)?;
     // `cache_size` is validated block-aligned at device enumeration, so rounding
     // `end` up never exceeds it; clamp as a safety net and verify the aligned
     // window stays inside the device.

--- a/nydus/src/fanotify/core.rs
+++ b/nydus/src/fanotify/core.rs
@@ -220,7 +220,7 @@ impl FanotifyCore {
             .map(|&idx| &self.devices[idx])
     }
 
-    /// Return true when the authoritative groupmap already covers the complete
+    /// Return true when the authoritative group_map already covers the complete
     /// aligned range. This never triggers backend I/O.
     pub fn is_range_ready(&self, id: &BlobId, offset: u64, len: u64) -> Result<bool> {
         let end = offset
@@ -262,7 +262,7 @@ impl FanotifyCore {
         }
     }
 
-    /// Remove the fanotify mark on a blob whose groupmap is fully ready.
+    /// Remove the fanotify mark on a blob whose group_map is fully ready.
     ///
     /// Called from fetch worker threads after a successful fetch. The per-slot
     /// [`AtomicBool`] ensures the readiness probe and the `FAN_MARK_REMOVE`
@@ -286,7 +286,7 @@ impl FanotifyCore {
         if self.unmarked[slot].load(Ordering::Acquire) {
             return false;
         }
-        // O(1) probe: single atomic load on the groupmap's shared ALL_READY flag.
+        // O(1) probe: single atomic load on the group_map's shared ALL_READY flag.
         if !self.core.blobs.is_all_ready(id).unwrap_or(false) {
             return false;
         }
@@ -378,10 +378,8 @@ pub(crate) fn align_fetch_range(
     let end = raw_end.min(cache_size);
 
     let aligned_off = offset & !(BLOCK_SIZE - 1);
-    let aligned_end = end
-        .checked_add(BLOCK_SIZE - 1)
-        .ok_or(RangeError::Overflow)?
-        & !(BLOCK_SIZE - 1);
+    let aligned_end =
+        crate::utils::align_up(end, BLOCK_SIZE).ok_or(RangeError::Overflow)?;
     // `cache_size` is validated block-aligned at device enumeration, so rounding
     // `end` up never exceeds it; clamp as a safety net and verify the aligned
     // window stays inside the device.

--- a/nydus/src/fanotify/mod.rs
+++ b/nydus/src/fanotify/mod.rs
@@ -30,5 +30,5 @@ pub mod service;
 
 pub use core::{BlobDevice, FanotifyCore, Response};
 pub use event::{EventIter, ParseError, ParseErrorKind, PreContentEvent, Range};
-pub use mount::{mount_erofs, unmount_erofs};
+pub use mount::mount_erofs;
 pub use service::FanotifyService;

--- a/nydus/src/fanotify/mount.rs
+++ b/nydus/src/fanotify/mount.rs
@@ -52,11 +52,6 @@ pub fn mount_erofs(bootstrap: &Path, devices: &[BlobDevice], mountpoint: &Path) 
     Ok(())
 }
 
-/// Unmount the EROFS at `mountpoint`.
-pub fn unmount_erofs(mountpoint: &Path) -> Result<()> {
-    crate::utils::unmount(mountpoint)
-}
-
 /// Build the binary mount data without lossy UTF-8 conversion. A comma in a
 /// device path is rejected because the kernel option grammar cannot distinguish
 /// it from the next mount option.

--- a/nydus/src/fanotify/response.rs
+++ b/nydus/src/fanotify/response.rs
@@ -224,15 +224,8 @@ mod tests {
         }
     }
 
-    fn event_fd() -> OwnedFd {
-        let fd = unsafe { libc::eventfd(0, libc::EFD_CLOEXEC | libc::EFD_NONBLOCK) };
-        assert!(fd >= 0, "eventfd failed: {}", io::Error::last_os_error());
-        // SAFETY: eventfd returned a fresh, owned descriptor.
-        unsafe { OwnedFd::from_raw_fd(fd) }
-    }
-
     fn pending(writer: Arc<MockWriter>) -> PendingPermission {
-        PendingPermission::new(event_fd(), writer)
+        PendingPermission::new(crate::fanotify::service::create_eventfd().unwrap(), writer)
     }
 
     #[test]

--- a/nydus/src/fanotify/service.rs
+++ b/nydus/src/fanotify/service.rs
@@ -183,7 +183,7 @@ fn epoll_add(epfd: RawFd, fd: RawFd, events: u32, data: u64) -> io::Result<()> {
 
 /// Non-blocking, close-on-exec eventfd used to wake the coordinator from a
 /// blocking `epoll_wait` when a fetch completes.
-fn create_eventfd() -> io::Result<OwnedFd> {
+pub(crate) fn create_eventfd() -> io::Result<OwnedFd> {
     let fd = unsafe { libc::eventfd(0, libc::EFD_CLOEXEC | libc::EFD_NONBLOCK) };
     if fd < 0 {
         return Err(io::Error::last_os_error());
@@ -730,7 +730,7 @@ fn admit_event(
             core.fetch(&id, cache_size, offset, count)
         }));
         // After a successful fetch, check whether this was the last group of
-        // the blob. If the groupmap's sticky ALL_READY flag is now set, remove
+        // the blob. If the group_map's sticky ALL_READY flag is now set, remove
         // the fanotify mark so the kernel stops generating events for this
         // file entirely — subsequent reads hit the page cache without any
         // daemon involvement.
@@ -952,14 +952,8 @@ mod tests {
         }
     }
 
-    fn eventfd() -> OwnedFd {
-        let fd = unsafe { libc::eventfd(0, libc::EFD_CLOEXEC | libc::EFD_NONBLOCK) };
-        assert!(fd >= 0, "eventfd: {}", io::Error::last_os_error());
-        unsafe { OwnedFd::from_raw_fd(fd) }
-    }
-
     fn perm(writer: &Arc<dyn ResponseWriter>) -> PendingPermission {
-        PendingPermission::new(eventfd(), writer.clone())
+        PendingPermission::new(create_eventfd().unwrap(), writer.clone())
     }
 
     fn key() -> FetchKey {

--- a/nydus/src/fuse.rs
+++ b/nydus/src/fuse.rs
@@ -16,7 +16,7 @@ use fuser::{
 use crate::metadata::*;
 use crate::metrics;
 
-use crate::fs::{ErofsReader, RawNameDirEntry};
+use crate::fs::{ErofsReader, RawDirEntry};
 
 const FUSE_ROOT_ID: u64 = 1;
 const EROFS_FUSE_TIMEOUT: Duration = Duration::from_secs(86400 * 365 * 10);
@@ -34,7 +34,7 @@ pub struct ErofsFs {
 }
 
 struct DirHandle {
-    entries: Vec<RawNameDirEntry>,
+    entries: Vec<RawDirEntry>,
 }
 
 impl ErofsFs {
@@ -126,7 +126,7 @@ impl ErofsFs {
     fn create_dir_handle(&self, inode: u64) -> io::Result<u64> {
         let nid = self.ino_to_nid(inode);
         let vi = self.reader.inode(nid)?;
-        let entries = self.reader.read_dir_raw(nid, &vi)?;
+        let entries = self.reader.read_dir(nid, &vi)?;
         let handle = self.next_dir_handle.fetch_add(1, Ordering::Relaxed);
         let dir_handle = Arc::new(DirHandle { entries });
         self.dir_handles.lock().unwrap().insert(handle, dir_handle);

--- a/nydus/src/lib.rs
+++ b/nydus/src/lib.rs
@@ -27,6 +27,7 @@ pub use nydus_core::Registry;
 pub use nydus_core::{
     build_backend, BlobBackend, BlobId, BlobInfo, BlobMeta, BlobMetaChunk, BlobMetaGroup,
     BlobMetaHeader, BlobPrefetcher, Blobs, Config, DirEntry, FdRange, FileType, Fs, FsEntry,
-    GroupMap, LocalBackend, Metadata, MetricsSnapshot, NydusCore, ReadKind, TraceDocument,
-    TraceEntry, TraceRecorder, BLOB_META_HEADER_SIZE, BLOB_META_MAGIC, DEFAULT_PREFETCH_THREADS,
+    GroupMap, LocalBackend, Metadata, MetricsSnapshot, NydusCore, ReadKind, ResolveMode,
+    TraceDocument, TraceEntry, TraceRecorder, BLOB_META_HEADER_SIZE, BLOB_META_MAGIC,
+    DEFAULT_PREFETCH_THREADS,
 };

--- a/nydus/src/merge.rs
+++ b/nydus/src/merge.rs
@@ -559,7 +559,12 @@ fn flatten_node(
                 ino,
                 nid: 0,
                 meta_offset: 0,
-                is_extended: needs_erofs_extended_inode(node.size, node.uid, node.gid, nlink as u64),
+                is_extended: needs_erofs_extended_inode(
+                    node.size,
+                    node.uid,
+                    node.gid,
+                    nlink as u64,
+                ),
                 data: InodeData::RegularFile {
                     chunk_index_entries: chunk_index_entries.clone(),
                     chunk_size_bits: *chunkbits,

--- a/nydus/src/merge.rs
+++ b/nydus/src/merge.rs
@@ -44,7 +44,7 @@ struct MergeLinkId {
 #[derive(Clone)]
 enum MergeNodeData {
     RegularFile {
-        chunk_indexes: Vec<ChunkIndex>,
+        chunk_index_entries: Vec<ChunkIndex>,
         chunkbits: u32,
     },
     Directory {
@@ -324,8 +324,8 @@ fn load_node(
                 bail!("merge currently only supports chunk-based regular files")
             }
             let chunkbits = reader.sb().blkszbits as u32 + (inode.chunk_format() as u32 & 0x1F);
-            let chunk_indexes = reader
-                .read_chunk_indexes(nid, &inode)?
+            let chunk_index_entries = reader
+                .read_chunk_index_entries(nid, &inode)?
                 .into_iter()
                 .map(|index| {
                     // A hole chunk carries no blob reference at all (its
@@ -350,7 +350,7 @@ fn load_node(
                 })
                 .collect::<Result<Vec<_>>>()?;
             MergeNodeData::RegularFile {
-                chunk_indexes,
+                chunk_index_entries,
                 chunkbits,
             }
         }
@@ -506,7 +506,7 @@ fn flatten_node(
                 ino,
                 nid: 0,
                 meta_offset: 0,
-                is_extended: needs_extended(0, node.uid, node.gid, 0),
+                is_extended: needs_erofs_extended_inode(0, node.uid, node.gid, 0),
                 data: InodeData::Directory {
                     children: Vec::new(),
                     startblk: 0,
@@ -532,7 +532,7 @@ fn flatten_node(
             }
 
             let nlink = 2 + subdir_count;
-            let is_extended = needs_extended(0, node.uid, node.gid, nlink);
+            let is_extended = needs_erofs_extended_inode(0, node.uid, node.gid, nlink as u64);
             inodes[inode_index].nlink = nlink;
             inodes[inode_index].is_extended = is_extended;
             if let InodeData::Directory {
@@ -544,7 +544,7 @@ fn flatten_node(
             }
         }
         MergeNodeData::RegularFile {
-            chunk_indexes,
+            chunk_index_entries,
             chunkbits,
         } => {
             let nlink = node.nlink.max(1);
@@ -559,9 +559,9 @@ fn flatten_node(
                 ino,
                 nid: 0,
                 meta_offset: 0,
-                is_extended: needs_extended(node.size, node.uid, node.gid, nlink),
+                is_extended: needs_erofs_extended_inode(node.size, node.uid, node.gid, nlink as u64),
                 data: InodeData::RegularFile {
-                    chunk_indexes: chunk_indexes.clone(),
+                    chunk_index_entries: chunk_index_entries.clone(),
                     chunk_size_bits: *chunkbits,
                 },
                 xattrs: node.xattrs.clone(),
@@ -584,7 +584,7 @@ fn flatten_node(
                 ino,
                 nid: 0,
                 meta_offset: 0,
-                is_extended: needs_extended(size, node.uid, node.gid, nlink),
+                is_extended: needs_erofs_extended_inode(size, node.uid, node.gid, nlink as u64),
                 data: InodeData::Symlink {
                     target: target.clone(),
                     startblk: 0,
@@ -605,7 +605,7 @@ fn flatten_node(
                 ino,
                 nid: 0,
                 meta_offset: 0,
-                is_extended: needs_extended(0, node.uid, node.gid, nlink),
+                is_extended: needs_erofs_extended_inode(0, node.uid, node.gid, nlink as u64),
                 data: InodeData::Device { rdev: *rdev },
                 xattrs: node.xattrs.clone(),
             });
@@ -623,7 +623,7 @@ fn flatten_node(
                 ino,
                 nid: 0,
                 meta_offset: 0,
-                is_extended: needs_extended(0, node.uid, node.gid, nlink),
+                is_extended: needs_erofs_extended_inode(0, node.uid, node.gid, nlink as u64),
                 data: InodeData::FifoOrSocket,
                 xattrs: node.xattrs.clone(),
             });
@@ -631,10 +631,6 @@ fn flatten_node(
     }
 
     inode_index
-}
-
-fn needs_extended(size: u64, uid: u32, gid: u32, nlink: u32) -> bool {
-    size > u32::MAX as u64 || uid > u16::MAX as u32 || gid > u16::MAX as u32 || nlink > 1
 }
 
 #[cfg(test)]
@@ -653,7 +649,7 @@ mod tests {
 
     fn regular_file() -> MergeNode {
         merge_node(MergeNodeData::RegularFile {
-            chunk_indexes: Vec::new(),
+            chunk_index_entries: Vec::new(),
             chunkbits: EROFS_BLKSZBITS as u32,
         })
     }

--- a/nydus/src/nbd/mod.rs
+++ b/nydus/src/nbd/mod.rs
@@ -21,5 +21,5 @@ pub mod proto;
 pub mod service;
 
 pub use core::NbdCore;
-pub use mount::{mount_nbd, unmount_nbd};
+pub use mount::mount_nbd;
 pub use service::NbdService;

--- a/nydus/src/nbd/mount.rs
+++ b/nydus/src/nbd/mount.rs
@@ -45,12 +45,6 @@ pub fn mount_nbd(device: &str, mountpoint: &Path, fstype: &str) -> Result<()> {
     Ok(())
 }
 
-/// Unmount whatever is mounted at `mountpoint`. A plain `umount2(., 0)`; the
-/// EBUSY retry loop lives in the CLI, mirroring fanotify's shutdown ordering.
-pub fn unmount_nbd(mountpoint: &Path) -> Result<()> {
-    crate::utils::unmount(mountpoint)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -60,10 +54,5 @@ mod tests {
         let mp = Path::new("/mnt/x");
         assert!(mount_nbd("/dev/nbd\0bad", mp, "erofs").is_err());
         assert!(mount_nbd("/dev/nbd0", mp, "ero\0fs").is_err());
-    }
-
-    #[test]
-    fn unmount_nbd_rejects_interior_nul_in_mountpoint() {
-        assert!(unmount_nbd(Path::new("/mnt/\0bad")).is_err());
     }
 }

--- a/nydus/src/nbd/service.rs
+++ b/nydus/src/nbd/service.rs
@@ -80,7 +80,7 @@ fn nbd_ioctl(fd: RawFd, request: u32, arg: u64) -> std::io::Result<i32> {
 }
 
 /// Read the block device's current capacity in bytes via `BLKGETSIZE64`.
-fn device_size(fd: RawFd) -> std::io::Result<u64> {
+fn query_block_device_size(fd: RawFd) -> std::io::Result<u64> {
     let mut size: u64 = 0;
     // SAFETY: `fd` is a live block-device descriptor and BLKGETSIZE64 writes
     // a single u64 through the pointer.
@@ -159,7 +159,7 @@ impl NbdService {
         // A nonzero capacity means another client is already serving this
         // device; the NBD_CLEAR_SOCK below would shut that session's sockets
         // down and kill it, so refuse instead of hijacking.
-        let size = device_size(fd).context("BLKGETSIZE64 failed")?;
+        let size = query_block_device_size(fd).context("BLKGETSIZE64 failed")?;
         if size != 0 {
             bail!(
                 "NBD device {nbd_path} is busy (reports {size} bytes); \
@@ -235,7 +235,7 @@ impl NbdService {
         let deadline = Instant::now() + timeout;
         let fd = self.nbd_dev.as_raw_fd();
         loop {
-            let size = device_size(fd).context("BLKGETSIZE64 failed")?;
+            let size = query_block_device_size(fd).context("BLKGETSIZE64 failed")?;
             if size == bytes {
                 debug!("nbd device capacity committed: {size} bytes");
                 return Ok(());

--- a/nydus/src/uffd/core.rs
+++ b/nydus/src/uffd/core.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, bail, Context, Result};
 
 use crate::utils::align_up;
-use crate::{Config, FdRange, NydusCore};
+use crate::{Config, FdRange, NydusCore, ResolveMode};
 
 use super::proto::{DeviceRange, FaultPolicy, VmaRegion};
 
@@ -53,12 +53,6 @@ struct UffdioZeropage {
     range_len: u64,
     mode: u64,
     zeropage: i64,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ResolveMode {
-    Fetch,
-    Probe,
 }
 
 pub struct UffdCore {

--- a/nydus/src/unpack.rs
+++ b/nydus/src/unpack.rs
@@ -65,7 +65,7 @@ impl Unpacker<'_> {
             .with_context(|| format!("failed to read inode {nid}"))?;
         let entries = self
             .reader
-            .read_dir_raw(nid, &inode)
+            .read_dir(nid, &inode)
             .with_context(|| format!("failed to read directory inode {nid}"))?;
 
         for entry in entries {

--- a/nydusify/internal/checker/bootstrap.go
+++ b/nydusify/internal/checker/bootstrap.go
@@ -12,7 +12,6 @@ package checker
 import (
 	"context"
 	"os"
-	"path/filepath"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/log"
@@ -58,8 +57,8 @@ func (r *bootstrapRule) validateImage(ctx context.Context, label string, img *Im
 	}
 	defer func() { _ = os.RemoveAll(dir) }()
 
-	bootstrapPath := filepath.Join(dir, "image.boot")
-	if err := extractBootstrap(ctx, r.cs, *img.Bootstrap, bootstrapPath); err != nil {
+	bootstrapPath, _, err := extractBootstrapLayer(ctx, r.cs, *img.Bootstrap, dir)
+	if err != nil {
 		return errors.Wrap(err, "extract bootstrap")
 	}
 

--- a/nydusify/internal/checker/checker.go
+++ b/nydusify/internal/checker/checker.go
@@ -24,8 +24,8 @@ type Option struct {
 	Source string
 	// Target is the target image reference (OCI or nydus). May be empty.
 	Target string
-	// Builder is the nydus binary path (PATH-resolvable). Defaults to "nydus".
-	Builder string
+	// BuilderPath is the nydus binary path (PATH-resolvable). Defaults to "nydus".
+	BuilderPath string
 	// WorkDir is the scratch directory backing the content store and rule
 	// staging. It must already exist.
 	WorkDir string
@@ -122,8 +122,8 @@ func (c *Checker) Check(ctx context.Context) error {
 
 	rules := []Rule{
 		&manifestRule{source: source, target: target},
-		&bootstrapRule{cs: cs, builder: c.opt.Builder, workDir: scratchDir, source: source, target: target},
-		&filesystemRule{cs: cs, provider: provider, builder: c.opt.Builder, logLevel: c.opt.LogLevel, workDir: scratchDir, source: source, target: target},
+		&bootstrapRule{cs: cs, builder: c.opt.BuilderPath, workDir: scratchDir, source: source, target: target},
+		&filesystemRule{cs: cs, provider: provider, builder: c.opt.BuilderPath, logLevel: c.opt.LogLevel, workDir: scratchDir, source: source, target: target},
 	}
 
 	for _, rule := range rules {

--- a/nydusify/internal/checker/export.go
+++ b/nydusify/internal/checker/export.go
@@ -15,9 +15,10 @@ import (
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/pkg/archive/compression"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+
+	"github.com/dragonflyoss/nydus/nydusify/internal/converter"
 )
 
 // exportImage writes the metadata of a single-image check into destDir for
@@ -76,16 +77,9 @@ func extractBootstrapTree(ctx context.Context, cs content.Store, desc ocispec.De
 		return errors.Wrap(err, "create bootstrap dir")
 	}
 
-	ra, err := cs.ReaderAt(ctx, desc)
+	decompressed, err := converter.OpenDecompressedBlob(ctx, cs, desc)
 	if err != nil {
-		return errors.Wrap(err, "open bootstrap reader")
-	}
-	defer func() { _ = ra.Close() }()
-
-	sr := io.NewSectionReader(ra, 0, ra.Size())
-	decompressed, err := compression.DecompressStream(sr)
-	if err != nil {
-		return errors.Wrap(err, "decompress bootstrap layer")
+		return errors.Wrap(err, "open bootstrap layer")
 	}
 	defer func() { _ = decompressed.Close() }()
 

--- a/nydusify/internal/checker/mount.go
+++ b/nydusify/internal/checker/mount.go
@@ -31,8 +31,8 @@ type MountOption struct {
 	// Mountpoint is the directory the image is mounted at. Required, and must
 	// already exist.
 	Mountpoint string
-	// Builder is the nydus binary path (PATH-resolvable). Defaults to "nydus".
-	Builder string
+	// BuilderPath is the nydus binary path (PATH-resolvable). Defaults to "nydus".
+	BuilderPath string
 	// WorkDir is the scratch directory backing the content store and the
 	// extracted bootstrap/cache. It must already exist.
 	WorkDir string
@@ -171,7 +171,7 @@ func (m *Mounter) mountNydus(ctx context.Context, provider *remote.Provider, cs 
 		"--log-dir", logDir,
 		"--console",
 	}
-	cmd := exec.Command(cmp.Or(m.opt.Builder, pkgconv.DefaultBuilder), args...)
+	cmd := exec.Command(cmp.Or(m.opt.BuilderPath, pkgconv.DefaultBuilder), args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {

--- a/nydusify/internal/checker/optimize.go
+++ b/nydusify/internal/checker/optimize.go
@@ -39,8 +39,8 @@ type OptimizeOption struct {
 	// Pattern is the path to a JSON access-pattern file (the same document
 	// served by the `/trace` endpoint). Required.
 	Pattern string
-	// Builder is the nydus binary path (PATH-resolvable). Defaults to "nydus".
-	Builder string
+	// BuilderPath is the nydus binary path (PATH-resolvable). Defaults to "nydus".
+	BuilderPath string
 	// WorkDir is the scratch directory backing the content store and the
 	// optimize staging area. It must already exist.
 	WorkDir string
@@ -164,7 +164,7 @@ func (o *Optimizer) Optimize(ctx context.Context) error {
 	log.G(ctx).Infof("built ondemand blob %s", ondemandHex)
 
 	// Commit the ondemand blob as a nydus data layer.
-	ondemandDesc, err := ingestBlobFile(ctx, cs, filepath.Join(blobDir, ondemandHex))
+	ondemandDesc, err := ingestDigestNamedBlobFile(ctx, cs, filepath.Join(blobDir, ondemandHex))
 	if err != nil {
 		return errors.Wrap(err, "commit ondemand blob")
 	}
@@ -219,7 +219,7 @@ func (o *Optimizer) runNydusOptimize(ctx context.Context, parentBootstrap, boots
 		"--log-level", cmp.Or(o.opt.LogLevel, pkgconv.DefaultLogLevel),
 		"--trace-file", o.opt.Pattern,
 	}
-	cmd := exec.CommandContext(ctx, cmp.Or(o.opt.Builder, pkgconv.DefaultBuilder), args...)
+	cmd := exec.CommandContext(ctx, cmp.Or(o.opt.BuilderPath, pkgconv.DefaultBuilder), args...)
 	var output bytes.Buffer
 	cmd.Stdout = io.MultiWriter(&output, os.Stderr)
 	cmd.Stderr = os.Stderr
@@ -233,9 +233,11 @@ func (o *Optimizer) runNydusOptimize(ctx context.Context, parentBootstrap, boots
 	return string(match[1]), nil
 }
 
-// ingestBlobFile commits a digest-named nydus blob file from disk into the
-// content store as a nydus data layer descriptor.
-func ingestBlobFile(ctx context.Context, cs content.Store, path string) (*ocispec.Descriptor, error) {
+// ingestDigestNamedBlobFile commits a nydus blob file into the content store,
+// trusting the file name as its SHA-256 digest (it does NOT re-hash the
+// contents — unlike converter.ingestBlobFile, which computes the digest by
+// streaming the file).
+func ingestDigestNamedBlobFile(ctx context.Context, cs content.Store, path string) (*ocispec.Descriptor, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "open blob %q", path)

--- a/nydusify/internal/checker/tool.go
+++ b/nydusify/internal/checker/tool.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/pkg/archive"
-	"github.com/containerd/containerd/v2/pkg/archive/compression"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -42,16 +41,9 @@ func extractBootstrapLayer(ctx context.Context, cs content.Store, desc ocispec.D
 		return "", nil, errors.Wrap(err, "create bootstrap dir")
 	}
 
-	ra, err := cs.ReaderAt(ctx, desc)
+	decompressed, err := converter.OpenDecompressedBlob(ctx, cs, desc)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "open bootstrap reader")
-	}
-	defer func() { _ = ra.Close() }()
-
-	sr := io.NewSectionReader(ra, 0, ra.Size())
-	decompressed, err := compression.DecompressStream(sr)
-	if err != nil {
-		return "", nil, errors.Wrap(err, "decompress bootstrap layer")
+		return "", nil, errors.Wrap(err, "open bootstrap layer")
 	}
 	defer func() { _ = decompressed.Close() }()
 
@@ -173,50 +165,6 @@ func copyFile(src, dst string) error {
 	return nil
 }
 
-// extractBootstrap reads a nydus bootstrap layer (gzip(tar(image/image.boot)))
-// from the content store and writes the embedded bootstrap file to destPath.
-func extractBootstrap(ctx context.Context, cs content.Store, desc ocispec.Descriptor, destPath string) error {
-	ra, err := cs.ReaderAt(ctx, desc)
-	if err != nil {
-		return errors.Wrap(err, "open bootstrap reader")
-	}
-	defer func() { _ = ra.Close() }()
-
-	sr := io.NewSectionReader(ra, 0, ra.Size())
-	decompressed, err := compression.DecompressStream(sr)
-	if err != nil {
-		return errors.Wrap(err, "decompress bootstrap layer")
-	}
-	defer func() { _ = decompressed.Close() }()
-
-	tr := tar.NewReader(decompressed)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return errors.Wrap(err, "read bootstrap tar")
-		}
-		if hdr.Name != converter.BootstrapFileNameInLayer {
-			continue
-		}
-		out, err := os.Create(destPath)
-		if err != nil {
-			return errors.Wrap(err, "create bootstrap file")
-		}
-		if _, err := io.Copy(out, tr); err != nil {
-			_ = out.Close()
-			return errors.Wrap(err, "write bootstrap file")
-		}
-		if err := out.Close(); err != nil {
-			return errors.Wrap(err, "close bootstrap file")
-		}
-		return nil
-	}
-	return errors.Errorf("bootstrap entry %q not found in layer", converter.BootstrapFileNameInLayer)
-}
-
 // applyOCIImage applies all OCI layers of img sequentially into rootfs,
 // resolving whiteouts so the result is the fully merged root filesystem.
 func applyOCIImage(ctx context.Context, cs content.Store, img *Image, rootfs string) error {
@@ -232,16 +180,9 @@ func applyOCIImage(ctx context.Context, cs content.Store, img *Image, rootfs str
 }
 
 func applyOCILayer(ctx context.Context, cs content.Store, layer ocispec.Descriptor, rootfs string) error {
-	ra, err := cs.ReaderAt(ctx, layer)
+	decompressed, err := converter.OpenDecompressedBlob(ctx, cs, layer)
 	if err != nil {
-		return errors.Wrap(err, "open layer reader")
-	}
-	defer func() { _ = ra.Close() }()
-
-	sr := io.NewSectionReader(ra, 0, ra.Size())
-	decompressed, err := compression.DecompressStream(sr)
-	if err != nil {
-		return errors.Wrap(err, "decompress layer")
+		return errors.Wrap(err, "open layer")
 	}
 	defer func() { _ = decompressed.Close() }()
 

--- a/nydusify/internal/converter/hook.go
+++ b/nydusify/internal/converter/hook.go
@@ -147,12 +147,16 @@ func convertManifest(ctx context.Context, cs content.Store, newDesc *ocispec.Des
 // raw config JSON and leaves every other field — in particular the runtime
 // `config` (env/cmd/entrypoint/working dir/etc.) — byte-for-byte intact.
 //
+// patchImageConfig replaces only the `rootfs` diff ids of a raw image config
+// and lets historyFn rewrite the `history` field, keeping every other field
+// byte-for-byte intact.
+//
 // Decoding the whole config into ocispec.Image and re-marshaling it would drop
 // empty-but-present fields via `omitempty` (e.g. `"Cmd": []` is re-encoded as
 // absent and then decodes back as a nil slice). The nydus config would then no
 // longer be reflect.DeepEqual to the untouched source OCI config, and
 // `nydusify check` would fail the manifest config-consistency rule.
-func rewriteBootstrapConfig(configJSON json.RawMessage, diffIDs []digest.Digest) (json.RawMessage, error) {
+func patchImageConfig(configJSON json.RawMessage, diffIDs []digest.Digest, historyFn func(history []ocispec.History, present bool) ([]ocispec.History, bool)) (json.RawMessage, error) {
 	var rawConfig map[string]json.RawMessage
 	if err := json.Unmarshal(configJSON, &rawConfig); err != nil {
 		return nil, errors.Wrap(err, "unmarshal image config")
@@ -164,6 +168,9 @@ func rewriteBootstrapConfig(configJSON json.RawMessage, diffIDs []digest.Digest)
 			return nil, errors.Wrap(err, "unmarshal image config rootfs")
 		}
 	}
+	if rootFS.Type == "" {
+		rootFS.Type = "layers"
+	}
 	rootFS.DiffIDs = diffIDs
 	rootFSRaw, err := json.Marshal(rootFS)
 	if err != nil {
@@ -172,26 +179,36 @@ func rewriteBootstrapConfig(configJSON json.RawMessage, diffIDs []digest.Digest)
 	rawConfig["rootfs"] = rootFSRaw
 
 	var history []ocispec.History
-	if raw, ok := rawConfig["history"]; ok {
-		if err := json.Unmarshal(raw, &history); err != nil {
+	rawHistory, present := rawConfig["history"]
+	if present {
+		if err := json.Unmarshal(rawHistory, &history); err != nil {
 			return nil, errors.Wrap(err, "unmarshal image config history")
 		}
 	}
-	history = append(history, ocispec.History{
-		CreatedBy: "Nydus Converter",
-		Comment:   "Nydus Bootstrap Layer",
-	})
-	historyRaw, err := json.Marshal(history)
-	if err != nil {
-		return nil, errors.Wrap(err, "marshal image config history")
+	if newHistory, write := historyFn(history, present); write {
+		historyRaw, err := json.Marshal(newHistory)
+		if err != nil {
+			return nil, errors.Wrap(err, "marshal image config history")
+		}
+		rawConfig["history"] = historyRaw
 	}
-	rawConfig["history"] = historyRaw
 
 	out, err := json.Marshal(rawConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal image config")
 	}
 	return out, nil
+}
+
+// rewriteBootstrapConfig appends the bootstrap layer's diff id and history
+// entry to the source config (see patchImageConfig for the raw-JSON rationale).
+func rewriteBootstrapConfig(configJSON json.RawMessage, diffIDs []digest.Digest) (json.RawMessage, error) {
+	return patchImageConfig(configJSON, diffIDs, func(history []ocispec.History, _ bool) ([]ocispec.History, bool) {
+		return append(history, ocispec.History{
+			CreatedBy: "Nydus Converter",
+			Comment:   "Nydus Bootstrap Layer",
+		}), true
+	})
 }
 
 // isMergeableBlobManifest reports whether the manifest is in the mergeable

--- a/nydusify/internal/converter/layer.go
+++ b/nydusify/internal/converter/layer.go
@@ -111,19 +111,42 @@ func convertLayer(ctx context.Context, cs content.Store, desc ocispec.Descriptor
 	}, nil
 }
 
-// extractOCILayer reads an OCI layer blob from the content store, decompresses
-// it (gzip/zstd/uncompressed are auto-detected) and extracts it into dir.
-func extractOCILayer(ctx context.Context, cs content.Store, desc ocispec.Descriptor, dir string) error {
+// OpenDecompressedBlob opens a content-store blob and returns a reader over
+// its decompressed bytes (gzip/zstd/uncompressed are auto-detected). Closing
+// the returned reader also releases the underlying content-store ReaderAt.
+func OpenDecompressedBlob(ctx context.Context, cs content.Store, desc ocispec.Descriptor) (io.ReadCloser, error) {
 	ra, err := cs.ReaderAt(ctx, desc)
 	if err != nil {
-		return errors.Wrap(err, "open layer reader")
+		return nil, errors.Wrap(err, "open blob reader")
 	}
-	defer func() { _ = ra.Close() }()
-
 	sr := io.NewSectionReader(ra, 0, ra.Size())
 	decompressed, err := compression.DecompressStream(sr)
 	if err != nil {
-		return errors.Wrap(err, "decompress layer")
+		_ = ra.Close()
+		return nil, errors.Wrap(err, "decompress blob")
+	}
+	return &decompressedBlob{ReadCloser: decompressed, ra: ra}, nil
+}
+
+type decompressedBlob struct {
+	io.ReadCloser
+	ra content.ReaderAt
+}
+
+func (b *decompressedBlob) Close() error {
+	err := b.ReadCloser.Close()
+	if raErr := b.ra.Close(); err == nil {
+		err = raErr
+	}
+	return err
+}
+
+// extractOCILayer reads an OCI layer blob from the content store, decompresses
+// it (gzip/zstd/uncompressed are auto-detected) and extracts it into dir.
+func extractOCILayer(ctx context.Context, cs content.Store, desc ocispec.Descriptor, dir string) error {
+	decompressed, err := OpenDecompressedBlob(ctx, cs, desc)
+	if err != nil {
+		return errors.Wrap(err, "open layer")
 	}
 	defer func() { _ = decompressed.Close() }()
 

--- a/nydusify/internal/converter/multi.go
+++ b/nydusify/internal/converter/multi.go
@@ -340,24 +340,9 @@ func buildImageConfig(base json.RawMessage, platform ocispec.Platform, diffIDs [
 		})
 	}
 
-	var rawConfig map[string]json.RawMessage
-	if err := json.Unmarshal(base, &rawConfig); err != nil {
-		return nil, errors.Wrap(err, "unmarshal image config")
-	}
-
-	rootFSRaw, err := json.Marshal(ocispec.RootFS{Type: "layers", DiffIDs: diffIDs})
-	if err != nil {
-		return nil, errors.Wrap(err, "marshal image config rootfs")
-	}
-	rawConfig["rootfs"] = rootFSRaw
-
-	historyRaw, err := json.Marshal(history)
-	if err != nil {
-		return nil, errors.Wrap(err, "marshal image config history")
-	}
-	rawConfig["history"] = historyRaw
-
-	return json.Marshal(rawConfig)
+	return patchImageConfig(base, diffIDs, func(_ []ocispec.History, _ bool) ([]ocispec.History, bool) {
+		return history, true
+	})
 }
 
 // labelNydusBlobDiffIDs sets the containerd.io/uncompressed content-store

--- a/nydusify/internal/converter/tooci.go
+++ b/nydusify/internal/converter/tooci.go
@@ -294,41 +294,12 @@ func materializeBlob(ctx context.Context, cs content.Store, desc ocispec.Descrip
 // entries of the layers the reverse conversion removed, patching the raw JSON
 // so unrelated fields stay byte-for-byte intact.
 func rewriteOCIConfig(configJSON json.RawMessage, diffIDs []digest.Digest, droppedLayers int) (json.RawMessage, error) {
-	var rawConfig map[string]json.RawMessage
-	if err := json.Unmarshal(configJSON, &rawConfig); err != nil {
-		return nil, errors.Wrap(err, "unmarshal image config")
-	}
-
-	var rootFS ocispec.RootFS
-	if raw, ok := rawConfig["rootfs"]; ok {
-		if err := json.Unmarshal(raw, &rootFS); err != nil {
-			return nil, errors.Wrap(err, "unmarshal image config rootfs")
+	return patchImageConfig(configJSON, diffIDs, func(history []ocispec.History, present bool) ([]ocispec.History, bool) {
+		if !present {
+			return nil, false
 		}
-	}
-	rootFS.DiffIDs = diffIDs
-	rootFSRaw, err := json.Marshal(rootFS)
-	if err != nil {
-		return nil, errors.Wrap(err, "marshal image config rootfs")
-	}
-	rawConfig["rootfs"] = rootFSRaw
-
-	if raw, ok := rawConfig["history"]; ok {
-		var history []ocispec.History
-		if err := json.Unmarshal(raw, &history); err != nil {
-			return nil, errors.Wrap(err, "unmarshal image config history")
-		}
-		historyRaw, err := json.Marshal(trimHistory(history, droppedLayers))
-		if err != nil {
-			return nil, errors.Wrap(err, "marshal image config history")
-		}
-		rawConfig["history"] = historyRaw
-	}
-
-	out, err := json.Marshal(rawConfig)
-	if err != nil {
-		return nil, errors.Wrap(err, "marshal image config")
-	}
-	return out, nil
+		return trimHistory(history, droppedLayers), true
+	})
 }
 
 // trimHistory drops the last droppedLayers non-empty history entries. The

--- a/nydusify/main.go
+++ b/nydusify/main.go
@@ -117,12 +117,35 @@ func convertCommand() *cli.Command {
 	}
 }
 
-func runConvert(c *cli.Context) error {
+// setupCommand applies the --log-level flag and returns the logger-carrying
+// base context shared by every subcommand.
+func setupCommand(c *cli.Context) context.Context {
 	if level, err := logrus.ParseLevel(c.String("log-level")); err == nil {
 		logrus.SetLevel(level)
 	}
+	return log.WithLogger(context.Background(), log.L)
+}
 
-	ctx := log.WithLogger(context.Background(), log.L)
+// scratchWorkDir resolves --work-dir: an explicit directory is created and
+// kept; otherwise a temp dir with the given prefix is created and the
+// returned cleanup removes it.
+func scratchWorkDir(c *cli.Context, prefix string) (string, func(), error) {
+	workDir := c.String("work-dir")
+	if workDir == "" {
+		tmp, err := os.MkdirTemp("", prefix)
+		if err != nil {
+			return "", nil, errors.Wrap(err, "create work dir")
+		}
+		return tmp, func() { _ = os.RemoveAll(tmp) }, nil
+	}
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		return "", nil, errors.Wrapf(err, "create work dir %q", workDir)
+	}
+	return workDir, func() {}, nil
+}
+
+func runConvert(c *cli.Context) error {
+	ctx := setupCommand(c)
 
 	sources := c.StringSlice("source")
 	source := sources[0]
@@ -161,22 +184,11 @@ func runConvert(c *cli.Context) error {
 		platformMC = platforms.Only(platform)
 	}
 
-	// Prepare a scratch work directory.
-	workDir := c.String("work-dir")
-	cleanup := false
-	if workDir == "" {
-		tmp, err := os.MkdirTemp("", "nydusify-")
-		if err != nil {
-			return errors.Wrap(err, "create work dir")
-		}
-		workDir = tmp
-		cleanup = true
-	} else if err := os.MkdirAll(workDir, 0o755); err != nil {
-		return errors.Wrapf(err, "create work dir %q", workDir)
+	workDir, cleanupWorkDir, err := scratchWorkDir(c, "nydusify-")
+	if err != nil {
+		return err
 	}
-	if cleanup {
-		defer func() { _ = os.RemoveAll(workDir) }()
-	}
+	defer cleanupWorkDir()
 
 	contentDir := joinWork(workDir, "content")
 	scratchDir := joinWork(workDir, "scratch")
@@ -403,11 +415,7 @@ func checkCommand() *cli.Command {
 }
 
 func runCheck(c *cli.Context) error {
-	if level, err := logrus.ParseLevel(c.String("log-level")); err == nil {
-		logrus.SetLevel(level)
-	}
-
-	ctx := log.WithLogger(context.Background(), log.L)
+	ctx := setupCommand(c)
 
 	source := c.String("source")
 	target := c.String("target")
@@ -437,7 +445,7 @@ func runCheck(c *cli.Context) error {
 	chk, err := checker.New(checker.Option{
 		Source:          source,
 		Target:          target,
-		Builder:         c.String("builder"),
+		BuilderPath:     c.String("builder"),
 		WorkDir:         workDir,
 		SourceInsecure:  c.Bool("source-insecure"),
 		SourcePlainHTTP: c.Bool("source-plain-http"),
@@ -515,11 +523,7 @@ func mountCommand() *cli.Command {
 }
 
 func runMount(c *cli.Context) error {
-	if level, err := logrus.ParseLevel(c.String("log-level")); err == nil {
-		logrus.SetLevel(level)
-	}
-
-	ctx := log.WithLogger(context.Background(), log.L)
+	ctx := setupCommand(c)
 
 	target := c.String("target")
 	mountpoint := c.String("mountpoint")
@@ -537,27 +541,16 @@ func runMount(c *cli.Context) error {
 		return errors.Wrapf(err, "create mountpoint %q", mountpoint)
 	}
 
-	// Prepare a scratch work directory.
-	workDir := c.String("work-dir")
-	cleanup := false
-	if workDir == "" {
-		tmp, err := os.MkdirTemp("", "nydusify-mount-")
-		if err != nil {
-			return errors.Wrap(err, "create work dir")
-		}
-		workDir = tmp
-		cleanup = true
-	} else if err := os.MkdirAll(workDir, 0o755); err != nil {
-		return errors.Wrapf(err, "create work dir %q", workDir)
+	workDir, cleanupWorkDir, err := scratchWorkDir(c, "nydusify-mount-")
+	if err != nil {
+		return err
 	}
-	if cleanup {
-		defer func() { _ = os.RemoveAll(workDir) }()
-	}
+	defer cleanupWorkDir()
 
 	mnt, err := checker.NewMounter(checker.MountOption{
 		Target:          target,
 		Mountpoint:      mountpoint,
-		Builder:         c.String("builder"),
+		BuilderPath:     c.String("builder"),
 		WorkDir:         workDir,
 		TargetInsecure:  c.Bool("target-insecure"),
 		TargetPlainHTTP: c.Bool("target-plain-http"),
@@ -637,11 +630,7 @@ func optimizeCommand() *cli.Command {
 }
 
 func runOptimize(c *cli.Context) error {
-	if level, err := logrus.ParseLevel(c.String("log-level")); err == nil {
-		logrus.SetLevel(level)
-	}
-
-	ctx := log.WithLogger(context.Background(), log.L)
+	ctx := setupCommand(c)
 
 	platformMC := platforms.Default()
 	if p := c.String("platform"); p != "" {
@@ -652,28 +641,17 @@ func runOptimize(c *cli.Context) error {
 		platformMC = platforms.Only(parsed)
 	}
 
-	// Prepare a scratch work directory.
-	workDir := c.String("work-dir")
-	cleanup := false
-	if workDir == "" {
-		tmp, err := os.MkdirTemp("", "nydusify-optimize-")
-		if err != nil {
-			return errors.Wrap(err, "create work dir")
-		}
-		workDir = tmp
-		cleanup = true
-	} else if err := os.MkdirAll(workDir, 0o755); err != nil {
-		return errors.Wrapf(err, "create work dir %q", workDir)
+	workDir, cleanupWorkDir, err := scratchWorkDir(c, "nydusify-optimize-")
+	if err != nil {
+		return err
 	}
-	if cleanup {
-		defer func() { _ = os.RemoveAll(workDir) }()
-	}
+	defer cleanupWorkDir()
 
 	opt, err := checker.NewOptimizer(checker.OptimizeOption{
 		Source:          c.String("source"),
 		Target:          c.String("target"),
 		Pattern:         c.String("pattern"),
-		Builder:         c.String("builder"),
+		BuilderPath:     c.String("builder"),
 		WorkDir:         workDir,
 		SourceInsecure:  c.Bool("source-insecure"),
 		SourcePlainHTTP: c.Bool("source-plain-http"),

--- a/nydusify/pkg/converter/footer.go
+++ b/nydusify/pkg/converter/footer.go
@@ -7,7 +7,6 @@
 package converter
 
 import (
-	"bytes"
 	"encoding/binary"
 	"io"
 	"os"
@@ -43,7 +42,7 @@ const (
 // NydusBlobFooterMagic is the 8 raw ASCII bytes at the start of the footer,
 // written as-is (same style as the "LPBLMETA" blob meta and "LPGRPMAP"
 // groupmap sidecars).
-var NydusBlobFooterMagic = []byte("LPFOOTER")
+const NydusBlobFooterMagic = "LPFOOTER"
 
 // BlobMetaFile is a per-layer blob meta artifact packed into the bootstrap layer
 // alongside image.boot, named "<full_blob_sha256>.blob.meta".
@@ -68,7 +67,7 @@ func readFooter(ra io.ReaderAt, size int64) ([]byte, error) {
 	if _, err := ra.ReadAt(footer, size-NydusBlobFooterSize); err != nil {
 		return nil, errors.Wrap(err, "read nydus footer")
 	}
-	if !bytes.Equal(footer[0:8], NydusBlobFooterMagic) {
+	if string(footer[0:8]) != NydusBlobFooterMagic {
 		return nil, errors.Errorf("not a nydus blob: bad footer magic %q", footer[0:8])
 	}
 	if incompat := binary.LittleEndian.Uint32(footer[12:16]) & footerIncompatMask; incompat != 0 {

--- a/tests/integration/bench_test.go
+++ b/tests/integration/bench_test.go
@@ -491,18 +491,6 @@ func ublkAvailable() bool {
 	return true
 }
 
-// wipeCacheDir removes every per-blob artifact so the next daemon starts
-// COLD. Leaving a stale .group.map behind makes the daemon believe groups
-// are ready while the re-created .blob.data is all zeros.
-func wipeCacheDir(cacheDir string) {
-	for _, pattern := range []string{"*.blob.data", "*.blob.meta", "*.group.map", "*.prefetch.lock"} {
-		matches, _ := filepath.Glob(filepath.Join(cacheDir, pattern))
-		for _, m := range matches {
-			_ = os.Remove(m)
-		}
-	}
-}
-
 // cacheDirUsedBytes returns the allocated (not apparent) MiB of the blob
 // cache files in cacheDir.
 func cacheDirUsedBytes(cacheDir string) float64 {

--- a/tests/integration/core_test.go
+++ b/tests/integration/core_test.go
@@ -288,13 +288,6 @@ func sha256Bytes(data []byte) string {
 	return hex.EncodeToString(sum[:])
 }
 
-func sha256File(t *testing.T, path string) string {
-	t.Helper()
-	data, err := os.ReadFile(path)
-	require.NoError(t, err)
-	return sha256Bytes(data)
-}
-
 // cacheFileInode returns the inode of a cache sidecar, identifying the file
 // across processes.
 func cacheFileInode(t *testing.T, path string) uint64 {

--- a/tests/integration/fanotify_test.go
+++ b/tests/integration/fanotify_test.go
@@ -86,16 +86,13 @@ type fanotifyEnv struct {
 	blobDir    string
 	cacheDir   string
 	mntDir     string
-	logDir     string
 	checkDir   string
 	configPath string
-	daemonLog  string
 	straceLog  string
 	bootstrap  string
 
-	registryCID  string // docker container id, if we started one
-	daemonCmd    *exec.Cmd
-	daemonExited chan struct{} // closed when cmd.Wait() returns
+	registryCID string // docker container id, if we started one
+	daemonProc
 
 	sourceHashes map[string]string // rel path -> sha256
 }
@@ -118,11 +115,11 @@ func TestFanotifyE2E(t *testing.T) {
 	}
 	env.imageRef = fmt.Sprintf("%s/%s:%s", env.registry, env.repo, env.tag)
 
-	env.nydusBin = lookupFanotifyBin(t, "NYDUS_BIN", "nydus")
+	env.nydusBin = lookupBinFromEnv(t, "NYDUS_BIN", "nydus")
 	if out, err := exec.Command(env.nydusBin, "fanotify", "--help").CombinedOutput(); err != nil {
 		t.Skipf("nydus binary lacks the fanotify subcommand; build with --features cli,fanotify: %s", out)
 	}
-	env.nydusifyBin = lookupFanotifyBin(t, "NYDUSIFY_BIN", "nydusify")
+	env.nydusifyBin = lookupBinFromEnv(t, "NYDUSIFY_BIN", "nydusify")
 	if _, err := exec.LookPath("docker"); err != nil {
 		t.Skip("docker required for the throwaway local registry")
 	}
@@ -277,18 +274,11 @@ prefetch:
 
 // ----------------------------------------------------------------- daemon ----
 
-// wipeCache removes every per-blob artifact so the next daemon starts COLD.
-// Leaving a stale .group.map behind makes the daemon believe groups are ready
-// while the re-created .blob.data is all zeros — is_range_ready would ALLOW
-// without fetching and the reader gets a sparse hole. Wipe data+meta+map+lock.
+// wipeCache removes every per-blob artifact so the next daemon starts COLD
+// (see wipeCacheDir in util.go for why the stale .group.map matters).
 func (e *fanotifyEnv) wipeCache(t *testing.T) {
 	t.Helper()
-	for _, pattern := range []string{"*.blob.data", "*.blob.meta", "*.group.map", "*.prefetch.lock"} {
-		matches, _ := filepath.Glob(filepath.Join(e.cacheDir, pattern))
-		for _, m := range matches {
-			_ = os.Remove(m)
-		}
-	}
+	wipeCacheDir(e.cacheDir)
 }
 
 // startDaemon starts a COLD daemon (wipes the cache first) and waits for it to
@@ -304,9 +294,6 @@ func (e *fanotifyEnv) startDaemon(t *testing.T) {
 func (e *fanotifyEnv) spawnDaemon(t *testing.T) {
 	t.Helper()
 	t.Log("starting nydus fanotify daemon")
-	logFile, err := os.Create(e.daemonLog)
-	require.NoError(t, err)
-
 	cmd := exec.Command(e.nydusBin, "fanotify",
 		"--bootstrap", e.bootstrap,
 		"--config", e.configPath,
@@ -314,13 +301,7 @@ func (e *fanotifyEnv) spawnDaemon(t *testing.T) {
 		"--log-level", "debug",
 		"--log-dir", e.logDir,
 	)
-	cmd.Stdout = logFile
-	cmd.Stderr = logFile
-	require.NoError(t, cmd.Start())
-	e.daemonCmd = cmd
-	e.daemonExited = make(chan struct{})
-	go func() { _ = cmd.Wait(); close(e.daemonExited) }()
-	_ = logFile.Close()
+	e.spawnDaemonCmd(t, cmd)
 
 	require.Eventually(t, func() bool {
 		select {
@@ -331,30 +312,6 @@ func (e *fanotifyEnv) spawnDaemon(t *testing.T) {
 		return isMountpoint(e.mntDir) && e.countLogs(`event loop ready`) > 0
 	}, 60*time.Second, time.Second, "daemon did not mount / become ready within 60s:\n%s", e.logCorpus())
 	t.Logf("  daemon ready (pid=%d)", cmd.Process.Pid)
-}
-
-func (e *fanotifyEnv) stopDaemon(t *testing.T) {
-	t.Helper()
-	if e.daemonCmd == nil || e.daemonCmd.Process == nil {
-		return
-	}
-	// If already exited (e.g. crash detected elsewhere), just reap.
-	if e.daemonExited != nil {
-		select {
-		case <-e.daemonExited:
-			e.daemonCmd = nil
-			return
-		default:
-		}
-	}
-	_ = e.daemonCmd.Process.Signal(syscall.SIGTERM)
-	select {
-	case <-e.daemonExited:
-	case <-time.After(20 * time.Second):
-		_ = e.daemonCmd.Process.Kill()
-		<-e.daemonExited
-	}
-	e.daemonCmd = nil
 }
 
 func (e *fanotifyEnv) restartDaemonCold(t *testing.T) {
@@ -385,8 +342,8 @@ func (e *fanotifyEnv) caseMetadataOffpath(t *testing.T) { // C1
 }
 
 func (e *fanotifyEnv) caseTinyFile(t *testing.T) { // C2
-	got := shaFile(t, filepath.Join(e.mntDir, "hello.txt"))
-	want := shaFile(t, filepath.Join(e.sourceDir, "hello.txt"))
+	got := sha256File(t, filepath.Join(e.mntDir, "hello.txt"))
+	want := sha256File(t, filepath.Join(e.sourceDir, "hello.txt"))
 	assert.Equal(t, want, got, "hello.txt byte-exact over fanotify")
 	content, err := os.ReadFile(filepath.Join(e.mntDir, "hello.txt"))
 	require.NoError(t, err)
@@ -442,8 +399,8 @@ func (e *fanotifyEnv) caseWarmFastpath(t *testing.T) { // C7 — behavioural war
 	// bytes AND allocate ~no new blocks (is_range_ready short-circuits the fetch).
 	blob := e.cacheBlob(t)
 	before := usedBytes(blob)
-	got := shaFile(t, filepath.Join(e.mntDir, "large.bin"))
-	want := shaFile(t, filepath.Join(e.sourceDir, "large.bin"))
+	got := sha256File(t, filepath.Join(e.mntDir, "large.bin"))
+	want := sha256File(t, filepath.Join(e.sourceDir, "large.bin"))
 	after := usedBytes(blob)
 	assert.Equal(t, want, got, "warm re-read is byte-exact")
 	assert.Less(t, after-before, int64(1<<20), "warm re-read allocates ~no new cache blocks (is_range_ready fast path)")
@@ -486,7 +443,7 @@ func (e *fanotifyEnv) caseConcurrency(t *testing.T) { // C8 — stress per-event
 	srcMany, _ := filepath.Glob(filepath.Join(e.sourceDir, "many", "*.bin"))
 	for _, f := range srcMany {
 		name := filepath.Base(f)
-		if shaFile(t, filepath.Join(e.mntDir, "many", name)) != shaFile(t, f) {
+		if sha256File(t, filepath.Join(e.mntDir, "many", name)) != sha256File(t, f) {
 			bad++
 		}
 	}
@@ -510,8 +467,8 @@ func (e *fanotifyEnv) casePersistence(t *testing.T) { // C9 — warm cache survi
 	e.spawnDaemon(t)
 
 	beforeFetch := e.countLogs(`job [0-9]+ dispatched`)
-	got := shaFile(t, filepath.Join(e.mntDir, "large.bin"))
-	want := shaFile(t, filepath.Join(e.sourceDir, "large.bin"))
+	got := sha256File(t, filepath.Join(e.mntDir, "large.bin"))
+	want := sha256File(t, filepath.Join(e.sourceDir, "large.bin"))
 	assert.Equal(t, want, got, "large.bin still byte-exact after restart")
 	afterFetch := e.countLogs(`job [0-9]+ dispatched`)
 	assert.Equal(t, beforeFetch, afterFetch, "warm cache re-serves with NO backend fetch after restart")
@@ -667,10 +624,6 @@ func (e *fanotifyEnv) registryIsLoopback() bool {
 		strings.HasPrefix(e.registry, "[::1]:")
 }
 
-func (e *fanotifyEnv) daemonAlive() bool {
-	return e.daemonCmd != nil && e.daemonCmd.ProcessState == nil
-}
-
 // cacheBlob returns the first *.blob.data file in the cache dir.
 func (e *fanotifyEnv) cacheBlob(t *testing.T) string {
 	t.Helper()
@@ -681,31 +634,6 @@ func (e *fanotifyEnv) cacheBlob(t *testing.T) string {
 	return matches[0]
 }
 
-// logCorpus concatenates the daemon console log and every file under logDir.
-func (e *fanotifyEnv) logCorpus() string {
-	var b strings.Builder
-	b.Write(readFileOrEmpty(e.daemonLog))
-	entries, _ := os.ReadDir(e.logDir)
-	for _, entry := range entries {
-		if entry.Type().IsRegular() {
-			b.Write(readFileOrEmpty(filepath.Join(e.logDir, entry.Name())))
-		}
-	}
-	return b.String()
-}
-
-// countLogs counts lines across every log sink matching the ERE-style pattern.
-func (e *fanotifyEnv) countLogs(pattern string) int {
-	re := regexp.MustCompile(pattern)
-	count := 0
-	for _, line := range strings.Split(e.logCorpus(), "\n") {
-		if re.MatchString(line) {
-			count++
-		}
-	}
-	return count
-}
-
 // usedBytes returns the actual on-disk allocated bytes (blocks * 512), NOT the
 // apparent size — the demand-paging signal (a hole file reports ~0).
 func usedBytes(path string) int64 {
@@ -714,17 +642,6 @@ func usedBytes(path string) int64 {
 		return 0
 	}
 	return st.Blocks * 512
-}
-
-func shaFile(t *testing.T, path string) string {
-	t.Helper()
-	f, err := os.Open(path)
-	require.NoError(t, err)
-	defer func() { _ = f.Close() }()
-	h := sha256.New()
-	_, err = io.Copy(h, f)
-	require.NoError(t, err)
-	return hex.EncodeToString(h.Sum(nil))
 }
 
 // sliceSHA reads countMiB starting at skipMiB (bs=1M semantics) and returns the
@@ -781,7 +698,7 @@ func hashTree(t *testing.T, dir string) map[string]string {
 		if err != nil {
 			return err
 		}
-		hashes[rel] = shaFile(t, path)
+		hashes[rel] = sha256File(t, path)
 		return nil
 	})
 	require.NoError(t, err)
@@ -841,27 +758,11 @@ func nonDigitTrim(s string) string {
 	return s
 }
 
-func lookupFanotifyBin(t *testing.T, envName, name string) string {
-	t.Helper()
-	if p := os.Getenv(envName); p != "" {
-		require.NoError(t, validateExecutablePath(p, envName))
-		return p
-	}
-	return mustLookupExecutable(t, name)
-}
-
 func envOr(key, def string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
 	}
 	return def
-}
-
-// readFileOrEmpty reads path for log dumps, treating missing or unreadable
-// files as empty.
-func readFileOrEmpty(path string) []byte {
-	data, _ := os.ReadFile(path)
-	return data
 }
 
 func findFile(root, name string) string {

--- a/tests/integration/nbd_test.go
+++ b/tests/integration/nbd_test.go
@@ -61,6 +61,8 @@ var nbdReadFailurePattern = regexp.MustCompile(`nbd: read .* failed:`)
 
 // nbdEnv holds the paths, binaries and process handles for one E2E run.
 type nbdEnv struct {
+	daemonProc
+
 	nydusBin string
 	device   string
 
@@ -69,13 +71,8 @@ type nbdEnv struct {
 	blobDir    string
 	cacheDir   string
 	mntDir     string
-	logDir     string
 	configPath string
-	daemonLog  string
 	bootstrap  string
-
-	daemonCmd    *exec.Cmd
-	daemonExited chan struct{} // closed when cmd.Wait() returns
 
 	sourceHashes map[string]string // rel path -> sha256
 }
@@ -97,7 +94,7 @@ func TestNbdE2E(t *testing.T) {
 	}
 
 	env := &nbdEnv{device: device}
-	env.nydusBin = lookupFanotifyBin(t, "NYDUS_BIN", "nydus")
+	env.nydusBin = lookupBinFromEnv(t, "NYDUS_BIN", "nydus")
 	if out, err := exec.Command(env.nydusBin, "nbd", "--help").CombinedOutput(); err != nil {
 		t.Skipf("nydus binary lacks the nbd subcommand; build with --features cli,nbd: %s", out)
 	}
@@ -182,18 +179,11 @@ func (e *nbdEnv) writeConfig(t *testing.T) {
 
 // ----------------------------------------------------------------- daemon ----
 
-// wipeCache removes every per-blob artifact so the next daemon starts COLD.
-// Leaving a stale .group.map behind makes the core believe groups are
-// ready while the re-created .blob.data is all zeros — reads would return
-// zeros without fetching. Wipe data+meta+map+lock.
+// wipeCache removes every per-blob artifact so the next daemon starts COLD
+// (see wipeCacheDir in util.go for why the stale .group.map matters).
 func (e *nbdEnv) wipeCache(t *testing.T) {
 	t.Helper()
-	for _, pattern := range []string{"*.blob.data", "*.blob.meta", "*.group.map", "*.prefetch.lock"} {
-		matches, _ := filepath.Glob(filepath.Join(e.cacheDir, pattern))
-		for _, m := range matches {
-			_ = os.Remove(m)
-		}
-	}
+	wipeCacheDir(e.cacheDir)
 }
 
 // startDaemon starts a COLD daemon (wipes the cache first) and waits for it
@@ -209,9 +199,6 @@ func (e *nbdEnv) startDaemon(t *testing.T) {
 func (e *nbdEnv) spawnDaemon(t *testing.T) {
 	t.Helper()
 	t.Logf("starting nydus nbd daemon on %s", e.device)
-	logFile, err := os.Create(e.daemonLog)
-	require.NoError(t, err)
-
 	cmd := exec.Command(e.nydusBin, "nbd",
 		"--bootstrap", e.bootstrap,
 		"--config", e.configPath,
@@ -220,13 +207,7 @@ func (e *nbdEnv) spawnDaemon(t *testing.T) {
 		"--log-level", "debug",
 		"--log-dir", e.logDir,
 	)
-	cmd.Stdout = logFile
-	cmd.Stderr = logFile
-	require.NoError(t, cmd.Start())
-	e.daemonCmd = cmd
-	e.daemonExited = make(chan struct{})
-	go func() { _ = cmd.Wait(); close(e.daemonExited) }()
-	_ = logFile.Close()
+	e.spawnDaemonCmd(t, cmd)
 
 	require.Eventually(t, func() bool {
 		select {
@@ -237,30 +218,6 @@ func (e *nbdEnv) spawnDaemon(t *testing.T) {
 		return isMountpoint(e.mntDir) && e.countLogs(`mounted `) > 0
 	}, 60*time.Second, time.Second, "daemon did not mount / become ready within 60s:\n%s", e.logCorpus())
 	t.Logf("  daemon ready (pid=%d, device=%s)", cmd.Process.Pid, e.device)
-}
-
-func (e *nbdEnv) stopDaemon(t *testing.T) {
-	t.Helper()
-	if e.daemonCmd == nil || e.daemonCmd.Process == nil {
-		return
-	}
-	// If already exited (e.g. crash detected elsewhere), just reap.
-	if e.daemonExited != nil {
-		select {
-		case <-e.daemonExited:
-			e.daemonCmd = nil
-			return
-		default:
-		}
-	}
-	_ = e.daemonCmd.Process.Signal(syscall.SIGTERM)
-	select {
-	case <-e.daemonExited:
-	case <-time.After(20 * time.Second):
-		_ = e.daemonCmd.Process.Kill()
-		<-e.daemonExited
-	}
-	e.daemonCmd = nil
 }
 
 // waitForDeviceRelease waits for the kernel to finalize NBD device teardown
@@ -320,8 +277,8 @@ func (e *nbdEnv) caseMetadataOffpath(t *testing.T) { // C1
 }
 
 func (e *nbdEnv) caseTinyFile(t *testing.T) { // C2
-	got := shaFile(t, filepath.Join(e.mntDir, "hello.txt"))
-	want := shaFile(t, filepath.Join(e.sourceDir, "hello.txt"))
+	got := sha256File(t, filepath.Join(e.mntDir, "hello.txt"))
+	want := sha256File(t, filepath.Join(e.sourceDir, "hello.txt"))
 	assert.Equal(t, want, got, "hello.txt byte-exact over NBD")
 	content, err := os.ReadFile(filepath.Join(e.mntDir, "hello.txt"))
 	require.NoError(t, err)
@@ -372,8 +329,8 @@ func (e *nbdEnv) caseWarmFastpath(t *testing.T) { // C7 — behavioural warm-pat
 	// bytes AND allocate ~no new blocks (the core's fully-ready fast path
 	// short-circuits the fetch).
 	before := e.cacheUsed()
-	got := shaFile(t, filepath.Join(e.mntDir, "large.bin"))
-	want := shaFile(t, filepath.Join(e.sourceDir, "large.bin"))
+	got := sha256File(t, filepath.Join(e.mntDir, "large.bin"))
+	want := sha256File(t, filepath.Join(e.sourceDir, "large.bin"))
 	after := e.cacheUsed()
 	assert.Equal(t, want, got, "warm re-read is byte-exact")
 	assert.Less(t, after-before, int64(1<<20), "warm re-read allocates ~no new cache blocks (fully-ready fast path)")
@@ -416,7 +373,7 @@ func (e *nbdEnv) caseConcurrency(t *testing.T) { // C8 — stress per-worker req
 	srcMany, _ := filepath.Glob(filepath.Join(e.sourceDir, "many", "*.bin"))
 	for _, f := range srcMany {
 		name := filepath.Base(f)
-		if shaFile(t, filepath.Join(e.mntDir, "many", name)) != shaFile(t, f) {
+		if sha256File(t, filepath.Join(e.mntDir, "many", name)) != sha256File(t, f) {
 			bad++
 		}
 	}
@@ -440,8 +397,8 @@ func (e *nbdEnv) casePersistence(t *testing.T) { // C9 — warm cache survives a
 	t.Log("  restarting daemon with warm cache (no wipe)")
 	e.spawnDaemon(t)
 
-	got := shaFile(t, filepath.Join(e.mntDir, "large.bin"))
-	want := shaFile(t, filepath.Join(e.sourceDir, "large.bin"))
+	got := sha256File(t, filepath.Join(e.mntDir, "large.bin"))
+	want := sha256File(t, filepath.Join(e.sourceDir, "large.bin"))
 	assert.Equal(t, want, got, "large.bin still byte-exact after restart")
 	after := e.cacheUsed()
 	// Warm cache: re-reading the same data should not grow the cache (the
@@ -534,16 +491,6 @@ func (e *nbdEnv) logCorpus() string {
 // countLogs counts lines across every log sink matching the pattern.
 func (e *nbdEnv) countLogs(pattern string) int {
 	return countMatchingLines(e.logCorpus(), regexp.MustCompile(pattern))
-}
-
-func countMatchingLines(corpus string, re *regexp.Regexp) int {
-	count := 0
-	for _, line := range strings.Split(corpus, "\n") {
-		if re.MatchString(line) {
-			count++
-		}
-	}
-	return count
 }
 
 func TestCountMatchingLinesCountsOnlyNbdReadFailures(t *testing.T) {

--- a/tests/integration/ublk_test.go
+++ b/tests/integration/ublk_test.go
@@ -2,10 +2,7 @@ package integration
 
 import (
 	"bufio"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -56,7 +53,7 @@ func TestUblkTarget(t *testing.T) {
 
 	texture.MakeStandardCorpus(t, corpusDir)
 	buildNydusFSImageToDir(t, nydusBin, bootstrapPath, blobDir, corpusDir, ublkChunkSize)
-	writeUblkConfig(t, configPath, blobDir, cacheDir)
+	writeLocalStorageConfig(t, configPath, blobDir, cacheDir)
 
 	devPath, stopDaemon := startUblkTarget(t, nydusBin, bootstrapPath, configPath, logDir)
 	defer stopDaemon()
@@ -97,7 +94,7 @@ func compareTrees(t *testing.T, want, got string) {
 		if !info.mode.IsRegular() {
 			continue
 		}
-		require.Equal(t, hashFile(t, filepath.Join(want, rel)), hashFile(t, filepath.Join(got, rel)),
+		require.Equal(t, sha256File(t, filepath.Join(want, rel)), sha256File(t, filepath.Join(got, rel)),
 			"content mismatch for %s", rel)
 	}
 }
@@ -143,30 +140,6 @@ func describeTree(t *testing.T, root string) map[string]entryInfo {
 	}))
 
 	return entries
-}
-
-func hashFile(t *testing.T, path string) string {
-	t.Helper()
-
-	file, err := os.Open(path)
-	require.NoError(t, err)
-	defer func() { _ = file.Close() }()
-
-	digest := sha256.New()
-	_, err = io.Copy(digest, file)
-	require.NoError(t, err)
-	return hex.EncodeToString(digest.Sum(nil))
-}
-
-func writeUblkConfig(t *testing.T, path, blobDir, cacheDir string) {
-	t.Helper()
-	require.NoError(t, os.MkdirAll(cacheDir, 0755))
-	config := fmt.Sprintf(
-		"backend:\n  type: local\n  config:\n    dir: %s\ncache:\n  type: local\n  config:\n    dir: %s\nprefetch:\n  enable: false\n",
-		blobDir,
-		cacheDir,
-	)
-	require.NoError(t, os.WriteFile(path, []byte(config), 0644))
 }
 
 // startUblkTarget runs `nydus ublk` and returns the device path it prints on

--- a/tests/integration/uffd_test.go
+++ b/tests/integration/uffd_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"net"
 	"os"
@@ -58,7 +57,7 @@ func TestUffdServiceSmoke(t *testing.T) {
 
 	texture.MakeStandardCorpus(t, corpusDir)
 	buildNydusFSImageToDir(t, nydusBin, bootstrapPath, blobDir, corpusDir, uffdSmokeRequestBlock)
-	writeUffdSmokeConfig(t, configPath, blobDir, cacheDir)
+	writeLocalStorageConfig(t, configPath, blobDir, cacheDir)
 
 	cmd := startUffdService(t, nydusBin, bootstrapPath, configPath, socketPath, logDir)
 	defer stopUffdService(t, cmd)
@@ -104,17 +103,6 @@ type uffdRange struct {
 	deviceOffset uint64
 	fileOffset   uint64
 	length       uint64
-}
-
-func writeUffdSmokeConfig(t *testing.T, path, blobDir, cacheDir string) {
-	t.Helper()
-	require.NoError(t, os.MkdirAll(cacheDir, 0755))
-	config := fmt.Sprintf(
-		"backend:\n  type: local\n  config:\n    dir: %s\ncache:\n  type: local\n  config:\n    dir: %s\nprefetch:\n  enable: false\n",
-		blobDir,
-		cacheDir,
-	)
-	require.NoError(t, os.WriteFile(path, []byte(config), 0644))
 }
 
 func startUffdService(t *testing.T, nydusBin, bootstrapPath, configPath, socketPath, logDir string) *exec.Cmd {

--- a/tests/integration/util.go
+++ b/tests/integration/util.go
@@ -2,13 +2,16 @@ package integration
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -251,6 +254,36 @@ func isMountpoint(path string) bool {
 	return exec.Command("mountpoint", "-q", path).Run() == nil
 }
 
+// startFuseMount starts a prepared FUSE daemon command, waits for mnt to
+// become a mountpoint, and returns a cleanup that unmounts (with EBUSY
+// retries) and reaps the child.
+func startFuseMount(t *testing.T, cmd *exec.Cmd, mnt, label string) (cleanup func()) {
+	t.Helper()
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Start())
+
+	require.Eventually(t, func() bool {
+		return isMountpoint(mnt)
+	}, 10*time.Second, 200*time.Millisecond, label+" failed to mount within 10s")
+
+	return func() {
+		unmountFuse(mnt)
+
+		// Send SIGTERM and don't block indefinitely while waiting.
+		if cmd.Process != nil {
+			_ = cmd.Process.Signal(syscall.SIGTERM)
+			done := make(chan struct{})
+			go func() { _ = cmd.Wait(); close(done) }()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				_ = cmd.Process.Kill()
+			}
+		}
+	}
+}
+
 // mountCErofsFuse mounts the EROFS image at imagePath using the C erofsfuse implementation and
 // returns a cleanup function to unmount it.
 func mountCErofsFuse(t *testing.T, cErofsFuseBin, imagePath, mnt string, blobdevs ...string) (cleanup func()) {
@@ -267,31 +300,7 @@ func mountCErofsFuse(t *testing.T, cErofsFuseBin, imagePath, mnt string, blobdev
 	}
 	args = append(args, imagePath, mnt, "-f")
 
-	cmd := exec.Command(cErofsFuseBin, args...)
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
-	require.NoError(t, cmd.Start())
-
-	// Wait for the mountpoint to become ready.
-	require.Eventually(t, func() bool {
-		return isMountpoint(mnt)
-	}, 10*time.Second, 200*time.Millisecond, "erofsfuse failed to mount within 10s")
-
-	return func() {
-		_ = exec.Command("fusermount", "-u", mnt).Run()
-
-		// Send SIGTERM and don't block indefinitely while waiting.
-		if cmd.Process != nil {
-			_ = cmd.Process.Signal(syscall.SIGTERM)
-			done := make(chan struct{})
-			go func() { _ = cmd.Wait(); close(done) }()
-			select {
-			case <-done:
-			case <-time.After(5 * time.Second):
-				_ = cmd.Process.Kill()
-			}
-		}
-	}
+	return startFuseMount(t, exec.Command(cErofsFuseBin, args...), mnt, "erofsfuse")
 }
 
 // mountNydus runs `nydus fuse` in the background and returns a cleanup
@@ -309,31 +318,7 @@ func mountNydus(t *testing.T, nydusBin, imagePath, blobdev, mnt string) (cleanup
 		require.FailNow(t, "mountNydus requires either blobdev or imagePath+blobdev")
 	}
 
-	cmd := exec.Command(nydusBin, args...)
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
-	require.NoError(t, cmd.Start())
-
-	// Wait for the mountpoint to become ready.
-	require.Eventually(t, func() bool {
-		return isMountpoint(mnt)
-	}, 10*time.Second, 200*time.Millisecond, "nydus fuse failed to mount within 10s")
-
-	return func() {
-		_ = exec.Command("fusermount", "-u", mnt).Run()
-
-		// Send SIGTERM and don't block indefinitely while waiting.
-		if cmd.Process != nil {
-			_ = cmd.Process.Signal(syscall.SIGTERM)
-			done := make(chan struct{})
-			go func() { _ = cmd.Wait(); close(done) }()
-			select {
-			case <-done:
-			case <-time.After(5 * time.Second):
-				_ = cmd.Process.Kill()
-			}
-		}
-	}
+	return startFuseMount(t, exec.Command(nydusBin, args...), mnt, "nydus fuse")
 }
 
 // mountNydusBootstrap runs `nydus fuse` using a bootstrap plus a blob directory.
@@ -359,29 +344,7 @@ func mountNydusBootstrapWithCache(
 		require.NoError(t, os.MkdirAll(cacheDir, 0755))
 		args = append(args, "--cache-dir", cacheDir)
 	}
-	cmd := exec.Command(nydusBin, args...)
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
-	require.NoError(t, cmd.Start())
-
-	require.Eventually(t, func() bool {
-		return isMountpoint(mnt)
-	}, 10*time.Second, 200*time.Millisecond, "nydus bootstrap fuse failed to mount within 10s")
-
-	return func() {
-		unmountFuse(mnt)
-
-		if cmd.Process != nil {
-			_ = cmd.Process.Signal(syscall.SIGTERM)
-			done := make(chan struct{})
-			go func() { _ = cmd.Wait(); close(done) }()
-			select {
-			case <-done:
-			case <-time.After(5 * time.Second):
-				_ = cmd.Process.Kill()
-			}
-		}
-	}
+	return startFuseMount(t, exec.Command(nydusBin, args...), mnt, "nydus bootstrap fuse")
 }
 
 // unmountFuse detaches mnt, retrying while the kernel still holds references.
@@ -470,4 +433,145 @@ func listFilesInDir(t *testing.T, dir string) map[string]struct{} {
 		}
 	}
 	return files
+}
+
+// sha256File returns the hex SHA-256 of a file, streaming to support large
+// files. Shared by every transport suite.
+func sha256File(t *testing.T, path string) string {
+	t.Helper()
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	_, err = io.Copy(h, f)
+	require.NoError(t, err)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// wipeCacheDir removes every per-blob artifact so the next daemon starts
+// COLD. Leaving a stale .group.map behind makes the daemon believe groups
+// are ready while the re-created .blob.data is all zeros — reads would
+// return zeros without fetching. Wipe data+meta+map+lock.
+func wipeCacheDir(cacheDir string) {
+	for _, pattern := range []string{"*.blob.data", "*.blob.meta", "*.group.map", "*.prefetch.lock"} {
+		matches, _ := filepath.Glob(filepath.Join(cacheDir, pattern))
+		for _, m := range matches {
+			_ = os.Remove(m)
+		}
+	}
+}
+
+// countMatchingLines counts the lines of corpus matching re.
+func countMatchingLines(corpus string, re *regexp.Regexp) int {
+	count := 0
+	for _, line := range strings.Split(corpus, "\n") {
+		if re.MatchString(line) {
+			count++
+		}
+	}
+	return count
+}
+
+// lookupBinFromEnv resolves a test binary: an explicit env override wins,
+// otherwise the name is resolved from PATH.
+func lookupBinFromEnv(t *testing.T, envName, name string) string {
+	t.Helper()
+	if p := os.Getenv(envName); p != "" {
+		require.NoError(t, validateExecutablePath(p, envName))
+		return p
+	}
+	return mustLookupExecutable(t, name)
+}
+
+// writeLocalStorageConfig writes the standard local-backend storage config
+// (prefetch disabled) used by the transport test suites.
+func writeLocalStorageConfig(t *testing.T, path, blobDir, cacheDir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(cacheDir, 0755))
+	config := fmt.Sprintf(
+		"backend:\n  type: local\n  config:\n    dir: %s\ncache:\n  type: local\n  config:\n    dir: %s\nprefetch:\n  enable: false\n",
+		blobDir,
+		cacheDir,
+	)
+	require.NoError(t, os.WriteFile(path, []byte(config), 0644))
+}
+
+// readFileOrEmpty reads path for log dumps, treating missing or unreadable
+// files as empty.
+func readFileOrEmpty(path string) []byte {
+	data, _ := os.ReadFile(path)
+	return data
+}
+
+// daemonProc tracks a spawned transport daemon (nydus nbd/fanotify): the
+// command, its exit channel, and its log locations. Embedded by the
+// per-transport test envs so spawn/stop/liveness/log logic is shared.
+type daemonProc struct {
+	daemonCmd    *exec.Cmd
+	daemonExited chan struct{} // closed when cmd.Wait() returns
+	daemonLog    string
+	logDir       string
+}
+
+// spawnDaemonCmd starts cmd with its output tee'd to the daemon log and
+// tracks its exit; readiness polling stays with the caller (per-transport).
+func (d *daemonProc) spawnDaemonCmd(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+	logFile, err := os.Create(d.daemonLog)
+	require.NoError(t, err)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	require.NoError(t, cmd.Start())
+	d.daemonCmd = cmd
+	d.daemonExited = make(chan struct{})
+	go func() { _ = cmd.Wait(); close(d.daemonExited) }()
+	_ = logFile.Close()
+}
+
+// stopDaemon SIGTERMs the daemon and reaps it, escalating to SIGKILL after
+// 20s. Safe to call when the daemon already exited or was never started.
+func (d *daemonProc) stopDaemon(t *testing.T) {
+	t.Helper()
+	if d.daemonCmd == nil || d.daemonCmd.Process == nil {
+		return
+	}
+	// If already exited (e.g. crash detected elsewhere), just reap.
+	if d.daemonExited != nil {
+		select {
+		case <-d.daemonExited:
+			d.daemonCmd = nil
+			return
+		default:
+		}
+	}
+	_ = d.daemonCmd.Process.Signal(syscall.SIGTERM)
+	select {
+	case <-d.daemonExited:
+	case <-time.After(20 * time.Second):
+		_ = d.daemonCmd.Process.Kill()
+		<-d.daemonExited
+	}
+	d.daemonCmd = nil
+}
+
+func (d *daemonProc) daemonAlive() bool {
+	return d.daemonCmd != nil && d.daemonCmd.ProcessState == nil
+}
+
+// logCorpus concatenates the console log and every file-log sink.
+func (d *daemonProc) logCorpus() string {
+	var b strings.Builder
+	b.Write(readFileOrEmpty(d.daemonLog))
+	entries, _ := os.ReadDir(d.logDir)
+	for _, entry := range entries {
+		if entry.Type().IsRegular() {
+			b.Write(readFileOrEmpty(filepath.Join(d.logDir, entry.Name())))
+		}
+	}
+	return b.String()
+}
+
+// countLogs counts lines across every log sink matching the ERE-style pattern.
+func (d *daemonProc) countLogs(pattern string) int {
+	return countMatchingLines(d.logCorpus(), regexp.MustCompile(pattern))
 }


### PR DESCRIPTION



## Overview
Rename chunk/resolve helpers, group_map/batches fields, and internal blob assembly identifiers for clarity. Replace per-combination BlobMeta constructors with a builder API, tighten the BlobBackend trait, deduplicate eventfd helpers and async read paths, consolidate blob decompression and patch image config logic, extract shared CLI log args and daemon preamble into cli_common, and move shared daemon/test helpers into util.go.
## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.