### PR TITLE
refactor: redesign blob footer API, unify validation, and migrate logging to stderr

### DIFF
--- a/docs/nydus.md
+++ b/docs/nydus.md
@@ -207,7 +207,7 @@ Current implementation notes:
 
 ### Export
 
-`nydus export <BLOB> [--output <path>|-]`
+`nydus export <BLOB> [-o <path>]`
 
 A nydus full blob is self-describing: it carries the filesystem tree, the chunk
 data and the footer of exactly one layer. Exporting it back into an OCI layer
@@ -226,8 +226,8 @@ Arguments:
 	<SOURCE>  Specify the nydus full blob to export the OCI layer tar stream from
 
 Options:
-	--output <OUTPUT>
-		Specify the file path to save the exported tar stream, or `-` for stdout [env: NYDUS_EXPORT_OUTPUT=] [default: -]
+	-o, --output <OUTPUT>
+		Specify the file path to save the exported tar stream (defaults to stdout) [env: NYDUS_EXPORT_OUTPUT=]
 	-l, --log-level <LOG_LEVEL>
 		Specify the logging level [trace, debug, info, warn, error] [env: NYDUS_EXPORT_LOG_LEVEL=] [default: info]
 ```
@@ -249,7 +249,7 @@ tar entry per inode, streaming file data straight out of the blob:
 Current implementation notes:
 
 - `<SOURCE>` must be a regular file, because the blob is memory-mapped.
-- With `--output -` the tar goes to stdout and logging is redirected to stderr,
+- Without `--output` the tar goes to stdout; logging always goes to stderr,
 	so the stream stays clean for piping.
 - Entries follow EROFS directory order, which is sorted by name, so the output
 	is deterministic for a given blob.

--- a/nydus-backend/src/local.rs
+++ b/nydus-backend/src/local.rs
@@ -237,7 +237,7 @@ fn probe_full_blob_source(
     path: &Path,
     cache_key: [u8; SHA256_DIGEST_SIZE],
 ) -> io::Result<Option<ResolvedSource>> {
-    let footer = match BlobFooter::read_from_path(path) {
+    let footer = match BlobFooter::from_blob_path(path) {
         Ok(footer) => footer,
         Err(_) => return Ok(None),
     };

--- a/nydus-backend/src/registry/mod.rs
+++ b/nydus-backend/src/registry/mod.rs
@@ -622,21 +622,17 @@ impl Registry {
         blob_id: &[u8; SHA256_DIGEST_SIZE],
     ) -> RegistryResult<BlobMetadata> {
         let size = self.fetch_blob_size(blob_id)?;
-        if size < NYDUS_BLOB_FOOTER_SIZE as u64 {
-            return Err(RegistryError::Io(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "registry blob is too small for a nydus footer",
-            )));
-        }
+        let footer_offset = BlobFooter::offset_from_size(size)
+            .map_err(|err| RegistryError::Io(io::Error::other(err)))?;
 
-        let mut footer_bytes = vec![0u8; NYDUS_BLOB_FOOTER_SIZE];
+        let mut footer_bytes = [0u8; NYDUS_BLOB_FOOTER_SIZE];
         self.try_read(
             blob_id,
-            size - NYDUS_BLOB_FOOTER_SIZE as u64,
+            footer_offset,
             &mut footer_bytes,
             ReadContext::raw(ReadKind::OnDemand),
         )?;
-        let footer = BlobFooter::parse(&footer_bytes, size)
+        let footer = BlobFooter::from_bytes(&footer_bytes)
             .map_err(|err| RegistryError::Io(io::Error::other(err)))?;
 
         let blob_metadata_size = usize::try_from(footer.blob_metadata_size()).map_err(|_| {

--- a/nydus-core/src/reader/mod.rs
+++ b/nydus-core/src/reader/mod.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, OnceLock};
 use memmap2::Mmap;
 
 use nydus_backend::{BlobBackend, Local};
-use nydus_format::blob::{BlobFooter, NYDUS_BLOB_FOOTER_SIZE};
+use nydus_format::blob::BlobFooter;
 use nydus_format::erofs::{
     cast_ref, is_nydus_prefetch_blobs_xattr, ErofsDeviceSlot, ErofsSuperblock, EROFS_BLOB_ID_SIZE,
     EROFS_BLOCK_SIZE, EROFS_DEVICESLOT_SIZE, EROFS_SB_BASE_SIZE, EROFS_SLOTSIZE,
@@ -72,7 +72,7 @@ pub struct ErofsReader {
 impl ErofsReader {
     /// Open a nydus blob / bootstrap file for metadata-only inspection.
     pub fn open_metadata_only(path: &Path) -> io::Result<Self> {
-        let mmap = Self::map_file(path)?;
+        let mmap = Self::mmap_file(path)?;
         let image_offset = Self::image_offset_from_footer(&mmap)?.unwrap_or(0);
         let sb_offset = image_offset
             .checked_add(EROFS_SUPER_OFFSET as usize)
@@ -95,7 +95,7 @@ impl ErofsReader {
     /// footer`): everything is served from the file itself, no backend or
     /// cache is involved.
     pub fn open_blob(blob_path: &Path) -> io::Result<Self> {
-        let mmap = Self::map_file(blob_path)?;
+        let mmap = Self::mmap_file(blob_path)?;
         let image_offset = Self::image_offset_from_footer(&mmap)?.ok_or_else(|| {
             io::Error::new(io::ErrorKind::InvalidData, "nydus blob footer not found")
         })?;
@@ -145,7 +145,7 @@ impl ErofsReader {
         cache_dir: Option<&Path>,
         trace_recorder: Option<Arc<TraceRecorder>>,
     ) -> io::Result<Self> {
-        let mmap = Self::map_file(bootstrap_path)?;
+        let mmap = Self::mmap_file(bootstrap_path)?;
         let sb_offset = EROFS_SUPER_OFFSET as usize;
         let sb = Self::superblock_from(&mmap, sb_offset)?;
         Self::validate_superblock(sb)?;
@@ -170,21 +170,16 @@ impl ErofsReader {
         })
     }
 
-    fn map_file(path: &Path) -> io::Result<Mmap> {
+    fn mmap_file(path: &Path) -> io::Result<Mmap> {
         let file = fs::File::open(path)?;
-        // SAFETY: file opened read-only, never modified while mapped.
         unsafe { Mmap::map(&file) }
     }
 
     fn image_offset_from_footer(mmap: &[u8]) -> io::Result<Option<usize>> {
-        if mmap.len() < NYDUS_BLOB_FOOTER_SIZE {
+        let Some(footer) = BlobFooter::from_blob_bytes(mmap).map_err(io::Error::other)? else {
             return Ok(None);
-        }
-        let footer_bytes = &mmap[mmap.len() - NYDUS_BLOB_FOOTER_SIZE..];
-        if !BlobFooter::has_magic(footer_bytes) {
-            return Ok(None);
-        }
-        let footer = BlobFooter::parse_from_tail(mmap).map_err(io::Error::other)?;
+        };
+
         usize::try_from(footer.bootstrap_offset())
             .map(Some)
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "bootstrap offset too large"))

--- a/nydus-format/src/blob/footer.rs
+++ b/nydus-format/src/blob/footer.rs
@@ -1,22 +1,30 @@
-use std::fs::File;
-use std::io::{Read, Seek, SeekFrom, Write};
-use std::path::Path;
-
-use crate::blob::validate::{crc32_with_zeroed_field, validate_incompat_flags};
+use crate::blob::validate::validate_incompat_flags;
 use crate::erofs::{blocks_to_bytes, EROFS_BLOCK_SIZE};
 use crate::error::{Context, Error, Result};
 use crate::utils::le::{read_u32_at, read_u64_at, write_u32_at, write_u64_at};
+use crc32c::crc32c;
+use std::fs::File;
+use std::io::Write;
+use std::ops::Range;
+use std::os::unix::fs::FileExt;
+use std::path::Path;
 
 /// On-disk magic: 8 raw ASCII bytes, written as-is so a hexdump of the
 /// footer starts with the readable string. Same style and `magic + version +
 /// flags` header prefix as the blob meta (`LPBLMETA`) and block_group_map
 /// (`LPGRPMAP`) sidecars.
 pub const NYDUS_BLOB_FOOTER_MAGIC: [u8; 8] = *b"LPFOOTER";
+
 /// On-disk format generation, informational only: readers do not gate on it.
 /// Compatibility is governed EROFS-style by the magic and the incompat half
 /// of `flags` (unknown incompat bits reject the footer).
 pub const NYDUS_BLOB_FOOTER_VERSION: u32 = 1;
+
+/// The footer's fixed on-disk size: one EROFS block at the blob's tail.
 pub const NYDUS_BLOB_FOOTER_SIZE: usize = 4096;
+
+/// Every region offset in the blob, and the footer itself, is aligned to
+/// this boundary (the EROFS block size).
 pub const NYDUS_BLOB_FOOTER_ALIGNMENT: u64 = EROFS_BLOCK_SIZE as u64;
 
 /// `flags` is split EROFS-style (see [`crate::blob::validate`]): the low 16
@@ -24,9 +32,44 @@ pub const NYDUS_BLOB_FOOTER_ALIGNMENT: u64 = EROFS_BLOCK_SIZE as u64;
 /// are compatible features (unknown bits are ignored). No bits are defined
 /// yet.
 const NYDUS_BLOB_FOOTER_SUPPORTED_INCOMPAT: u32 = 0;
-/// Byte offset of the crc32 field within the footer.
-const NYDUS_BLOB_FOOTER_CRC32_OFFSET: usize = 16;
 
