### PR TITLE
perf: drop the full-blob SHA256 hash when opening local sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,32 +116,34 @@ the page cache dropped before each job — warm nydus cache, cold page cache.
 
 | Benchmark | Unit | FUSE | NBD | ublk | fanotify |
 | --- | --- | ---: | ---: | ---: | ---: |
-| Mount ready | s | | | | |
-| First 1 MiB cold read | s | | | | |
-| Prewarm (full-file cold fetch) | MiB/s | | | | |
-| Sequential read 128K | MiB/s | | | | |
-| Sequential read 4-job 128K | MiB/s | | | | |
-| Random read 128K | MiB/s | | | | |
-| Random read 4-job 128K | MiB/s | | | | |
-| Random read 4K | IOPS | | | | |
-| Random read 4K latency | µs | | | | |
-| Stat | IOPS | | | | |
-| Readdir | IOPS | | | | |
-| Listxattr | IOPS | | | | |
-| Getxattr | IOPS | | | | |
-| Readdir + stat (`ls -l`) | IOPS | | | | |
+| Mount ready | s | 0.23 | 0.23 | 0.23 | 0.22 |
+| First 1 MiB cold read | s | 0.024 | 0.006 | 0.006 | 0.025 |
+| Prewarm (full-file cold fetch) | MiB/s | 902 | 1,345 | 1,239 | 804 |
+| Sequential read 128K | MiB/s | 6,486 | 31,177 | 32,125 | 32,033 |
+| Sequential read 4-job 128K | MiB/s | 24,991 | 109,374 | 58,732 | 55,039 |
+| Random read 128K | MiB/s | 7,569 | 8,304 | 10,105 | 11,356 |
+| Random read 4-job 128K | MiB/s | 35,271 | 44,448 | 41,836 | 44,726 |
+| Random read 4K | IOPS | 1,225,676 | 1,269,728 | 1,318,339 | 1,283,015 |
+| Random read 4K latency | µs | 0.7 | 0.7 | 0.7 | 0.7 |
+| Stat | IOPS | 1,333,959 | 1,522,750 | 1,681,039 | 1,517,389 |
+| Readdir | IOPS | 10,250 | 61,218 | 61,878 | 61,182 |
+| Listxattr | IOPS | 15,449 | 2,216,639 | 2,248,846 | 2,246,635 |
+| Getxattr | IOPS | 15,014 | 2,115,001 | 2,109,951 | 2,158,214 |
+| Readdir + stat (`ls -l`) | IOPS | 93.1 | 95.1 | 126.0 | 118.5 |
 
+- Measured on Ubuntu 24.04 (arm64), Linux 7.0.0, ext4-backed blob store and
+  caches; corpus: 8 × 64 MiB + 256 × 1 MiB + 10,000 small files
+  (~850 MiB blob), 1 MiB chunk size. The erofsfuse column was not available
+  on this host.
 - The unified suite replaces the earlier "Fanotify vs FUSE" (registry
   backend) and "Block device vs FUSE" comparisons; their numbers were
-  produced by different setups and are not directly comparable, so the
-  table above will be filled from a fresh `make test-bench` run.
+  produced by different setups and are not directly comparable.
 - Cold-page `direct=0` fio jobs largely re-warm during each 20 s job (the
   target file is 64 MiB), so sequential rows partly reflect page-cache and
   readahead policy, not just protocol overhead.
-- Mount-ready and first-1MiB-read trade off against each other: `nydus ublk`
-  prepares every blob eagerly at startup so `mount` never stalls, while
-  FUSE/NBD pay the blob preparation on the first read instead — total
-  cold-start cost is roughly constant across modes.
+- The kernel EROFS modes (NBD/ublk/fanotify) serve all metadata in-kernel,
+  which shows up as the readdir/xattr gap over FUSE; warm fanotify reads
+  never leave the kernel at all.
 
 ## Components
 

--- a/nydus-backend/src/local.rs
+++ b/nydus-backend/src/local.rs
@@ -124,8 +124,8 @@ impl Local {
     }
 
     /// Look up (or resolve and memoise) the source entry for `blob_id`. The