+/// Byte range of the crc32 field within the footer.
+const NYDUS_BLOB_FOOTER_CRC32_FIELD: Range<usize> = 16..20;
+
+/// The trailing footer of a nydus full blob: the blob's self-describing map,
+/// recording where each region lives, sealed with a crc32c.
+///
+/// A full blob lays its regions out back to back (alignment gaps allowed),
+/// every offset 4KiB aligned, with the footer as the fixed-size tail:
+///
+/// ```text
+/// ┌─────────────────┬───────────────────┬───────────┬────────┐
+/// │ compressed data │ bootstrap (EROFS) │ blob meta │ footer │
+/// └─────────────────┴───────────────────┴───────────┴────────┘
+/// 0                                                 ▲        EOF
+///                                 blob meta ends exactly at the
+///                                 footer offset (EOF - 4096)
+/// ```
+///
+/// The footer's own 4096 bytes (integers little-endian):
+///
+/// ```text
+/// offset  size  field
+///      0     8  magic                   b"LPFOOTER"
+///      8     4  version                 informational, never gated on
+///     12     4  flags                   low 16 incompat / high 16 compat
+///     16     4  crc32                   crc32c of these 4096 bytes with
+///                                       this field treated as zero
+///     20     4  reserved0               future compat field slot
+///     24     8  compressed_data_offset
+///     32     8  bootstrap_offset
+///     40     8  blob_metadata_offset
+///     48     8  compressed_data_size    bytes
+///     56     4  bootstrap_blocks        4KiB blocks, zero for an ondemand
+///                                       redirect blob without a bootstrap
+///     60     4  blob_metadata_blocks    4KiB blocks, never zero
+///     64  4032  reserved                writers zero it, readers ignore it
+/// ```
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct BlobFooter {
     magic: [u8; 8],
@@ -43,6 +86,9 @@ pub struct BlobFooter {
 }
 
 impl BlobFooter {
+    /// Creates a validated, sealed footer for the given region layout: the
+    /// fields and the layout are checked first, so a constructed footer is
+    /// valid by definition, then the crc32 is computed over the final bytes.
     pub fn new(
         compressed_data_offset: u64,
         compressed_data_size: u64,
@@ -64,152 +110,53 @@ impl BlobFooter {
             bootstrap_blocks,
             blob_metadata_blocks,
         };
-        footer.validate_layout(
-            blob_metadata_offset
-                .checked_add(blocks_to_bytes(blob_metadata_blocks))
-                .ok_or_else(|| Error::Overflow("blob footer offset overflow".to_string()))?,
-        )?;
-        footer.crc32 = footer.compute_crc32();
+
+        footer.validate_fields()?;
+        footer.validate_layout(footer.offset()?)?;
+        footer.crc32 = Self::compute_crc32(&footer.to_bytes());
         Ok(footer)
     }
 
-    pub fn parse_from_tail(data: &[u8]) -> Result<Self> {
-        if data.len() < NYDUS_BLOB_FOOTER_SIZE {
-            return Err(Error::InvalidImage(
-                "blob too small for nydus footer".to_string(),
-            ));
-        }
-        let footer_offset = data.len() - NYDUS_BLOB_FOOTER_SIZE;
-        let footer = Self::from_bytes(&data[footer_offset..])?;
-        footer.validate(data.len() as u64)?;
-        Ok(footer)
-    }
-
-    /// Parse a footer from exactly its `NYDUS_BLOB_FOOTER_SIZE` trailing bytes,
-    /// validating the region layout against the known total blob size. Use this
-    /// when the footer has been fetched in isolation (e.g. a registry range
-    /// read) rather than reading the whole blob.
-    pub fn parse(footer_bytes: &[u8], blob_size: u64) -> Result<Self> {
-        if footer_bytes.len() != NYDUS_BLOB_FOOTER_SIZE {
-            return Err(Error::InvalidImage(format!(
-                "invalid nydus footer size: {} (expected {})",
-                footer_bytes.len(),
-                NYDUS_BLOB_FOOTER_SIZE
-            )));
-        }
-        let footer = Self::from_bytes(footer_bytes)?;
-        footer.validate(blob_size)?;
-        Ok(footer)
-    }
-
-    pub fn read_from_path(path: &Path) -> Result<Self> {
-        let mut file = File::open(path)
-            .with_context(|| format!("failed to open blob footer: {}", path.display()))?;
-        let file_size = file
-            .metadata()
-            .with_context(|| format!("failed to stat blob footer: {}", path.display()))?
-            .len();
-        if file_size < NYDUS_BLOB_FOOTER_SIZE as u64 {
-            return Err(Error::InvalidImage(format!(
-                "blob too small for nydus footer: {}",
-                path.display()
-            )));
-        }
-        file.seek(SeekFrom::Start(file_size - NYDUS_BLOB_FOOTER_SIZE as u64))
-            .with_context(|| format!("failed to seek blob footer: {}", path.display()))?;
-        let mut data = [0u8; NYDUS_BLOB_FOOTER_SIZE];
-        file.read_exact(&mut data)
-            .with_context(|| format!("failed to read blob footer: {}", path.display()))?;
-        let footer = Self::from_bytes(&data)?;
-        footer.validate(file_size)?;
-        Ok(footer)
-    }
-
-    pub fn has_magic(data: &[u8]) -> bool {
-        data.len() >= NYDUS_BLOB_FOOTER_MAGIC.len()
-            && data[..NYDUS_BLOB_FOOTER_MAGIC.len()] == NYDUS_BLOB_FOOTER_MAGIC
-    }
-
-    pub fn write_to(&self, writer: &mut dyn Write) -> Result<()> {
-        writer.write_all(&self.to_bytes())?;
-        Ok(())
-    }
-
-    pub fn compressed_data_offset(&self) -> u64 {
-        self.compressed_data_offset
-    }
-
-    pub fn bootstrap_offset(&self) -> u64 {
-        self.bootstrap_offset
-    }
-
-    pub fn blob_metadata_offset(&self) -> u64 {
-        self.blob_metadata_offset
-    }
-
-    pub fn compressed_data_size(&self) -> u64 {
-        self.compressed_data_size
-    }
-
-    pub fn bootstrap_blocks(&self) -> u32 {
-        self.bootstrap_blocks
-    }
-
-    pub fn blob_metadata_blocks(&self) -> u32 {
-        self.blob_metadata_blocks
-    }
-
-    pub fn bootstrap_size(&self) -> u64 {
-        blocks_to_bytes(self.bootstrap_blocks)
-    }
-
-    pub fn blob_metadata_size(&self) -> u64 {
-        blocks_to_bytes(self.blob_metadata_blocks)
-    }
-
-    pub fn footer_offset(file_size: u64) -> Result<u64> {
-        file_size
-            .checked_sub(NYDUS_BLOB_FOOTER_SIZE as u64)
-            .ok_or_else(|| Error::InvalidImage("blob too small for nydus footer".to_string()))
-    }
-
-    fn from_bytes(data: &[u8]) -> Result<Self> {
-        if data.len() != NYDUS_BLOB_FOOTER_SIZE {
-            return Err(Error::InvalidImage(format!(
-                "invalid nydus footer size: {}",
-                data.len()
-            )));
-        }
-        // Bytes past the fixed fields are reserved for future compat fields.
-        // Writers zero them, but readers deliberately do not enforce that
-        // (EROFS-style): a newer writer may have placed compat fields there
-        // that this reader ignores. Corruption is caught by the footer crc32c.
+    /// Parse a footer from exactly its `NYDUS_BLOB_FOOTER_SIZE` bytes,
+    /// verifying the intrinsic fields and the crc32 over the raw bytes.
+    ///
+    /// The declared region offsets are not anchored against the blob's actual
+    /// size here. The whole-blob entry points ([`Self::from_blob_bytes`],
+    /// [`Self::from_blob_path`]) do that anchoring themselves. Callers
+    /// parsing an isolated footer (e.g. a registry range read) must treat the
+    /// offsets as untrusted hints whose reads are bounds-checked downstream.
+    pub fn from_bytes(bytes: &[u8; NYDUS_BLOB_FOOTER_SIZE]) -> Result<Self> {
         let footer = Self {
-            magic: data[0..8].try_into().expect("slice checked"),
-            version: read_u32_at(data, 8),
-            flags: read_u32_at(data, 12),
-            crc32: read_u32_at(data, 16),
-            reserved0: read_u32_at(data, 20),
-            compressed_data_offset: read_u64_at(data, 24),
-            bootstrap_offset: read_u64_at(data, 32),
-            blob_metadata_offset: read_u64_at(data, 40),
-            compressed_data_size: read_u64_at(data, 48),
-            bootstrap_blocks: read_u32_at(data, 56),
-            blob_metadata_blocks: read_u32_at(data, 60),
+            magic: bytes[0..8].try_into().expect("slice checked"),
+            version: read_u32_at(bytes, 8),
+            flags: read_u32_at(bytes, 12),
+            crc32: read_u32_at(bytes, 16),
+            reserved0: read_u32_at(bytes, 20),
+            compressed_data_offset: read_u64_at(bytes, 24),
+            bootstrap_offset: read_u64_at(bytes, 32),
+            blob_metadata_offset: read_u64_at(bytes, 40),
+            compressed_data_size: read_u64_at(bytes, 48),
+            bootstrap_blocks: read_u32_at(bytes, 56),
+            blob_metadata_blocks: read_u32_at(bytes, 60),
         };
-        footer.validate_common()?;
-        // Verify the crc32 over the raw incoming bytes (with the crc32 field
-        // zeroed), not over a re-serialization of the parsed struct: the
-        // reserved tail may carry nonzero compat fields from a newer writer,
-        // which `to_bytes` would drop and thereby corrupt the checksum.
-        if footer.crc32 != crc32_with_zeroed_field(data, Self::crc32_field()) {
+        footer.validate_fields()?;
+
+        // Verify over the raw incoming bytes, never over `to_bytes()`: a
+        // re-serialization emits only the fields this reader knows, zeroing a
+        // newer writer's compat fields in the reserved tail and thereby
+        // rejecting a valid image.
+        if footer.crc32 != Self::compute_crc32(bytes) {
             return Err(Error::InvalidImage(
                 "nydus footer crc32 mismatch".to_string(),
             ));
         }
+
         Ok(footer)
     }
 
+    /// Serialize the footer into its on-disk bytes. The reserved tail is
+    /// zeroed, so this is only the writer's view: raw bytes read from disk
+    /// may carry newer compat fields there that this type does not model.
     fn to_bytes(self) -> [u8; NYDUS_BLOB_FOOTER_SIZE] {
         let mut data = [0u8; NYDUS_BLOB_FOOTER_SIZE];
         data[0..8].copy_from_slice(&self.magic);
@@ -226,83 +173,210 @@ impl BlobFooter {
         data
     }
 
-    fn validate(&self, file_size: u64) -> Result<()> {
-        let footer_offset = Self::footer_offset(file_size)?;
-        self.validate_layout(footer_offset)
+    /// Probe a whole blob's bytes for a trailing footer and parse it.
+    ///
+    /// Returns `Ok(None)` when the bytes are too short for a footer or the
+    /// tail carries no footer magic (the input is not a full blob, e.g. a
+    /// bare bootstrap), the parsed and fully validated footer when it is,
+    /// and an error when the magic is present but the footer is malformed
+    /// or its declared layout does not match the blob's size.
+    pub fn from_blob_bytes(blob: &[u8]) -> Result<Option<Self>> {
+        let Some(footer_bytes) = blob.last_chunk::<NYDUS_BLOB_FOOTER_SIZE>() else {
+            return Ok(None);
+        };
+
+        if !Self::has_magic(footer_bytes) {
+            return Ok(None);
+        }
+
+        let footer = Self::from_bytes(footer_bytes)?;
+        footer.validate_layout(Self::offset_from_size(blob.len() as u64)?)?;
+        Ok(Some(footer))
     }
 
-    fn validate_common(&self) -> Result<()> {
+    /// Read and fully validate the footer of the blob file at `path`,
+    /// without reading the rest of the blob.
+    pub fn from_blob_path(path: &Path) -> Result<Self> {
+        let file = File::open(path)
+            .with_context(|| format!("failed to open blob footer: {}", path.display()))?;
+
+        let file_size = file
+            .metadata()
+            .with_context(|| format!("failed to stat blob footer: {}", path.display()))?
+            .len();
+
+        let footer_offset = Self::offset_from_size(file_size)
+            .with_context(|| format!("failed to locate blob footer: {}", path.display()))?;
+
+        let mut bytes = [0u8; NYDUS_BLOB_FOOTER_SIZE];
+        file.read_exact_at(&mut bytes, footer_offset)
+            .with_context(|| format!("failed to read blob footer: {}", path.display()))?;
+
+        let footer = Self::from_bytes(&bytes)
+            .with_context(|| format!("failed to parse blob footer: {}", path.display()))?;
+
+        footer.validate_layout(footer_offset).with_context(|| {
+            format!("failed to validate blob footer layout: {}", path.display())
+        })?;
+
+        Ok(footer)
+    }
+
+    /// Validate the intrinsic field invariants, needing nothing beyond the
+    /// fields themselves. Run once per entry point: by [`Self::from_bytes`]
+    /// on the read side and by [`Self::new`] on the write side.
+    ///
+    /// Deliberately not checked: `version` is informational (compatibility
+    /// is governed by the magic and the incompat flag bits), `reserved0` and
+    /// the reserved tail may carry a newer writer's compat fields (corruption
+    /// is caught by the crc32), and `bootstrap_blocks` may be zero (an
+    /// ondemand redirect blob embeds no bootstrap image).
+    fn validate_fields(&self) -> Result<()> {
         if self.magic != NYDUS_BLOB_FOOTER_MAGIC {
             return Err(Error::InvalidImage(
                 "invalid nydus footer magic".to_string(),
             ));
         }
-        // `version` is informational and deliberately not gated on:
-        // compatibility is carried by the magic and the incompat flag bits.
-        validate_incompat_flags(
-            self.flags,
-            NYDUS_BLOB_FOOTER_SUPPORTED_INCOMPAT,
-            "nydus footer",
-        )?;
-        // `reserved0` is a future compat-field slot and deliberately not
-        // enforced to zero; corruption is caught by the footer crc32c.
-        // `bootstrap_blocks` may be zero: an "ondemand" redirect blob carries
-        // only block group data plus blob meta and embeds no bootstrap image.
+
         if self.blob_metadata_blocks == 0 {
             return Err(Error::InvalidImage(
                 "nydus footer blob meta block count must be non-zero".to_string(),
             ));
         }
+
+        validate_incompat_flags(self.flags, NYDUS_BLOB_FOOTER_SUPPORTED_INCOMPAT)?;
         Ok(())
     }
 
-    fn validate_layout(&self, footer_offset: u64) -> Result<()> {
-        self.validate_common()?;
-        for (name, value) in [
-            ("compressed_data_offset", self.compressed_data_offset),
-            ("bootstrap_offset", self.bootstrap_offset),
-            ("blob_metadata_offset", self.blob_metadata_offset),
-            ("footer_offset", footer_offset),
-        ] {
-            if value % NYDUS_BLOB_FOOTER_ALIGNMENT != 0 {
+    /// Validate the declared region layout against `offset`, the footer's
+    /// actual position (an external fact the footer cannot fake): the
+    /// regions must tile the blob back to back (alignment gaps allowed) and
+    /// end exactly where the footer sits.
+    fn validate_layout(&self, offset: u64) -> Result<()> {
+        let regions = [
+            (
+                "compressed data",
+                self.compressed_data_offset,
+                self.compressed_data_size,
+            ),
+            ("bootstrap", self.bootstrap_offset, self.bootstrap_size()),
+            (
+                "blob meta",
+                self.blob_metadata_offset,
+                self.blob_metadata_size(),
+            ),
+        ];
+
+        let mut cursor = 0;
+        for (name, start, size) in regions {
+            if start % NYDUS_BLOB_FOOTER_ALIGNMENT != 0 {
                 return Err(Error::InvalidImage(format!(
-                    "nydus footer {name} is not 4KiB aligned"
+                    "nydus footer {name} region offset {start:#x} is not 4KiB aligned"
                 )));
             }
+
+            if start < cursor {
+                return Err(Error::InvalidImage(format!(
+                    "nydus footer {name} region starts at {start:#x}, overlapping the previous region ending at {cursor:#x}"
+                )));
+            }
+
+            cursor = start
+                .checked_add(size)
+                .ok_or_else(|| Error::Overflow(format!("nydus footer {name} region overflow")))?;
         }
 
-        let compressed_data_end = self
-            .compressed_data_offset
-            .checked_add(self.compressed_data_size)
-            .ok_or_else(|| {
-                Error::Overflow("nydus footer compressed data region overflow".to_string())
-            })?;
-        let bootstrap_end = self
-            .bootstrap_offset
-            .checked_add(self.bootstrap_size())
-            .ok_or_else(|| Error::Overflow("nydus footer bootstrap region overflow".to_string()))?;
-        let blob_metadata_end = self
-            .blob_metadata_offset
-            .checked_add(self.blob_metadata_size())
-            .ok_or_else(|| Error::Overflow("nydus footer blob meta region overflow".to_string()))?;
-
-        if !(compressed_data_end <= self.bootstrap_offset
-            && bootstrap_end <= self.blob_metadata_offset
-            && blob_metadata_end == footer_offset)
-        {
-            return Err(Error::InvalidImage(
-                "invalid nydus footer region layout".to_string(),
-            ));
+        if offset % NYDUS_BLOB_FOOTER_ALIGNMENT != 0 {
+            return Err(Error::InvalidImage(format!(
+                "nydus footer offset {offset:#x} is not 4KiB aligned"
+            )));
         }
+
+        if cursor != offset {
+            return Err(Error::InvalidImage(format!(
+                "nydus footer declared layout ends at {cursor:#x}, not at the footer offset {offset:#x}"
+            )));
+        }
+
         Ok(())
     }
 
-    fn crc32_field() -> std::ops::Range<usize> {
-        NYDUS_BLOB_FOOTER_CRC32_OFFSET..NYDUS_BLOB_FOOTER_CRC32_OFFSET + 4
+    /// Whether `data` starts with the footer magic.
+    pub fn has_magic(data: &[u8]) -> bool {
+        data.starts_with(&NYDUS_BLOB_FOOTER_MAGIC)
     }
 
-    fn compute_crc32(&self) -> u32 {
-        crc32_with_zeroed_field(&self.to_bytes(), Self::crc32_field())
+    /// Write the footer's on-disk bytes to `writer`.
+    pub fn write_to(&self, writer: &mut dyn Write) -> Result<()> {
+        writer.write_all(&self.to_bytes())?;
+        Ok(())
+    }
+
+    /// The footer offset the declared layout implies: a full blob lays the
+    /// footer immediately after the blob meta region, so this is the
+    /// exclusive end of that region.
+    pub fn offset(&self) -> Result<u64> {
+        self.blob_metadata_offset
+            .checked_add(self.blob_metadata_size())
+            .ok_or_else(|| Error::Overflow("nydus footer blob meta region overflow".to_string()))
+    }
+
+    /// The footer's actual offset in a blob of `blob_size` total bytes: the
+    /// footer is the blob's fixed-size tail.
+    pub fn offset_from_size(blob_size: u64) -> Result<u64> {
+        blob_size
+            .checked_sub(NYDUS_BLOB_FOOTER_SIZE as u64)
+            .ok_or_else(|| Error::InvalidImage("blob too small for nydus footer".to_string()))
+    }
+
+    /// Byte offset of the compressed data region.
+    pub fn compressed_data_offset(&self) -> u64 {
+        self.compressed_data_offset
+    }
+
+    /// Byte offset of the embedded EROFS bootstrap region.
+    pub fn bootstrap_offset(&self) -> u64 {
+        self.bootstrap_offset
+    }
+
+    /// Byte offset of the blob meta region.
+    pub fn blob_metadata_offset(&self) -> u64 {
+        self.blob_metadata_offset
+    }
+
+    /// Size of the compressed data region in bytes.
+    pub fn compressed_data_size(&self) -> u64 {
+        self.compressed_data_size
+    }
+
+    /// Size of the bootstrap region in 4KiB blocks, zero for an ondemand
+    /// redirect blob.
+    pub fn bootstrap_blocks(&self) -> u32 {
+        self.bootstrap_blocks
+    }
+
+    /// Size of the blob meta region in 4KiB blocks, never zero.
+    pub fn blob_metadata_blocks(&self) -> u32 {
+        self.blob_metadata_blocks
+    }
+
+    /// Size of the bootstrap region in bytes.
+    pub fn bootstrap_size(&self) -> u64 {
+        blocks_to_bytes(self.bootstrap_blocks)
+    }
+
+    /// Size of the blob meta region in bytes.
+    pub fn blob_metadata_size(&self) -> u64 {
+        blocks_to_bytes(self.blob_metadata_blocks)
+    }
+
+    /// crc32c over the footer bytes with the crc32 field treated as zero:
+    /// the writer seals `to_bytes()` with it, the reader verifies the raw
+    /// incoming bytes against it.
+    fn compute_crc32(bytes: &[u8; NYDUS_BLOB_FOOTER_SIZE]) -> u32 {
+        let mut zeroed = *bytes;
+        zeroed[NYDUS_BLOB_FOOTER_CRC32_FIELD].fill(0);
+        crc32c(&zeroed)
     }
 }
 
@@ -310,53 +384,230 @@ impl BlobFooter {
 mod tests {
     use super::*;
 
-    #[test]
-    fn footer_round_trips_and_validates_crc32() {
-        let footer = BlobFooter::new(0, 17, 4096, 1, 8192, 1).unwrap();
-        let parsed = BlobFooter::from_bytes(&footer.to_bytes()).unwrap();
+    fn footer() -> BlobFooter {
+        BlobFooter::new(0, 17, 4096, 1, 8192, 1).unwrap()
+    }
 
-        assert_eq!(parsed, footer);
-        assert_eq!(NYDUS_BLOB_FOOTER_SIZE, 4096);
+    fn reseal(mut bytes: [u8; NYDUS_BLOB_FOOTER_SIZE]) -> [u8; NYDUS_BLOB_FOOTER_SIZE] {
+        let crc32 = BlobFooter::compute_crc32(&bytes);
+        bytes[NYDUS_BLOB_FOOTER_CRC32_FIELD].copy_from_slice(&crc32.to_le_bytes());
+        bytes
+    }
+
+    fn sealed_blob() -> Vec<u8> {
+        let mut blob = vec![0u8; 16384];
+        blob[12288..].copy_from_slice(&footer().to_bytes());
+        blob
     }
 
     #[test]
-    fn footer_version_is_informational_and_incompat_flags_reject() {
-        let footer = BlobFooter::new(0, 17, 4096, 1, 8192, 1).unwrap();
-
-        // Re-seal the footer bytes after poking a field: crc32 covers
-        // everything but itself.
-        let reseal = |mut data: [u8; NYDUS_BLOB_FOOTER_SIZE]| {
-            let crc32 = crc32_with_zeroed_field(&data, BlobFooter::crc32_field());
-            data[BlobFooter::crc32_field()].copy_from_slice(&crc32.to_le_bytes());
-            data
-        };
-
-        // A future format generation is readable: version is informational.
-        let mut future = footer.to_bytes();
-        future[8..12].copy_from_slice(&(NYDUS_BLOB_FOOTER_VERSION + 1).to_le_bytes());
-        BlobFooter::from_bytes(&reseal(future)).expect("future version must be readable");
-
-        // An unknown compat (high-half) flag bit is ignored.
-        let mut compat = footer.to_bytes();
-        compat[12..16].copy_from_slice(&(1u32 << 31).to_le_bytes());
-        BlobFooter::from_bytes(&reseal(compat)).expect("unknown compat flag must be ignored");
-
-        // An unknown incompat (low-half) flag bit rejects the footer.
-        let mut incompat = footer.to_bytes();
-        incompat[12..16].copy_from_slice(&(1u32 << 3).to_le_bytes());
-        let err = BlobFooter::from_bytes(&reseal(incompat)).unwrap_err();
-        assert!(err.to_string().contains("incompat"), "{err}");
-
-        // A resealed nonzero reserved tail (a future compat field) is readable.
-        let mut tail = footer.to_bytes();
-        tail[NYDUS_BLOB_FOOTER_SIZE - 1] = 0xff;
-        BlobFooter::from_bytes(&reseal(tail)).expect("reserved tail must be ignored");
+    fn accessors_expose_the_sealed_layout() {
+        let footer = footer();
+        assert_eq!(footer.compressed_data_offset(), 0);
+        assert_eq!(footer.compressed_data_size(), 17);
+        assert_eq!(footer.bootstrap_offset(), 4096);
+        assert_eq!(footer.bootstrap_blocks(), 1);
+        assert_eq!(footer.bootstrap_size(), 4096);
+        assert_eq!(footer.blob_metadata_offset(), 8192);
+        assert_eq!(footer.blob_metadata_blocks(), 1);
+        assert_eq!(footer.blob_metadata_size(), 4096);
+        assert_eq!(footer.offset().unwrap(), 12288);
     }
 
     #[test]
-    fn footer_rejects_unaligned_offsets() {
-        let err = BlobFooter::new(0, 17, 17, 1, 8192, 1).unwrap_err();
+    fn offset_from_size_locates_the_fixed_tail() {
+        assert_eq!(BlobFooter::offset_from_size(16384).unwrap(), 12288);
+    }
 
-        assert!(err.to_string().contains("aligned"));
+    #[test]
+    fn write_to_emits_parseable_bytes() {
+        let footer = footer();
+        let mut written = Vec::new();
+        footer.write_to(&mut written).unwrap();
+
+        let bytes: [u8; NYDUS_BLOB_FOOTER_SIZE] = written.as_slice().try_into().unwrap();
+        assert!(BlobFooter::has_magic(&bytes));
+        assert_eq!(BlobFooter::from_bytes(&bytes).unwrap(), footer);
+    }
+
+    #[test]
+    fn round_trips_through_bytes() {
+        let footer = footer();
+
+        assert_eq!(BlobFooter::from_bytes(&footer.to_bytes()).unwrap(), footer);
+    }
+
+    #[test]
+    fn resealed_header_mutations_follow_the_compat_rules() {
+        let cases: [(&str, usize, [u8; 4], Option<&str>); 4] = [
+            (
+                "future version is readable",
+                8,
+                (NYDUS_BLOB_FOOTER_VERSION + 1).to_le_bytes(),
+                None,
+            ),
+            (
+                "unknown compat flag is ignored",
+                12,
+                (1u32 << 31).to_le_bytes(),
+                None,
+            ),
+            (
+                "unknown incompat flag rejects",
+                12,
+                (1u32 << 3).to_le_bytes(),
+                Some("incompat"),
+            ),
+            (
+                "nonzero reserved tail is readable",
+                NYDUS_BLOB_FOOTER_SIZE - 4,
+                [0, 0, 0, 0xff],
+                None,
+            ),
+        ];
+
+        for (case, offset, value, expected_err) in cases {
+            let mut bytes = footer().to_bytes();
+            bytes[offset..offset + 4].copy_from_slice(&value);
+
+            let result = BlobFooter::from_bytes(&reseal(bytes));
+            match expected_err {
+                None => {
+                    result.unwrap_or_else(|err| panic!("{case}: {err}"));
+                }
+                Some(expected) => {
+                    let err = result.unwrap_err();
+                    assert!(err.to_string().contains(expected), "{case}: {err}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn corrupted_bytes_fail_the_crc32_check() {
+        let mut bytes = footer().to_bytes();
+        bytes[24] ^= 0xff;
+
+        let err = BlobFooter::from_bytes(&bytes).unwrap_err();
+        assert!(err.to_string().contains("crc32 mismatch"), "{err}");
+    }
+
+    #[test]
+    fn from_blob_bytes_returns_none_for_a_short_input() {
+        assert!(BlobFooter::from_blob_bytes(&[0u8; 100]).unwrap().is_none());
+    }
+
+    #[test]
+    fn from_blob_bytes_returns_none_without_the_magic() {
+        assert!(BlobFooter::from_blob_bytes(&[0u8; 16384])
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn from_blob_bytes_parses_a_sealed_blob() {
+        let parsed = BlobFooter::from_blob_bytes(&sealed_blob())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(parsed, footer());
+    }
+
+    #[test]
+    fn from_blob_bytes_errors_on_corruption_behind_the_magic() {
+        let mut blob = sealed_blob();
+        blob[12288 + 24] ^= 0xff;
+
+        let err = BlobFooter::from_blob_bytes(&blob).unwrap_err();
+        assert!(err.to_string().contains("crc32 mismatch"), "{err}");
+    }
+
+    #[test]
+    fn zero_bootstrap_blocks_are_valid() {
+        BlobFooter::new(0, 17, 4096, 0, 4096, 1).unwrap();
+    }
+
+    #[test]
+    fn invalid_layouts_reject() {
+        let cases = [
+            (
+                "zero blob meta blocks",
+                (0, 17, 4096, 1, 8192, 0),
+                "must be non-zero",
+            ),
+            ("unaligned offset", (0, 17, 17, 1, 8192, 1), "aligned"),
+            (
+                "overlapping regions",
+                (0, 8192, 4096, 1, 8192, 1),
+                "overlapping",
+            ),
+            (
+                "region overflow",
+                (4096, u64::MAX, 4096, 1, 8192, 1),
+                "overflow",
+            ),
+        ];
+
+        for (case, (data_off, data_size, boot_off, boot_blocks, meta_off, meta_blocks), expected) in
+            cases
+        {
+            let err = BlobFooter::new(
+                data_off,
+                data_size,
+                boot_off,
+                boot_blocks,
+                meta_off,
+                meta_blocks,
+            )
+            .unwrap_err();
+            assert!(err.to_string().contains(expected), "{case}: {err}");
+        }
+    }
+
+    #[test]
+    fn a_layout_not_ending_at_the_footer_rejects() {
+        let err = footer()
+            .validate_layout(BlobFooter::offset_from_size(16384 + 4096).unwrap())
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("not at the footer offset"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn from_blob_path_reads_back_the_sealed_footer() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("layer.blob");
+        std::fs::write(&path, sealed_blob()).unwrap();
+
+        assert_eq!(BlobFooter::from_blob_path(&path).unwrap(), footer());
+    }
+
+    #[test]
+    fn bad_magic_rejects() {
+        let mut bytes = footer().to_bytes();
+        bytes[0] ^= 0xff;
+
+        let err = BlobFooter::from_bytes(&bytes).unwrap_err();
+        assert!(err.to_string().contains("magic"), "{err}");
+    }
+
+    #[test]
+    fn an_unaligned_blob_length_rejects() {
+        let mut blob = vec![0u8; 16385];
+        let tail = blob.len() - NYDUS_BLOB_FOOTER_SIZE;
+        blob[tail..].copy_from_slice(&footer().to_bytes());
+
+        let err = BlobFooter::from_blob_bytes(&blob).unwrap_err();
+        assert!(err.to_string().contains("aligned"), "{err}");
+    }
+
+    #[test]
+    fn an_undersized_blob_rejects() {
+        let err = BlobFooter::offset_from_size(100).unwrap_err();
+
+        assert!(err.to_string().contains("too small"), "{err}");
     }
 }

--- a/nydus-format/src/blob/metadata.rs
+++ b/nydus-format/src/blob/metadata.rs
@@ -1,15 +1,16 @@
-use crate::blob::validate::{crc32_with_zeroed_field, validate_incompat_flags};
+use crate::blob::validate::validate_incompat_flags;
 use crate::erofs::EROFS_BLOCK_SIZE;
 use crate::error::{Context, Error, Result};
 use crate::utils::le::{read_u16_from, read_u32_from, read_u64_from};
 use crate::utils::SHA256_DIGEST_SIZE;
 use bitflags::bitflags;
-use crc32c::crc32c_append;
+use crc32c::{crc32c, crc32c_append};
 use memmap2::{Mmap, MmapOptions};
 use std::fmt;
 use std::fs::File;
 use std::io::{Cursor, Read, Write};
 use std::mem::{align_of, size_of};
+use std::ops::Range;
 use std::path::Path;
 
 /// On-disk magic: 8 raw ASCII bytes ("LPBLMETA" = LePton BLob META),
@@ -41,7 +42,10 @@ pub const BLOB_METADATA_SUFFIX: &str = ".blob.meta";
 /// representable in a `u32` (2 GiB at most).
 const BLOB_METADATA_MAX_BLOCK_BITS: u8 = 19;
 
-const BLOB_METADATA_HEADER_CRC32_OFFSET: usize = 16;
+/// Range of the crc32 field in the header, for zeroing it when computing
+/// the crc32 over the serialized metadata.
+const BLOB_METADATA_HEADER_CRC32_FIELD: Range<usize> = 16..20;
+
 /// Bytes of the header actually carrying fields; the rest of the 4 KiB
 /// header block is a reserved compat area (writer-zeroed, reader-ignored).
 const BLOB_METADATA_HEADER_FIELD_BYTES: usize = 56;
@@ -341,7 +345,7 @@ impl BlobMetadataHeader {
         // EROFS-style feature gating: unknown incompat (low-half) bits mean
         // the file cannot be read correctly and must be rejected; unknown
         // compat (high-half) bits are ignored.
-        validate_incompat_flags(self.flags, BlobMetadataFlags::all().bits(), "blob meta")?;
+        validate_incompat_flags(self.flags, BlobMetadataFlags::all().bits())?;
         let flags = BlobMetadataFlags::from_bits_truncate(self.flags);
         BlobMetadataCompressor::try_from(flags)?;
         BlobMetadataDigester::try_from(flags)?;
@@ -358,8 +362,7 @@ impl BlobMetadataHeader {
         data[0..8].copy_from_slice(&self.magic);
         data[8..12].copy_from_slice(&self.version.to_le_bytes());
         data[12..16].copy_from_slice(&self.flags.to_le_bytes());
-        data[BLOB_METADATA_HEADER_CRC32_OFFSET..BLOB_METADATA_HEADER_CRC32_OFFSET + 4]
-            .copy_from_slice(&crc32.to_le_bytes());
+        data[BLOB_METADATA_HEADER_CRC32_FIELD].copy_from_slice(&crc32.to_le_bytes());
         data[20..24].copy_from_slice(&self.reserved0.to_le_bytes());
         data[24..32].copy_from_slice(&self.chunks_offset.to_le_bytes());
         data[32..40].copy_from_slice(&self.block_groups_offset.to_le_bytes());
@@ -766,7 +769,7 @@ impl BlobMetadata {
                 block_groups,
             },
         };
-        blob_metadata.header.crc32 = blob_metadata.compute_crc32();
+        blob_metadata.header.crc32 = blob_metadata.compute_crc32_from_parts();
         Ok(blob_metadata)
     }
 
@@ -879,21 +882,42 @@ impl BlobMetadata {
         self.header.metadata_size()
     }
 
-    fn compute_crc32(&self) -> u32 {
+    /// crc32c over the serialized metadata bytes with the crc32 field
+    /// treated as zero: the header (copied and zeroed) seeds the crc that
+    /// continues over the records and padding. The reader verifies the raw
+    /// incoming bytes against it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `data` is shorter than the blob meta header.
+    fn compute_crc32(data: &[u8]) -> u32 {
+        let mut header: [u8; BLOB_METADATA_HEADER_SIZE as usize] = data
+            [..BLOB_METADATA_HEADER_SIZE as usize]
+            .try_into()
+            .expect("caller checked the header length");
+        header[BLOB_METADATA_HEADER_CRC32_FIELD].fill(0);
+        crc32c_append(crc32c(&header), &data[BLOB_METADATA_HEADER_SIZE as usize..])
+    }
+
+    fn compute_crc32_from_parts(&self) -> u32 {
         // Seal over the serialized metadata with the crc field zeroed; the
         // header bytes seed the running crc32c that continues over the
         // records and padding.
-        let mut crc32 = crc32_with_zeroed_field(
-            &self.header.to_bytes_with_crc32(0),
-            blob_metadata_crc32_field(),
-        );
+        let mut crc32 = crc32c(&self.header.to_bytes_with_crc32(0));
         for chunk in self.chunks() {
             crc32 = crc32c_append(crc32, &chunk.to_bytes());
         }
         for block_group in self.block_groups() {
             crc32 = crc32c_append(crc32, &block_group.to_bytes());
         }
-        crc32c_append(crc32, &vec![0u8; self.padding_size()])
+        const ZERO_BLOCK: [u8; EROFS_BLOCK_SIZE as usize] = [0u8; EROFS_BLOCK_SIZE as usize];
+        let mut remaining = self.padding_size();
+        while remaining > 0 {
+            let run = remaining.min(ZERO_BLOCK.len());
+            crc32 = crc32c_append(crc32, &ZERO_BLOCK[..run]);
+            remaining -= run;
+        }
+        crc32
     }
 
     fn padding_size(&self) -> usize {
@@ -902,7 +926,7 @@ impl BlobMetadata {
 
     pub fn write_to(&self, writer: &mut dyn Write) -> Result<()> {
         self.header
-            .write_to_with_crc32(writer, self.compute_crc32())?;
+            .write_to_with_crc32(writer, self.compute_crc32_from_parts())?;
         for chunk in self.chunks() {
             chunk.write_to(writer)?;
         }
@@ -1093,7 +1117,7 @@ fn validate_padding(data: &[u8], header: &BlobMetadataHeader) -> Result<()> {
 }
 
 fn validate_blob_metadata_crc32(data: &[u8], header: &BlobMetadataHeader) -> Result<()> {
-    let computed = compute_blob_metadata_crc32(data);
+    let computed = BlobMetadata::compute_crc32(data);
     if computed != header.crc32() {
         return Err(Error::InvalidImage(format!(
             "blob meta header crc32 mismatch: stored {:#010x}, computed {:#010x}",
@@ -1102,14 +1126,6 @@ fn validate_blob_metadata_crc32(data: &[u8], header: &BlobMetadataHeader) -> Res
         )));
     }
     Ok(())
-}
-
-fn compute_blob_metadata_crc32(data: &[u8]) -> u32 {
-    crc32_with_zeroed_field(data, blob_metadata_crc32_field())
-}
-
-fn blob_metadata_crc32_field() -> std::ops::Range<usize> {
-    BLOB_METADATA_HEADER_CRC32_OFFSET..BLOB_METADATA_HEADER_CRC32_OFFSET + 4
 }
 
 fn validate_tables(
@@ -1385,12 +1401,9 @@ mod tests {
         let mut raw = Vec::new();
         blob_metadata.write_to(&mut raw).unwrap();
 
-        let stored_crc32 = u32::from_le_bytes(
-            raw[BLOB_METADATA_HEADER_CRC32_OFFSET..BLOB_METADATA_HEADER_CRC32_OFFSET + 4]
-                .try_into()
-                .unwrap(),
-        );
-        raw[BLOB_METADATA_HEADER_CRC32_OFFSET..BLOB_METADATA_HEADER_CRC32_OFFSET + 4].fill(0);
+        let stored_crc32 =
+            u32::from_le_bytes(raw[BLOB_METADATA_HEADER_CRC32_FIELD].try_into().unwrap());
+        raw[BLOB_METADATA_HEADER_CRC32_FIELD].fill(0);
 
         assert_eq!(stored_crc32, crc32c::crc32c(&raw));
     }
@@ -1407,12 +1420,9 @@ mod tests {
         .unwrap();
         let mut raw = Vec::new();
         blob_metadata.write_to(&mut raw).unwrap();
-        raw[BLOB_METADATA_HEADER_CRC32_OFFSET] ^= 0xff;
-        let corrupted_crc32 = u32::from_le_bytes(
-            raw[BLOB_METADATA_HEADER_CRC32_OFFSET..BLOB_METADATA_HEADER_CRC32_OFFSET + 4]
-                .try_into()
-                .unwrap(),
-        );
+        raw[BLOB_METADATA_HEADER_CRC32_FIELD.start] ^= 0xff;
+        let corrupted_crc32 =
+            u32::from_le_bytes(raw[BLOB_METADATA_HEADER_CRC32_FIELD].try_into().unwrap());
 
         let loaded = BlobMetadata::loader().from_bytes(&raw).unwrap();
 

--- a/nydus-format/src/blob/mod.rs
+++ b/nydus-format/src/blob/mod.rs
@@ -4,10 +4,14 @@
 //! the `.blob.meta` sidecar ([`metadata`]) and the trailing blob footer
 //! ([`footer`]) — not part of the EROFS metadata format itself.
 
+use crate::erofs::bytes_to_blocks;
+use crate::error::{Context, Error, Result};
+use crate::utils::{align_up, write_zero_padding};
+use std::io::Write;
+
 pub mod footer;
 pub mod metadata;
 pub mod validate;
-
 pub use footer::NYDUS_BLOB_FOOTER_ALIGNMENT;
 pub use footer::{BlobFooter, NYDUS_BLOB_FOOTER_SIZE};
 pub use metadata::{
@@ -17,11 +21,21 @@ pub use metadata::{
     BLOB_METADATA_DEFAULT_CHUNK_SIZE, BLOB_METADATA_SUFFIX,
 };
 
-use std::io::Write;
+/// The incompatible (reject-when-unknown) half of a format `flags` word.
+pub const INCOMPAT_MASK: u32 = 0x0000_FFFF;
 
-use crate::erofs::bytes_to_blocks;
-use crate::error::{Context, Error, Result};
-use crate::utils::{align_up, write_zero_padding};
+/// Reject `flags` whose incompat half carries bits outside `supported`.
+/// `what` names the format in the error message.
+pub fn validate_incompat_flags(flags: u32, supported: u32) -> Result<()> {
+    let unknown_incompat = flags & INCOMPAT_MASK & !supported;
+    if unknown_incompat != 0 {
+        return Err(Error::Unsupported(format!(
+            "unsupported incompat flags {unknown_incompat:#x} (image is newer than this reader)"
+        )));
+    }
+
+    Ok(())
+}
 
 /// Append the trailing regions of the full-blob layout
 /// `[data][pad][bootstrap][pad][blob meta][footer]` to `writer`, which must

--- a/nydus-format/src/blob/validate.rs
+++ b/nydus-format/src/blob/validate.rs
@@ -5,10 +5,6 @@
 //! are ignored) — and a crc32c computed over the record with the crc field
 //! zeroed.
 
-use std::ops::Range;
-
-use crc32c::crc32c_append;
-
 use crate::error::{Error, Result};
 
 /// The incompatible (reject-when-unknown) half of a format `flags` word.
@@ -16,21 +12,13 @@ pub const INCOMPAT_MASK: u32 = 0x0000_FFFF;
 
 /// Reject `flags` whose incompat half carries bits outside `supported`.
 /// `what` names the format in the error message.
-pub fn validate_incompat_flags(flags: u32, supported: u32, what: &str) -> Result<()> {
+pub fn validate_incompat_flags(flags: u32, supported: u32) -> Result<()> {
     let unknown_incompat = flags & INCOMPAT_MASK & !supported;
     if unknown_incompat != 0 {
         return Err(Error::Unsupported(format!(
-            "unsupported {what} incompat flags: {unknown_incompat:#x}"
+            "unsupported incompat flags {unknown_incompat:#x} (image is newer than this reader)"
         )));
     }
-    Ok(())
-}
 
-/// crc32c over `bytes` with the `field` range treated as zeroed, without
-/// mutating or copying `bytes`. The result may seed further `crc32c_append`
-/// calls for records that continue past `bytes`.
-pub fn crc32_with_zeroed_field(bytes: &[u8], field: Range<usize>) -> u32 {
-    let crc32 = crc32c_append(0, &bytes[..field.start]);
-    let crc32 = crc32c_append(crc32, &vec![0u8; field.len()]);
-    crc32c_append(crc32, &bytes[field.end..])
+    Ok(())
 }

--- a/nydus-format/src/erofs/block.rs
+++ b/nydus-format/src/erofs/block.rs
@@ -12,6 +12,7 @@ pub fn bytes_to_blocks(size: u64, name: &str) -> Result<u32> {
             "{name} size is not block aligned: {size}"
         )));
     }
+
     u32::try_from(size / EROFS_BLOCK_SIZE as u64)
         .map_err(|err| Error::Overflow(format!("{name} exceeds u32 block count: {err}")))
 }

--- a/nydus-storage/src/cache/caches.rs
+++ b/nydus-storage/src/cache/caches.rs
@@ -215,7 +215,7 @@ impl BlobCaches {
         cache.for_each_redirect_block_group(threads, deadline, &skip, &|block_group, decoded| {
             if !block_group.is_redirect() {
                 nydus_telemetry::metrics::inc_cache_redirect_skip_block_group();
-                warn!("ondemand blob {blob_index} contains a non-redirect block group; skipping");
+                warn!("ondemand blob {blob_index} contains a non-redirect block group (skipping)");
                 return Ok(());
             }
             let source_blob_index = block_group.source_blob_index();
@@ -229,7 +229,7 @@ impl BlobCaches {
                 }
                 None => {
                     nydus_telemetry::metrics::inc_cache_redirect_skip_block_group();
-                    warn!("ondemand blob {blob_index} redirects to unknown blob {source_blob_index}; skipping block group");
+                    warn!("ondemand blob {blob_index} redirects to unknown blob {source_blob_index} (skipping block group)");
                     return Ok(());
                 }
             };

--- a/nydus-storage/src/cache/local.rs
+++ b/nydus-storage/src/cache/local.rs
@@ -681,7 +681,7 @@ impl BlobCache for LocalBlobCache {
             }
             if !contention_logged {
                 info!(
-                    "prefetch lock for blob {} is held by another process; waiting",
+                    "prefetch lock for blob {} is held by another process (waiting)",
                     self.blob_index
                 );
                 contention_logged = true;

--- a/nydus-telemetry/src/logging.rs
+++ b/nydus-telemetry/src/logging.rs
@@ -85,26 +85,14 @@ pub fn init_tracing(
     guards
 }
 
-/// Initializes the tracing system for command line tools, which only logs to
-/// stdout and does not log to files.
+/// Initializes the tracing system for command line tools, which logs to
+/// stderr and does not log to files. Diagnostics stay off stdout so command
+/// payloads and reports (tar streams, tables) remain clean.
 pub fn init_command_tracing(log_level: Level, console: bool) -> Vec<WorkerGuard> {
-    init_command_tracing_to(std::io::stdout(), log_level, console)
-}
-
-/// Same as [`init_command_tracing`] but logs to stderr, for commands that
-/// write their payload to stdout.
-pub fn init_command_tracing_stderr(log_level: Level, console: bool) -> Vec<WorkerGuard> {
-    init_command_tracing_to(std::io::stderr(), log_level, console)
-}
-
-fn init_command_tracing_to<W>(writer: W, log_level: Level, console: bool) -> Vec<WorkerGuard>
-where
-    W: std::io::Write + Send + 'static,
-{
     let mut guards = vec![];
 
     // Setup console layer.
-    let (console_writer, console_guard) = tracing_appender::non_blocking(writer);
+    let (console_writer, console_guard) = tracing_appender::non_blocking(std::io::stderr());
     guards.push(console_guard);
 
     // Initialize console layer.

--- a/nydus/src/bin/nydus/build.rs
+++ b/nydus/src/bin/nydus/build.rs
@@ -12,7 +12,6 @@ use std::path::{Path, PathBuf};
 use tabled::{settings::Style, Table, Tabled};
 use tracing::Level;
 
-/// The subcommand of build.
 #[derive(Debug, Clone, Parser)]
 #[command(group(
     clap::ArgGroup::new("blob_output")

--- a/nydus/src/bin/nydus/check.rs
+++ b/nydus/src/bin/nydus/check.rs
@@ -51,6 +51,17 @@ pub struct CheckCommand {
 impl CheckCommand {
     /// Executes the check sub command, statically inspecting the image.
     pub fn execute(&self) -> Result<()> {
+        // Resolves the inspection target from the raw CLI flags.
+        let (kind, path, blob_dir) = self.prepare()?;
+
+        // Runs the inspection and prints the report.
+        self.run(kind, path, blob_dir.as_deref())
+    }
+
+    /// Lowers the raw CLI flags into the inspection target: the image kind,
+    /// its path, and the optional blob directory resolved from --blob-dir or
+    /// the config's local backend.
+    fn prepare(&self) -> Result<(ImageKind, &Path, Option<PathBuf>)> {
         // `check` verifies blobs from a local directory. --blob-dir takes precedence
         // over the config; a config is only usable here when it has a local backend.
         let blob_dir = match &self.blob_dir {
@@ -91,7 +102,13 @@ impl CheckCommand {
             }
         };
 
-        let report = check_image(kind, path, blob_dir.as_deref())?;
+        Ok((kind, path, blob_dir))
+    }
+
+    /// Runs the inspection: checks the image, prints the report, and fails
+    /// on inline data crossing a metadata block.
+    fn run(&self, kind: ImageKind, path: &Path, blob_dir: Option<&Path>) -> Result<()> {
+        let report = check_image(kind, path, blob_dir)?;
 
         print_header(kind, path, &report);
         print_superblock(&report.superblock);
@@ -101,8 +118,7 @@ impl CheckCommand {
 
         if !report.stats.inline_overflows.is_empty() {
             return Err(Error::InvalidImage(format!(
-                "{} inode(s) have inline data crossing a metadata block; \
-                 the kernel cannot read them",
+                "{} inode(s) have inline data crossing a metadata block (the kernel cannot read them)",
                 report.stats.inline_overflows.len()
             )));
         }

--- a/nydus/src/bin/nydus/export.rs
+++ b/nydus/src/bin/nydus/export.rs
@@ -2,25 +2,24 @@ use clap::Parser;
 use nydus::error::{Context, Error, Result};
 use nydus::export::write_tar;
 use nydus_core::ErofsReader;
-use nydus_telemetry::logging::{init_command_tracing, init_command_tracing_stderr};
+use nydus_telemetry::logging::init_command_tracing;
 use std::fs::File;
 use std::io::{self, BufWriter};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use tracing::Level;
 
-/// The subcommand of export.
 #[derive(Debug, Clone, Parser)]
 pub struct ExportCommand {
     #[arg(help = "Specify the nydus full blob to export the OCI layer tar stream from")]
     source: PathBuf,
 
     #[arg(
+        short = 'o',
         long,
-        default_value = "-",
         env = "NYDUS_EXPORT_OUTPUT",
-        help = "Specify the file path to save the exported tar stream, or `-` for stdout"
+        help = "Specify the file path to save the exported tar stream (defaults to stdout)"
     )]
-    output: PathBuf,
+    output: Option<PathBuf>,
 
     #[arg(
         short = 'l',
@@ -46,14 +45,19 @@ impl ExportCommand {
     /// Executes the export sub command, writing the source blob's OCI layer
     /// tar stream to the output.
     pub fn execute(&self) -> Result<()> {
-        let tar_to_stdout = self.output == Path::new("-");
-        // Logging to stdout would corrupt a tar stream written to stdout.
-        let _guards = if tar_to_stdout {
-            init_command_tracing_stderr(self.log_level, self.console)
-        } else {
-            init_command_tracing(self.log_level, self.console)
-        };
+        // Initializes the tracing subscriber for logging, using the specified log level and
+        // console output preference.
+        let _guards = init_command_tracing(self.log_level, self.console);
 
+        // Validates the source before opening it.
+        self.validate()?;
+
+        // Runs the export, writing the tar stream to the output.
+        self.run()
+    }
+
+    /// Validates that the source is an existing nydus blob file.
+    fn validate(&self) -> Result<()> {
         if !self.source.is_file() {
             return Err(Error::InvalidParameter(format!(
                 "source {} is not a nydus blob file",
@@ -61,17 +65,27 @@ impl ExportCommand {
             )));
         }
 
+        Ok(())
+    }
+
+    /// Runs the export: opens the source blob and streams its OCI layer tar
+    /// to the output file, or to stdout when no output is given.
+    fn run(&self) -> Result<()> {
         let reader = ErofsReader::open_blob(&self.source)
             .with_context(|| format!("failed to open nydus blob: {}", self.source.display()))?;
 
-        if tar_to_stdout {
-            let stdout = io::stdout();
-            write_tar(&reader, BufWriter::new(stdout.lock()))?;
-        } else {
-            let file = File::create(&self.output)
-                .with_context(|| format!("failed to create output: {}", self.output.display()))?;
-            write_tar(&reader, BufWriter::new(file))?;
+        match &self.output {
+            Some(path) => {
+                let file = File::create(path)
+                    .with_context(|| format!("failed to create output: {}", path.display()))?;
+                write_tar(&reader, BufWriter::new(file))?;
+            }
+            None => {
+                let stdout = io::stdout();
+                write_tar(&reader, BufWriter::new(stdout.lock()))?;
+            }
         }
+
         Ok(())
     }
 }
@@ -85,6 +99,7 @@ mod tests {
     use std::collections::{BTreeMap, HashSet};
     use std::fs;
     use std::io::Read;
+    use std::path::Path;
     use tempfile::tempdir;
 
     fn build_and_export(source: &Path, blob: &Path, tar_path: &Path) {
@@ -107,7 +122,7 @@ mod tests {
     #[test]
     fn export_writes_to_stdout_by_default() {
         let cmd = ExportCommand::try_parse_from(["export", "/tmp/layer.blob"]).unwrap();
-        assert_eq!(cmd.output, PathBuf::from("-"));
+        assert_eq!(cmd.output, None);
     }
 
     #[test]

--- a/nydus/src/bin/nydus/fanotify.rs
+++ b/nydus/src/bin/nydus/fanotify.rs
@@ -138,6 +138,14 @@ impl FanotifyCommand {
         // Load the storage config.
         let config = Config::load(&self.config)?;
 
+        // Runs the fanotify service until shutdown.
+        self.run(signals, config)
+    }
+
+    /// Runs the fanotify service: builds the core, spawns the event loop,
+    /// mounts the EROFS bootstrap once the loop is ready, and unmounts it
+    /// again on shutdown before releasing the fanotify group fd.
+    fn run(&self, signals: signal::Signals, config: Config) -> Result<()> {
         raise_nofile_limit();
         let core = std::sync::Arc::new(
             FanotifyCore::new(&self.bootstrap, config).context("failed to build fanotify core")?,

--- a/nydus/src/bin/nydus/fuse.rs
+++ b/nydus/src/bin/nydus/fuse.rs
@@ -152,13 +152,8 @@ impl FuseCommand {
             self.console,
         );
 
-        let mountpoint = &self.mountpoint;
-        if !mountpoint.is_dir() {
-            return Err(Error::InvalidParameter(format!(
-                "mountpoint {} is not a directory",
-                mountpoint.display()
-            )));
-        }
+        // Validates the mountpoint before any expensive work.
+        self.validate()?;
 
         // Load the optional storage config. CLI flags take precedence over config
         // values, so --blob-dir/--cache-dir override the backend/cache directories.
@@ -166,6 +161,28 @@ impl FuseCommand {
             Some(path) => Some(Config::load(path)?),
             None => None,
         };
+
+        // Runs the FUSE service until shutdown.
+        self.run(storage_config)
+    }
+
+    /// Validates that the mountpoint is an existing directory.
+    fn validate(&self) -> Result<()> {
+        if !self.mountpoint.is_dir() {
+            return Err(Error::InvalidParameter(format!(
+                "mountpoint {} is not a directory",
+                self.mountpoint.display()
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Runs the FUSE service: resolves the cache, prefetch, and backend
+    /// settings, opens the EROFS image, mounts it, and serves until a
+    /// termination signal stops it.
+    fn run(&self, storage_config: Option<Config>) -> Result<()> {
+        let mountpoint = &self.mountpoint;
 
         let cache_dir = if let Some(dir) = self.cache_dir.clone() {
             Some(dir)

--- a/nydus/src/bin/nydus/merge.rs
+++ b/nydus/src/bin/nydus/merge.rs
@@ -62,9 +62,17 @@ impl MergeCommand {
     /// Executes the merge sub command, merging the layer blobs into an
     /// overlaid bootstrap.
     pub fn execute(&self) -> Result<()> {
-        // Initialize tracing.
+        // Initializes the tracing subscriber for logging, using the specified log level and
+        // console output preference.
         let _guards = init_command_tracing(self.log_level, self.console);
 
+        // Runs the merge, writing the overlaid bootstrap to the output.
+        self.run()
+    }
+
+    /// Runs the merge: overlays the source layers in order and persists the
+    /// merged bootstrap.
+    fn run(&self) -> Result<()> {
         let whiteout_spec = match self.whiteout_spec {
             WhiteoutSpec::Oci => MergeWhiteoutSpec::Oci,
         };

--- a/nydus/src/bin/nydus/nbd.rs
+++ b/nydus/src/bin/nydus/nbd.rs
@@ -129,6 +129,14 @@ impl NbdCommand {
         // Load the storage config.
         let config = Config::load(&self.config)?;
 
+        // Runs the NBD service until shutdown.
+        self.run(signals, config)
+    }
+
+    /// Runs the NBD service: builds the core, attaches the device, spawns
+    /// the workers, optionally mounts the device, and serves until a
+    /// termination signal stops it.
+    fn run(&self, signals: signal::Signals, config: Config) -> Result<()> {
         let core =
             Arc::new(NbdCore::new(&self.bootstrap, config).context("failed to build nbd core")?);
         let service = Arc::new(NbdService::new(

--- a/nydus/src/bin/nydus/optimize.rs
+++ b/nydus/src/bin/nydus/optimize.rs
@@ -1,14 +1,17 @@
 use clap::Parser;
 use nydus::error::{Context, Error, Result};
-use nydus::optimize::{build_ondemand_blob, load_patterns_from_apiserver, load_patterns_from_file};
-use nydus_backend::build_backend;
+use nydus::optimize::{
+    build_ondemand_blob, load_patterns_from_apiserver, load_patterns_from_file, BlockGroupRef,
+};
+use nydus_backend::{build_backend, BlobBackend};
 use nydus_config::Config;
 use nydus_format::blob::BLOB_METADATA_SUFFIX;
 use nydus_format::erofs::EROFS_BLOCK_SIZE;
 use nydus_format::utils::hex_string;
 use nydus_telemetry::logging::init_command_tracing;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use tabled::{settings::Style, Table, Tabled};
 use tracing::{info, Level};
 
@@ -83,27 +86,44 @@ impl OptimizeCommand {
     /// Executes the optimize sub command, running the optimize pipeline from
     /// [`nydus::optimize`] and writing out its artifacts.
     pub fn execute(&self) -> Result<()> {
-        // Initialize tracing.
+        // Initializes the tracing subscriber for logging, using the specified log level and
+        // console output preference.
         let _guards = init_command_tracing(self.log_level, self.console);
 
+        // Validates the flag combination before any expensive work.
+        self.validate()?;
+
+        // Prepares the access patterns, blob backend, and cache directory from the raw CLI flags.
+        let (patterns, backend, cache_dir) = self.prepare()?;
+
+        // Runs the optimize pipeline, persisting its artifacts and printing the summary.
+        self.run(&patterns, backend, &cache_dir)
+    }
+
+    /// Validates the flag combination before any expensive work: the
+    /// rewritten bootstrap must not overwrite its parent.
+    fn validate(&self) -> Result<()> {
         if self.parent_bootstrap == self.bootstrap {
             return Err(Error::InvalidParameter(
                 "--parent-bootstrap and --bootstrap must point to different files".to_string(),
             ));
         }
 
+        Ok(())
+    }
+
+    /// Lowers the raw CLI flags into the optimize inputs: the access patterns
+    /// from the trace source, the blob backend, and the local cache directory
+    /// the source block groups are pulled through.
+    fn prepare(&self) -> Result<(Vec<BlockGroupRef>, Arc<dyn BlobBackend>, PathBuf)> {
         let patterns = match (&self.trace_file, &self.apiserver) {
             (Some(path), _) => load_patterns_from_file(path)?,
             (None, Some(apiserver)) => load_patterns_from_apiserver(apiserver)?,
-            (None, None) => {
-                return Err(Error::InvalidParameter(
-                    "either --trace-file or --apiserver must be provided".to_string(),
-                ))
-            }
+            _ => unreachable!("clap enforces exactly one of --trace-file and --apiserver"),
         };
         if patterns.is_empty() {
             return Err(Error::InvalidParameter(
-                "no block group accesses found in the access trace; exercise the workload before optimizing"
+                "no block group accesses found in the access trace (exercise the workload before optimizing)"
                     .to_string(),
             ));
         }
@@ -114,17 +134,29 @@ impl OptimizeCommand {
             build_backend(&storage_config.backend).context("failed to build blob backend")?;
         // Source block groups are pulled through the local blob cache, so diskless mode
         // cannot apply.
-        let Some(cache_dir) = &storage_config.storage.dir else {
+        let Some(cache_dir) = storage_config.storage.dir else {
             return Err(Error::InvalidConfig(
                 "optimize requires storage.dir: source block groups are pulled through the local blob cache"
                     .to_string(),
             ));
         };
+
+        Ok((patterns, backend, cache_dir))
+    }
+
+    /// Runs the optimize pipeline: builds the ondemand blob, persists the
+    /// blob, its metadata, and the rewritten bootstrap, and prints the summary.
+    fn run(
+        &self,
+        patterns: &[BlockGroupRef],
+        backend: Arc<dyn BlobBackend>,
+        cache_dir: &Path,
+    ) -> Result<()> {
         fs::create_dir_all(cache_dir).with_context(|| {
             format!("failed to create cache directory: {}", cache_dir.display())
         })?;
 
-        let ondemand = build_ondemand_blob(&self.parent_bootstrap, &patterns, backend, cache_dir)?;
+        let ondemand = build_ondemand_blob(&self.parent_bootstrap, patterns, backend, cache_dir)?;
         let digest_hex = hex_string(&ondemand.full_blob_digest);
 
         fs::create_dir_all(&self.blob_dir).with_context(|| {

--- a/nydus/src/bin/nydus/ublk.rs
+++ b/nydus/src/bin/nydus/ublk.rs
@@ -131,6 +131,13 @@ impl UblkCommand {
         // Load the storage config.
         let config = Config::load(&self.config)?;
 
+        // Runs the ublk block device service until shutdown.
+        self.run(signals, config)
+    }
+
+    /// Runs the ublk service: builds the core, attaches the device, prints
+    /// its path, and serves I/O until a termination signal stops it.
+    fn run(&self, signals: signal::Signals, config: Config) -> Result<()> {
         let core = Arc::new(UblkCore::new(&self.bootstrap, config)?);
         info!(
             "serving {} as a {} byte block device",

--- a/nydus/src/bin/nydus/uffd.rs
+++ b/nydus/src/bin/nydus/uffd.rs
@@ -98,6 +98,14 @@ impl UffdCommand {
         // Load the storage config.
         let config = Config::load(&self.config)?;
 
+        // Runs the userfaultfd service until shutdown.
+        self.run(signals, config)
+    }
+
+    /// Runs the userfaultfd service: builds the core, spawns the signal
+    /// thread, and blocks on the tokio runtime until a termination signal or
+    /// a fatal error stops it.
+    fn run(&self, signals: signal::Signals, config: Config) -> Result<()> {
         let core = Arc::new(UffdCore::new(&self.bootstrap, config)?);
         let service = Arc::new(UffdService::new(core, self.socket.clone()));
         let signal_service = service.clone();

--- a/nydus/src/check/mod.rs
+++ b/nydus/src/check/mod.rs
@@ -7,9 +7,7 @@ use memmap2::Mmap;
 use nydus_core::reader::RawBlobInfo;
 use nydus_core::ErofsReader;
 use nydus_error::{Context, Error, Result};
-use nydus_format::blob::{
-    BlobFooter, BlobMetadata, BlobMetadataCompressor, BlobMetadataDigester, NYDUS_BLOB_FOOTER_SIZE,
-};
+use nydus_format::blob::{BlobFooter, BlobMetadata, BlobMetadataCompressor, BlobMetadataDigester};
 use nydus_format::erofs::{
     mode_to_erofs_file_type, ErofsInode, ErofsSuperblock, EROFS_BLOB_ID_SIZE, EROFS_BLOCK_SIZE,
     EROFS_FT_BLKDEV, EROFS_FT_CHRDEV, EROFS_FT_DIR, EROFS_FT_FIFO, EROFS_FT_REG_FILE,
@@ -436,15 +434,9 @@ fn inspect_blob(path: &Path) -> Result<Option<BlobInspection>> {
         .with_context(|| format!("failed to open blob candidate: {}", path.display()))?;
     let mmap = unsafe { Mmap::map(&file) }
         .with_context(|| format!("failed to map blob candidate: {}", path.display()))?;
-    if mmap.len() < NYDUS_BLOB_FOOTER_SIZE {
+    let Some(footer) = BlobFooter::from_blob_bytes(&mmap)? else {
         return Ok(None);
-    }
-    let footer_bytes = &mmap[mmap.len() - NYDUS_BLOB_FOOTER_SIZE..];
-    if !BlobFooter::has_magic(footer_bytes) {
-        return Ok(None);
-    }
-
-    let footer = BlobFooter::parse_from_tail(&mmap)?;
+    };
     let data_start = usize::try_from(footer.compressed_data_offset())
         .map_err(|err| Error::Overflow(format!("compressed data offset too large: {err}")))?;
     let data_size = usize::try_from(footer.compressed_data_size())

--- a/nydus/src/fanotify/service.rs
+++ b/nydus/src/fanotify/service.rs
@@ -592,7 +592,7 @@ impl Coordinator<'_> {
             let event = match parsed {
                 Ok(event) if event.is_overflow() => {
                     return Err(Error::Runtime(
-                        "fanotify queue overflow; stopping fail-closed".to_string(),
+                        "fanotify queue overflow (stopping fail-closed)".to_string(),
                     ));
                 }
                 Ok(event) => event,
@@ -685,7 +685,7 @@ impl Coordinator<'_> {
         match self.core.is_range_ready(&device.id, offset, count) {
             Ok(true) => {
                 debug!(
-                    "fanotify: range [{}, +{}) already ready for blob {}; allowing immediately",
+                    "fanotify: range [{}, +{}) already ready for blob {} (allowing immediately)",
                     offset, count, device.id
                 );
                 respond(&mut permission, Response::Allow)?;
@@ -798,7 +798,7 @@ impl JobTable {
                 let response = match completion.result {
                     CompletionResult::Fetch(Ok(())) => {
                         debug!(
-                            "fanotify: job {} fetch succeeded; allowing",
+                            "fanotify: job {} fetch succeeded (allowing)",
                             completion.job_id
                         );
                         Response::Allow
@@ -820,7 +820,7 @@ impl JobTable {
             }
             CompletionAction::Late => {
                 debug!(
-                    "fanotify: late completion for job {}; response already denied",
+                    "fanotify: late completion for job {} (response already denied)",
                     completion.job_id
                 );
                 Ok(())

--- a/nydus/src/nbd/service.rs
+++ b/nydus/src/nbd/service.rs
@@ -319,7 +319,7 @@ impl NbdWorker {
                 // boundaries and there is no way to resync; a reply would
                 // carry a fabricated handle the kernel cannot match, killing
                 // the connection from its side anyway. Drop the session.
-                warn!("nbd: invalid request magic 0x{got:08x}; dropping connection");
+                warn!("nbd: invalid request magic 0x{got:08x} (dropping connection)");
                 return Ok(false);
             }
         };

--- a/nydus/src/signal/mod.rs
+++ b/nydus/src/signal/mod.rs
@@ -5,7 +5,8 @@
 use nydus_error::{Context, Error, Result};
 use signal_hook::consts::{signal::SIGHUP, TERM_SIGNALS};
 use signal_hook::flag;
-use signal_hook::iterator::{Handle, Signals};
+use signal_hook::iterator::Handle;
+pub use signal_hook::iterator::Signals;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use tracing::info;

--- a/nydusify/pkg/nydus/builder.go
+++ b/nydusify/pkg/nydus/builder.go
@@ -135,7 +135,6 @@ func RunNydusMerge(ctx context.Context, opt MergeBuildOption) error {
 func RunNydusExport(ctx context.Context, opt ExportOption, dest io.Writer) error {
 	args := []string{
 		"export", opt.BlobPath,
-		"--output", "-",
 		"--log-level", cmp.Or(opt.LogLevel, DefaultLogLevel),
 	}
 

--- a/tests/e2e/fanotify_test.go
+++ b/tests/e2e/fanotify_test.go
@@ -387,7 +387,7 @@ func (e *fanotifyEnv) caseEventDriven(t *testing.T) { // C6 — daemon health un
 	// observability artifact, not evidence the path was skipped. We keep only
 	// the ROBUST negative checks as hard assertions.
 	t.Logf("  [C6 info] job-dispatched log lines: %d (lossy)", e.countLogs(`job [0-9]+ dispatched`))
-	t.Logf("  [C6 info] fetch-allow  log lines: %d", e.countLogs(`fetch succeeded; allowing`))
+	t.Logf("  [C6 info] fetch-allow  log lines: %d", e.countLogs(`fetch succeeded`))
 	assert.Equal(t, 0, e.countLogs(`unknown event fd`), "no unknown-device denies for legit reads")
 	assert.Equal(t, 0, e.countLogs(`immediate deny: InvalidRange`), "no invalid-range denies for legit reads")
 	assert.Equal(t, 0, e.countLogs(`fetch backend failure`), "no backend failures against the registry")


### PR DESCRIPTION

Redesign the BlobFooter parsing API with typed entry points and improved validation logic, consolidating validate_incompat_flags across callers. Extract validate/prepare/run helpers in subcommands for consistency. Migrate logging output to stderr and clean up minor log messages. Update docs to reflect export command changes.

## Overview
This pull request includes several improvements and refactorings across the documentation and codebase, focusing on CRC32 handling for blob metadata, argument and logging behavior for the export command, and code simplification and clarity. The most notable changes are the refactoring of CRC32 calculation for blob metadata, improved validation of incompatibility flags, and updates to documentation and argument parsing for the `nydus export` command.

### Blob Metadata CRC32 Handling

* Refactored CRC32 calculation for blob metadata to use a more efficient and clearer approach, removing the `crc32_with_zeroed_field` helper and centralizing logic in `BlobMetadata` (`nydus-format/src/blob/metadata.rs`, `nydus-format/src/blob/validate.rs`) [[1]](diffhunk://#diff-f4fcbe4530c56fb80da03a0cfa010fe248975a17b4b9dc5f654fd044bd9f930cL882-R920) [[2]](diffhunk://#diff-f4fcbe4530c56fb80da03a0cfa010fe248975a17b4b9dc5f654fd044bd9f930cL769-R772) [[3]](diffhunk://#diff-f4fcbe4530c56fb80da03a0cfa010fe248975a17b4b9dc5f654fd044bd9f930cL905-R929) [[4]](diffhunk://#diff-f4fcbe4530c56fb80da03a0cfa010fe248975a17b4b9dc5f654fd044bd9f930cL1096-R1120) [[5]](diffhunk://#diff-f4fcbe4530c56fb80da03a0cfa010fe248975a17b4b9dc5f654fd044bd9f930cL1107-L1114).
* Updated tests to use the new CRC32 field range constant and logic (`nydus-format/src/blob/metadata.rs`) [[1]](diffhunk://#diff-f4fcbe4530c56fb80da03a0cfa010fe248975a17b4b9dc5f654fd044bd9f930cL1388-R1406) [[2]](diffhunk://#diff-f4fcbe4530c56fb80da03a0cfa010fe248975a17b4b9dc5f654fd044bd9f930cL1410-R1425).

### Incompatibility Flag Validation

* Moved and simplified the `validate_incompat_flags` function, removing the `what` parameter and standardizing error messages (`nydus-format/src/blob/validate.rs`, `nydus-format/src/blob/mod.rs`, `nydus-format/src/blob/metadata.rs`) [[1]](diffhunk://#diff-f4fcbe4530c56fb80da03a0cfa010fe248975a17b4b9dc5f654fd044bd9f930cL344-R348) [[2]](diffhunk://#diff-d106511bd25a96f5aef6488a9dfce215fd50417b307e6ff4df12d58105f1f4f3L20-R38) [[3]](diffhunk://#diff-6c3baf607443c42e07c1360feb2b7476cb6e18809981b7f724d61949b86c1e0aL8-R23).

### Export Command Argument and Logging Behavior

* Updated the documentation and argument parsing for the `nydus export` command to use `-o`/`--output` instead of `--output`, clarified default behavior, and improved explanation of logging and output streams (`docs/nydus.md`) [[1]](diffhunk://#diff-f4e81f062b5700b1c95dff51e313ec47a16d710250bec2e0ce29fbe7eb54df06L210-R210) [[2]](diffhunk://#diff-f4e81f062b5700b1c95dff51e313ec47a16d710250bec2e0ce29fbe7eb54df06L229-R230) [[3]](diffhunk://#diff-f4e81f062b5700b1c95dff51e313ec47a16d710250bec2e0ce29fbe7eb54df06L252-R252).

### Code Simplification and Naming Consistency

* Renamed internal functions for clarity (e.g., `map_file` to `mmap_file`) and improved file mapping logic in `ErofsReader` (`nydus-core/src/reader/mod.rs`) [[1]](diffhunk://#diff-2cbdb5cd56dab051d004aca37e7396339dd3c51378e53ed2c2d84ad1b7fb4d6aL75-R75) [[2]](diffhunk://#diff-2cbdb5cd56dab051d004aca37e7396339dd3c51378e53ed2c2d84ad1b7fb4d6aL98-R98) [[3]](diffhunk://#diff-2cbdb5cd56dab051d004aca37e7396339dd3c51378e53ed2c2d84ad1b7fb4d6aL148-R148) [[4]](diffhunk://#diff-2cbdb5cd56dab051d004aca37e7396339dd3c51378e53ed2c2d84ad1b7fb4d6aL173-R182).
* Updated method calls for reading blob footers to use more descriptive and consistent names (`nydus-backend/src/local.rs`, `nydus-backend/src/registry/mod.rs`) [[1]](diffhunk://#diff-fe3598e7ba75043adee9263d1b8e731558442fc84da71a0b633c678807f3f1dfL240-R240) [[2]](diffhunk://#diff-04a635e2a14945be677bd46725b82cdb3ef08ec0b94f63f0b05c6cb9666f889aL625-R635).

### Minor Improvements

* Improved warning message clarity for non-redirect block groups in cache logic (`nydus-storage/src/cache/caches.rs`).
* Minor code style and whitespace adjustments for consistency (`nydus-format/src/erofs/block.rs`).

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [x] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.