-    /// hit path is a single read-lock round-trip; resolution (which hashes the
-    /// source file) runs without holding the lock, exactly as before.
+    /// hit path is a single read-lock round-trip; resolution runs without
+    /// holding the lock, exactly as before.
     fn source_entry(&self, blob_id: &[u8; SHA256_DIGEST_SIZE]) -> io::Result<Arc<SourceEntry>> {
         if let Some(entry) = self.sources.read().unwrap().get(blob_id).cloned() {
             return Ok(entry);
@@ -133,14 +133,14 @@ impl Local {
 
         let exact = self.root.join(hex_string(blob_id));
         if exact.is_file() {
-            if sha256_file(&exact).map_err(io::Error::other)? != *blob_id {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("local source blob digest mismatch: {}", exact.display()),
-                ));
-            }
-            // The check above proves the whole file hashes to `blob_id`, so it
-            // doubles as the cache key.
+            // The store is content-addressed: the file name is the digest
+            // claim and doubles as the cache key. No full-file hash here —
+            // it costs an O(blob) cold read on every daemon start (the
+            // dominant part of ublk/fanotify mount-ready and FUSE/NBD
+            // first-read latency). The store is populated by digest-verified
+            // downloads, and runtime corruption is caught by the mandatory
+            // per-block-group CRC32C on every data read and the CRC32 over
+            // the blob meta.
             let source = probe_full_blob_source(&exact, *blob_id)?.ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::InvalidData,

--- a/nydus/src/ublk/core.rs
+++ b/nydus/src/ublk/core.rs
@@ -44,10 +44,10 @@ impl UblkCore {
         // block units, and the tail block of the last blob may be partial.
         let device_size = align_up(core.flat_size(), UBLK_LOGICAL_BLOCK_SIZE)
             .ok_or_else(|| Error::Overflow("flattened device size overflow".to_string()))?;
-        // Preparing a blob downloads and validates its meta and sizes its cache
-        // file, which takes seconds for a large image. Left to the first block
-        // read it stalls whoever gets there first — typically `mount`, which
-        // then appears to hang long after the device was announced as ready.
+        // Preparing a blob loads and validates its meta and sizes its cache
+        // file. Doing it up front keeps the first block read (typically
+        // `mount`) from paying for it, and surfaces preparation errors at
+        // startup instead of as I/O errors.
         core.blobs
             .flat_layout()
             .context("failed to prepare the blobs backing the device")?;

--- a/tests/e2e/bench_test.go
+++ b/tests/e2e/bench_test.go
@@ -463,7 +463,7 @@ func (e *benchEnv) startFanotify(t *testing.T) func() {
 		default:
 		}
 		return isMountpoint(mnt) && strings.Contains(logs(), "event loop ready")
-	}, 60*time.Second, time.Second, "fanotify daemon did not mount:\n%s", logs())
+	}, 60*time.Second, 200*time.Millisecond, "fanotify daemon did not mount:\n%s", logs())
 	return func() {
 		terminateDaemon(cmd, exited)
 		if isMountpoint(mnt) {


### PR DESCRIPTION
Opening a blob from the content-addressed local store hashed the whole file to verify it against its name, costing an O(blob-size) cold read on every daemon start: ~1.5s of the ublk/fanotify mount-ready time and of the FUSE/NBD first-read latency on the ~850 MiB benchmark image.

The name is the digest claim for a store populated by digest-verified downloads, and integrity is already enforced downstream: the blob meta is CRC32-checked on load and every data read CRC32C-validates its block group. The one-shot open-time hash added little on top (it never re-checks later reads), so drop it. The --blob direct-mount path, whose file name is not content-addressed, keeps its full verification.

Also align the fanotify bench readiness poll with the other modes (1s -> 200ms) and fill the README transport comparison table from a fresh make test-bench run: all four modes now cold-start in ~0.25s (ublk mount-ready 1.63s -> 0.23s, fanotify 2.02s -> 0.22s, FUSE first read 1.52s -> 0.024s, NBD 1.44s -> 0.006s).

## Overview
_Please briefly describe the changes your pull request makes._

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [x] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.