### PR TITLE
[v3] Add dragonfly backend error handling and E2E tests

### DIFF
--- a/.github/workflows/e2e-dragonfly.yml
+++ b/.github/workflows/e2e-dragonfly.yml
@@ -1,0 +1,397 @@
+name: E2E Test With Dragonfly
+
+on:
+  push:
+    branches: [main, release-*, v3]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE*'
+  pull_request:
+    branches: [main, release-*, v3]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DRAGONFLY_VERSION: "2.4.3"
+  CLIENT_VERSION: "1.3.3"
+
+jobs:
+  nydus-build:
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GH_TOKEN }}
+
+      - name: Setup Rust toolchain
+        uses: dsherret/rust-toolchain-file@v1
+
+      - name: Build nydus (with Dragonfly backend)
+        run: |
+          cargo build -p nydus --release --features "cli,backend-dragonfly-proxy"
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.5'
+          cache: false
+
+      - name: Build nydusify
+        run: |
+          cd nydusify
+          go build -o ../target/release/nydusify .
+
+      - name: Upload nydus binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: nydus-artifact
+          path: |
+            target/release/nydus
+            target/release/nydusify
+
+  dragonfly-download:
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    steps:
+      - name: Cache Dragonfly binaries
+        id: cache-dragonfly
+        uses: actions/cache@v4
+        with:
+          path: /tmp/dragonfly-bin
+          key: dragonfly-${{ env.DRAGONFLY_VERSION }}-client-${{ env.CLIENT_VERSION }}-linux-amd64
+
+      - name: Download Dragonfly server binaries
+        if: steps.cache-dragonfly.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /tmp/dragonfly-bin
+          wget -q -O /tmp/dragonfly-server.tar.gz \
+            "https://github.com/dragonflyoss/dragonfly/releases/download/v${DRAGONFLY_VERSION}/dragonfly-${DRAGONFLY_VERSION}-linux-amd64.tar.gz"
+          tar -xzf /tmp/dragonfly-server.tar.gz -C /tmp/dragonfly-bin manager scheduler
+          rm /tmp/dragonfly-server.tar.gz
+
+      - name: Download Dragonfly client binaries
+        if: steps.cache-dragonfly.outputs.cache-hit != 'true'
+        run: |
+          wget -q -O /tmp/dragonfly-client.tar.gz \
+            "https://github.com/dragonflyoss/client/releases/download/v${CLIENT_VERSION}/dragonfly-client-v${CLIENT_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          tar -xzf /tmp/dragonfly-client.tar.gz --strip-components=1 -C /tmp/dragonfly-bin
+          rm /tmp/dragonfly-client.tar.gz
+
+      - name: Upload Dragonfly binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: dragonfly-artifact
+          path: /tmp/dragonfly-bin
+
+  e2e-test:
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
+    needs: [nydus-build, dragonfly-download]
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - mode: sdk-proxy-fallback
+            config: misc/dragonfly/nydus-sdk-fallback.yaml
+            cache_dir: /tmp/nydus-dragonfly/cache-fallback
+          - mode: sdk-proxy-strict
+            config: misc/dragonfly/nydus-sdk-strict.yaml
+            cache_dir: /tmp/nydus-dragonfly/cache-strict
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Download nydus artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: nydus-artifact
+          path: /tmp/nydus-bin
+
+      - name: Download Dragonfly artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dragonfly-artifact
+          path: /tmp/dragonfly-bin
+
+      - name: Install binaries
+        run: |
+          sudo install -m 0755 /tmp/nydus-bin/nydus /usr/local/bin/nydus
+          sudo install -m 0755 /tmp/nydus-bin/nydusify /usr/local/bin/nydusify
+          sudo install -m 0755 /tmp/dragonfly-bin/manager /usr/local/bin/manager
+          sudo install -m 0755 /tmp/dragonfly-bin/scheduler /usr/local/bin/scheduler
+          sudo install -m 0755 /tmp/dragonfly-bin/dfdaemon /usr/local/bin/dfdaemon
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.5'
+          cache: false
+
+      - name: Install runtime dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq mysql-client redis-tools fuse3
+
+      - name: Start MySQL
+        run: |
+          docker run -d --name mysql \
+            -e MYSQL_ROOT_PASSWORD=dragonfly \
+            -e MYSQL_DATABASE=manager \
+            -p 3306:3306 \
+            mysql:8
+          for i in $(seq 1 60); do
+            if docker exec mysql mysqladmin ping -h 127.0.0.1 -u root -pdragonfly --silent 2>/dev/null; then
+              break
+            fi
+            sleep 2
+          done
+
+      - name: Start Redis
+        run: |
+          docker run -d --name redis -p 6379:6379 redis:latest
+          for i in $(seq 1 30); do
+            if docker exec redis redis-cli ping 2>/dev/null | grep -q PONG; then
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Setup Dragonfly config
+        run: |
+          sudo mkdir -p /etc/dragonfly
+          sudo cp misc/dragonfly/manager.yaml /etc/dragonfly/manager.yaml
+          sudo cp misc/dragonfly/scheduler.yaml /etc/dragonfly/scheduler.yaml
+          sudo cp misc/dragonfly/dfdaemon.yaml /etc/dragonfly/dfdaemon.yaml
+          mkdir -p /tmp/dragonfly/logs /tmp/dragonfly/cache /tmp/dragonfly/storage
+          mkdir -p /tmp/nydus-dragonfly/cache-fallback /tmp/nydus-dragonfly/cache-strict /tmp/nydus-dragonfly/mnt
+
+      - name: Start Dragonfly services
+        run: |
+          # manager/scheduler create their default workHome under /usr/local/dragonfly,
+          # so they must run as root. Start services sequentially since each one
+          # registers with the previous.
+          sudo /usr/local/bin/manager --config /etc/dragonfly/manager.yaml > /tmp/dragonfly/logs/manager.stdout.log 2>&1 &
+          timeout 90 bash -c 'until nc -z 127.0.0.1 65003; do sleep 1; done'
+
+          sudo /usr/local/bin/scheduler --config /etc/dragonfly/scheduler.yaml > /tmp/dragonfly/logs/scheduler.stdout.log 2>&1 &
+          timeout 60 bash -c 'until nc -z 127.0.0.1 8002; do sleep 1; done'
+
+          # Rust dfdaemon has no `daemon` subcommand and takes the log dir via --log-dir.
+          sudo /usr/local/bin/dfdaemon --config /etc/dragonfly/dfdaemon.yaml --log-dir /tmp/dragonfly/logs/dfdaemon > /tmp/dragonfly/logs/dfdaemon.stdout.log 2>&1 &
+          timeout 60 bash -c 'until nc -z 127.0.0.1 4001; do sleep 1; done'
+
+      - name: Build and push nydus test image
+        run: |
+          # Seed a throwaway local registry with a freshly converted nydus
+          # image: upstream nydus sample images use the legacy RAFS format,
+          # which this nydus cannot mount (EROFS-based bootstraps only).
+          docker run -d --name registry -p 5000:5000 --restart=no registry:2
+          timeout 30 bash -c 'until curl -sf http://127.0.0.1:5000/v2/ >/dev/null; do sleep 1; done'
+
+          WORK_DIR="/tmp/nydus-dragonfly"
+          mkdir -p "${WORK_DIR}/source/etc" "${WORK_DIR}/source/data"
+          printf 'NAME="Nydus Dragonfly E2E"\nID=nydus-e2e\nVERSION_ID=1\n' > "${WORK_DIR}/source/etc/os-release"
+          echo "root:x:0:0:root:/root:/bin/sh" > "${WORK_DIR}/source/etc/passwd"
+          echo "root:x:0:" > "${WORK_DIR}/source/etc/group"
+          head -c 4194304 /dev/urandom > "${WORK_DIR}/source/data/blob1.bin"
+          head -c 8388608 /dev/urandom > "${WORK_DIR}/source/data/blob2.bin"
+
+          nydusify convert --source "${WORK_DIR}/source" \
+            --target 127.0.0.1:5000/nydus-e2e/dragonfly:v1 \
+            --builder /usr/local/bin/nydus \
+            --target-insecure --target-plain-http
+          nydusify check --target 127.0.0.1:5000/nydus-e2e/dragonfly:v1 \
+            --work-dir "${WORK_DIR}/check" \
+            --builder /usr/local/bin/nydus \
+            --target-insecure --target-plain-http
+
+          BOOTSTRAP_FILE=$(find "${WORK_DIR}/check" -name image.boot | head -1)
+          [ -n "${BOOTSTRAP_FILE}" ] || { echo "exported image.boot not found under ${WORK_DIR}/check"; exit 1; }
+          cp "${BOOTSTRAP_FILE}" "${WORK_DIR}/bootstrap"
+
+      - name: Run Dragonfly FUSE E2E test (${{ matrix.mode }})
+        run: |
+          cd tests/e2e
+          sudo -E env "PATH=$PATH" \
+            NYDUS_BIN=/usr/local/bin/nydus \
+            NYDUS_CONFIG=${{ github.workspace }}/${{ matrix.config }} \
+            NYDUS_CACHE_DIR=${{ matrix.cache_dir }} \
+            DRAGONFLY_MODE=${{ matrix.mode }} \
+            BOOTSTRAP_PATH=/tmp/nydus-dragonfly/bootstrap \
+            WORK_DIR=/tmp/nydus-dragonfly \
+            go test -v -run '^TestDragonflyE2E$' -timeout 15m -count=1 dragonfly_test.go harness.go
+
+      - name: Dump service logs
+        if: always()
+        continue-on-error: true
+        run: |
+          LOG_DIR="/tmp/dragonfly-e2e-logs"
+          mkdir -p "${LOG_DIR}"
+          cp -r /tmp/dragonfly/logs/. "${LOG_DIR}/" 2>/dev/null || true
+          cp -r /tmp/nydus-dragonfly/logs "${LOG_DIR}/nydus" 2>/dev/null || true
+          docker logs mysql > "${LOG_DIR}/mysql.log" 2>&1 || true
+          docker logs redis > "${LOG_DIR}/redis.log" 2>&1 || true
+
+      - name: Cleanup
+        if: always()
+        continue-on-error: true
+        run: |
+          sudo umount /tmp/nydus-dragonfly/mnt 2>/dev/null || true
+          sudo pkill -f '/usr/local/bin/dfdaemon' 2>/dev/null || true
+          sudo pkill -f '/usr/local/bin/scheduler' 2>/dev/null || true
+          sudo pkill -f '/usr/local/bin/manager' 2>/dev/null || true
+          docker rm -f mysql redis registry 2>/dev/null || true
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: dragonfly-e2e-logs-${{ matrix.mode }}
+          path: /tmp/dragonfly-e2e-logs/
+
+  proxy-error-test:
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
+    needs: [nydus-build, dragonfly-download]
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Download nydus artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: nydus-artifact
+          path: /tmp/nydus-bin
+
+      - name: Download Dragonfly artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dragonfly-artifact
+          path: /tmp/dragonfly-bin
+
+      - name: Install binaries
+        run: |
+          sudo install -m 0755 /tmp/nydus-bin/nydus /usr/local/bin/nydus
+          sudo install -m 0755 /tmp/nydus-bin/nydusify /usr/local/bin/nydusify
+          sudo install -m 0755 /tmp/dragonfly-bin/manager /usr/local/bin/manager
+          sudo install -m 0755 /tmp/dragonfly-bin/scheduler /usr/local/bin/scheduler
+          sudo install -m 0755 /tmp/dragonfly-bin/dfdaemon /usr/local/bin/dfdaemon
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.5'
+          cache: false
+
+      - name: Start MySQL and Redis
+        run: |
+          docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=dragonfly -e MYSQL_DATABASE=manager -p 3306:3306 mysql:8
+          docker run -d --name redis -p 6379:6379 redis:latest
+          timeout 60 bash -c 'until docker exec mysql mysqladmin ping -h 127.0.0.1 -u root -pdragonfly --silent; do sleep 2; done'
+          timeout 30 bash -c 'until docker exec redis redis-cli ping | grep -q PONG; do sleep 1; done'
+
+      - name: Setup and start Dragonfly services
+        run: |
+          sudo mkdir -p /etc/dragonfly
+          sudo cp misc/dragonfly/manager.yaml /etc/dragonfly/manager.yaml
+          sudo cp misc/dragonfly/scheduler.yaml /etc/dragonfly/scheduler.yaml
+          sudo cp misc/dragonfly/dfdaemon.yaml /etc/dragonfly/dfdaemon.yaml
+          mkdir -p /tmp/dragonfly/logs /tmp/dragonfly/cache /tmp/dragonfly/storage
+          mkdir -p /tmp/nydus-dragonfly/cache-proxy-fallback /tmp/nydus-dragonfly/cache-proxy-strict /tmp/nydus-dragonfly/mnt
+
+          # manager/scheduler create their default workHome under /usr/local/dragonfly,
+          # so they must run as root. Start services sequentially since each one
+          # registers with the previous.
+          sudo /usr/local/bin/manager --config /etc/dragonfly/manager.yaml > /tmp/dragonfly/logs/manager.stdout.log 2>&1 &
+          timeout 90 bash -c 'until nc -z 127.0.0.1 65003; do sleep 1; done'
+
+          sudo /usr/local/bin/scheduler --config /etc/dragonfly/scheduler.yaml > /tmp/dragonfly/logs/scheduler.stdout.log 2>&1 &
+          timeout 60 bash -c 'until nc -z 127.0.0.1 8002; do sleep 1; done'
+
+          # Rust dfdaemon has no `daemon` subcommand and takes the log dir via --log-dir.
+          sudo /usr/local/bin/dfdaemon --config /etc/dragonfly/dfdaemon.yaml --log-dir /tmp/dragonfly/logs/dfdaemon > /tmp/dragonfly/logs/dfdaemon.stdout.log 2>&1 &
+          timeout 60 bash -c 'until nc -z 127.0.0.1 4001; do sleep 1; done'
+
+      - name: Build and push nydus test image
+        run: |
+          # Seed a throwaway local registry with a freshly converted nydus
+          # image: upstream nydus sample images use the legacy RAFS format,
+          # which this nydus cannot mount (EROFS-based bootstraps only).
+          docker run -d --name registry -p 5000:5000 --restart=no registry:2
+          timeout 30 bash -c 'until curl -sf http://127.0.0.1:5000/v2/ >/dev/null; do sleep 1; done'
+
+          WORK_DIR="/tmp/nydus-dragonfly"
+          mkdir -p "${WORK_DIR}/source/etc" "${WORK_DIR}/source/data"
+          printf 'NAME="Nydus Dragonfly E2E"\nID=nydus-e2e\nVERSION_ID=1\n' > "${WORK_DIR}/source/etc/os-release"
+          echo "root:x:0:0:root:/root:/bin/sh" > "${WORK_DIR}/source/etc/passwd"
+          echo "root:x:0:" > "${WORK_DIR}/source/etc/group"
+          head -c 4194304 /dev/urandom > "${WORK_DIR}/source/data/blob1.bin"
+          head -c 8388608 /dev/urandom > "${WORK_DIR}/source/data/blob2.bin"
+
+          nydusify convert --source "${WORK_DIR}/source" \
+            --target 127.0.0.1:5000/nydus-e2e/dragonfly:v1 \
+            --builder /usr/local/bin/nydus \
+            --target-insecure --target-plain-http
+          nydusify check --target 127.0.0.1:5000/nydus-e2e/dragonfly:v1 \
+            --work-dir "${WORK_DIR}/check" \
+            --builder /usr/local/bin/nydus \
+            --target-insecure --target-plain-http
+
+          BOOTSTRAP_FILE=$(find "${WORK_DIR}/check" -name image.boot | head -1)
+          [ -n "${BOOTSTRAP_FILE}" ] || { echo "exported image.boot not found under ${WORK_DIR}/check"; exit 1; }
+          cp "${BOOTSTRAP_FILE}" "${WORK_DIR}/bootstrap"
+
+      - name: Run proxy error simulation test
+        run: |
+          cd tests/e2e
+          sudo -E env "PATH=$PATH" \
+            NYDUS_BIN=/usr/local/bin/nydus \
+            NYDUS_CONFIG=${{ github.workspace }}/misc/dragonfly/nydus-sdk-fallback.yaml \
+            NYDUS_CACHE_DIR=/tmp/nydus-dragonfly/cache-proxy-fallback \
+            NYDUS_PROXY_ERROR_CONFIG=${{ github.workspace }}/misc/dragonfly/nydus-proxy-error-fallback.yaml \
+            BOOTSTRAP_PATH=/tmp/nydus-dragonfly/bootstrap \
+            WORK_DIR=/tmp/nydus-dragonfly \
+            go test -v -run '^TestProxyErrorSimulation$' -timeout 20m -count=1 dragonfly_test.go harness.go
+
+      - name: Dump logs
+        if: always()
+        continue-on-error: true
+        run: |
+          LOG_DIR="/tmp/proxy-error-test-logs"
+          mkdir -p "${LOG_DIR}"
+          cp -r /tmp/dragonfly/logs/. "${LOG_DIR}/" 2>/dev/null || true
+          cp -r /tmp/nydus-dragonfly/logs "${LOG_DIR}/nydus" 2>/dev/null || true
+
+      - name: Cleanup
+        if: always()
+        continue-on-error: true
+        run: |
+          sudo umount /tmp/nydus-dragonfly/mnt 2>/dev/null || true
+          sudo pkill -f '/usr/local/bin/dfdaemon' 2>/dev/null || true
+          sudo pkill -f '/usr/local/bin/scheduler' 2>/dev/null || true
+          sudo pkill -f '/usr/local/bin/manager' 2>/dev/null || true
+          docker rm -f mysql redis registry 2>/dev/null || true
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: proxy-error-test-logs
+          path: /tmp/proxy-error-test-logs/

--- a/docs/nydus.md
+++ b/docs/nydus.md
@@ -720,6 +720,13 @@ Fields:
 	blob may take, while `http.timeout` bounds each block group request within it;
 	`0s` disables the bound. A blob that exceeds it is aborted with a warning
 	and prefetch moves on.
+- `prefetch.retry_delay_min` / `prefetch.retry_delay_max` (defaults `6h` /
+	`12h`) bound the random delay before a blob prefetch that the backend
+	throttled (a Dragonfly proxy `429`) is re-attempted; each throttled blob is
+	rescheduled with a fresh random deadline inside the window so retry load
+	spreads out instead of stampeding. `retry_delay_min` must not exceed
+	`retry_delay_max`. Only throttled failures are rescheduled; other prefetch
+	failures are logged and skipped.
 - `prefetch.scope` (default `ondemand`) selects which blobs to pull. `none`
 	disables prefetch; `ondemand` prefetches only the "ondemand" redirect blob
 	(if any), warming the access-ordered hot set while leaving backend
@@ -776,7 +783,8 @@ Fields under `backend.config`:
 - `auth` (optional): base64-encoded `username:password` string for basic auth.
 	Omit for anonymous / token-only registries.
 - `http` (optional): the HTTP client settings — timeouts, retries, and TLS
-	trust. The timeout and retry limits also apply to Dragonfly SDK requests.
+	trust. The timeout also applies to Dragonfly SDK requests; retry counts
+	for Dragonfly reads are governed by the `dragonfly` policy knobs below.
 	- `timeout` (default `5s`): per-request timeout in humantime format (e.g.
 		`5s`, `1m`); `0s` disables it. Kept short because a read holds the
 		block group's cross-process fetch claim for its whole duration, and what
@@ -784,7 +792,11 @@ Fields under `backend.config`:
 		sharing the cache directory.
 	- `max_retries` (default `3`): maximum number of retry attempts per
 		request, applied with exponential backoff by the HTTP client's retry
-		middleware and by the Dragonfly SDK.
+		middleware on direct origin requests. Origin requests issued as
+		Dragonfly fallbacks share the same budget but pace each retry through
+		the fallback throttle instead of the middleware's backoff, so this
+		default is what bounds "origin failing 3 retries" before a fallback
+		read errors out.
 	- `proxy` (optional): routes every registry request through an HTTP
 		forward proxy. Requests keep their original upstream URL, so a proxy
 		like a Dragonfly `dfdaemon` knows what to back-source. Omit to connect
@@ -799,15 +811,46 @@ Fields under `backend.config`:
 - `dragonfly` (optional): routes blob `GET`s through the Dragonfly client SDK
 	(crate `dragonfly-client-request`) for P2P distribution, carrying a
 	priority hint (`6` for on-demand reads, `3` for prefetch) plus the
-	configured `timeout` and `max_retries`; every other request (`HEAD`, auth
-	token fetches) goes directly to the origin registry. When a Dragonfly
-	request still fails after the SDK's retries, the read falls back to the
-	origin. Only available when the binary is built with the
-	`backend-dragonfly-proxy` feature. Omit to talk to the origin directly.
-	Metrics attribute each read to the origin or proxy side (see
-	[Metrics](#metrics)).
+	configured `timeout`; every other request (`HEAD`, auth token fetches)
+	goes directly to the origin registry. Only available when the binary is
+	built with the `backend-dragonfly-proxy` feature. Omit to talk to the
+	origin directly. Metrics attribute each read to the origin or proxy side
+	(see [Metrics](#metrics)).
+
+	Failed Dragonfly reads are handled by a load-shedding policy keyed on the
+	failure class and the read kind. The SDK's internal retries are disabled;
+	the retry counts below are exact and observable:
+
+	| Failure class | Prefetch | On-demand |
+	|---|---|---|
+	| Proxy `429` | No retry, no origin fallback; the blob's prefetch fails and is rescheduled after a random `prefetch.retry_delay_min`–`prefetch.retry_delay_max` delay | No Dragonfly retry; fall back to the origin through the fallback throttle; the origin failing `http.max_retries` attempts → IO error |
+	| Proxy `403` | Fail immediately, no retry, no fallback | Fail immediately, no retry, no fallback |
+	| Timeout | `prefetch_max_retries` Dragonfly retries (each after a random 100ms–1s delay), then fail (no fallback) | `ondemand_max_retries` Dragonfly retries, then throttled origin fallback |
+	| Connect / `5xx` / other | `prefetch_max_retries` Dragonfly retries (each after a random 100ms–1s delay), then fail (no fallback) | `ondemand_max_retries` Dragonfly retries, then throttled origin fallback |
+
+	Prefetch reads never fall back to the origin, so a Dragonfly outage
+	degrades prefetch instead of flooding the registry, while on-demand reads
+	stay served through the shaped fallback path.
+
 	- `scheduler_endpoint` (required): the Dragonfly scheduler endpoint (gRPC),
 		e.g. `http://127.0.0.1:65000`.
+	- `ondemand_max_retries` (default `3`): Dragonfly retries for a retryable
+		(timeout / connect / `5xx`) on-demand read failure before falling back
+		to the origin.
+	- `prefetch_max_retries` (default `10`): Dragonfly retries for a retryable
+		prefetch read failure before the read fails. Each prefetch retry waits
+		a random 100ms–1s delay first so failing prefetch reads do not hammer
+		a struggling Dragonfly proxy in lockstep; on-demand retries are never
+		delayed.
+	- `fallback_interval` (default `1s`, i.e. 1 QPS per process): the minimum
+		interval between origin requests issued as Dragonfly fallbacks; `0s`
+		disables the throttle. Every fallback attempt — including each retry
+		of a transient origin failure — waits for its own throttle slot, so
+		actual origin requests never exceed one per interval. Only fallback
+		reads are shaped — the normal direct path and auth fetches are never
+		throttled. On-demand group singleflight already dedupes concurrent
+		readers per group, so the throttle queues at most one leader per cold
+		group.
 
 
 ## Metrics
@@ -858,6 +901,22 @@ Backend:
 	source. A read is "high latency" when it takes 250ms or more.
 - `backend_origin_crc_check_errors`, `backend_proxy_crc_check_errors` — CRC
 	validation failures on fetched data, attributed to the serving side.
+- `backend_dragonfly_read_errors{class,kind}` — Dragonfly read failures by
+	failure class (`rate_limited`, `forbidden`, `timeout`, `connect`,
+	`server_error`, `other`) and read kind (`ondemand`, `prefetch`).
+- `backend_fallback_read_count`, `backend_fallback_read_errors` — origin
+	requests issued as Dragonfly fallbacks and how many of them failed; these
+	reads also count into the `backend_origin_*` split above. Each logical
+	fallback read counts once, however many throttled retry attempts it made.
+	The error counter covers only HTTP transport errors (connect failures,
+	timeouts) surfaced once the retry budget is spent — an HTTP error status
+	from the origin or a failure while streaming the response body is not
+	counted here. Watch this rate to confirm origin load stays shaped by
+	`fallback_interval`.
+- `backend_fallback_throttle_wait` — histogram of how long fallback reads
+	waited in the throttle queue (seconds).
+- `prefetch_reschedule_count`, `prefetch_reschedule_run_count` — throttled
+	blob prefetches queued for a delayed retry, and delayed retries executed.
 
 Filesystem:
 

--- a/misc/dragonfly/dfdaemon.yaml
+++ b/misc/dragonfly/dfdaemon.yaml
@@ -1,0 +1,33 @@
+host:
+  schedulerClusterID: 1
+
+manager:
+  addr: http://127.0.0.1:65003
+
+seedPeer:
+  enable: true
+  type: super
+
+upload:
+  server:
+    port: 4000
+
+proxy:
+  server:
+    port: 4001
+
+storage:
+  dir: /tmp/dragonfly/storage
+
+server:
+  cacheDir: /tmp/dragonfly/cache/dfdaemon
+  logDir: /tmp/dragonfly/logs/dfdaemon
+
+download:
+  server:
+    socketPath: /tmp/dragonfly/dfdaemon.sock
+
+dynconfig:
+  refreshInterval: 1m
+
+console: true

--- a/misc/dragonfly/manager.yaml
+++ b/misc/dragonfly/manager.yaml
@@ -1,0 +1,32 @@
+server:
+  grpc:
+    port:
+      start: 65003
+      end: 65003
+  rest:
+    addr: :8080
+  logDir: /tmp/dragonfly/logs/manager
+  cacheDir: /tmp/dragonfly/cache/manager
+  logLevel: info
+
+auth:
+  jwt:
+    realm: 'Dragonfly'
+    key: 'ZHJhZ29uZmx5Cg=='
+    timeout: 48h
+    maxRefresh: 48h
+
+database:
+  type: mysql
+  mysql:
+    user: root
+    password: dragonfly
+    host: 127.0.0.1
+    port: 3306
+    dbname: manager
+    migrate: true
+  redis:
+    addrs:
+      - 127.0.0.1:6379
+
+console: true

--- a/misc/dragonfly/nydus-proxy-error-fallback.yaml
+++ b/misc/dragonfly/nydus-proxy-error-fallback.yaml
@@ -1,0 +1,19 @@
+backend:
+  type: registry
+  config:
+    addr: http://127.0.0.1:18080
+    repository: nydus-e2e/dragonfly
+    http:
+      timeout: 5s
+      max_retries: 0
+      tls:
+        skip_verify: true
+    dragonfly:
+      scheduler_endpoint: http://127.0.0.1:8002
+      ondemand_max_retries: 3
+      prefetch_max_retries: 2
+      fallback_interval: 0s
+storage:
+  dir: /tmp/nydus-dragonfly/cache-proxy-fallback
+prefetch:
+  scope: none

--- a/misc/dragonfly/nydus-proxy-error-strict.yaml
+++ b/misc/dragonfly/nydus-proxy-error-strict.yaml
@@ -1,0 +1,19 @@
+backend:
+  type: registry
+  config:
+    addr: http://127.0.0.1:18080
+    repository: nydus-e2e/dragonfly
+    http:
+      timeout: 5s
+      max_retries: 0
+      tls:
+        skip_verify: true
+    dragonfly:
+      scheduler_endpoint: http://127.0.0.1:8002
+      ondemand_max_retries: 0
+      prefetch_max_retries: 0
+      fallback_interval: 0s
+storage:
+  dir: /tmp/nydus-dragonfly/cache-proxy-strict
+prefetch:
+  scope: none

--- a/misc/dragonfly/nydus-sdk-fallback.yaml
+++ b/misc/dragonfly/nydus-sdk-fallback.yaml
@@ -1,0 +1,21 @@
+backend:
+  type: registry
+  config:
+    # The throwaway local registry that CI seeds with a freshly converted
+    # nydus image (see .github/workflows/e2e-dragonfly.yml).
+    addr: http://127.0.0.1:5000
+    repository: nydus-e2e/dragonfly
+    http:
+      timeout: 5s
+      max_retries: 1
+      tls:
+        skip_verify: true
+    dragonfly:
+      scheduler_endpoint: http://127.0.0.1:8002
+      ondemand_max_retries: 3
+      prefetch_max_retries: 10
+      fallback_interval: 1s
+storage:
+  dir: /tmp/nydus-dragonfly/cache-fallback
+prefetch:
+  scope: none

--- a/misc/dragonfly/nydus-sdk-strict.yaml
+++ b/misc/dragonfly/nydus-sdk-strict.yaml
@@ -1,0 +1,23 @@
+backend:
+  type: registry
+  config:
+    # The origin is the in-test injectable proxy (fronting the local
+    # registry): Dragonfly back-to-source works while the proxy is healthy,
+    # and the test injects hard failures to assert that reads fail once
+    # Dragonfly is down and origin fallback cannot succeed.
+    addr: http://127.0.0.1:18080
+    repository: nydus-e2e/dragonfly
+    http:
+      timeout: 5s
+      max_retries: 0
+      tls:
+        skip_verify: true
+    dragonfly:
+      scheduler_endpoint: http://127.0.0.1:8002
+      ondemand_max_retries: 1
+      prefetch_max_retries: 1
+      fallback_interval: 0s
+storage:
+  dir: /tmp/nydus-dragonfly/cache-strict
+prefetch:
+  scope: none

--- a/misc/dragonfly/scheduler.yaml
+++ b/misc/dragonfly/scheduler.yaml
@@ -1,0 +1,28 @@
+server:
+  port: 8002
+  logDir: /tmp/dragonfly/logs/scheduler
+  cacheDir: /tmp/dragonfly/cache/scheduler
+  logLevel: info
+
+scheduler:
+  algorithm: default
+  retryBackToSourceLimit: 3
+  retryLimit: 5
+  retryInterval: 2s
+
+database:
+  redis:
+    addrs:
+      - 127.0.0.1:6379
+    brokerDB: 1
+    backendDB: 2
+
+manager:
+  addr: 127.0.0.1:65003
+  schedulerClusterID: 1
+  keepAlive:
+    interval: 5s
+
+seedPeer: {}
+
+console: true

--- a/nydus-backend/src/lib.rs
+++ b/nydus-backend/src/lib.rs
@@ -5,7 +5,9 @@
 //! service edges; this crate must not depend on the control-plane error
 //! type. Backend-private errors (registry auth, Dragonfly classification) are
 //! matched for retry decisions internally and fold into `io::Error` at the
-//! trait boundary.
+//! trait boundary. The one deliberately typed escape hatch is the
+//! backend-throttled marker ([`throttled_error`] / [`is_backend_throttled`]),
+//! which lets the storage layer reschedule throttled prefetches.
 
 mod local;
 
@@ -69,6 +71,53 @@ impl ReadContext {
     }
 }
 
+/// Marker error wrapped in an [`io::Error`] when the backend throttled a read
+/// (a prefetch rejected by a Dragonfly proxy `429` under the load-shedding
+/// policy), so the storage layer can distinguish "throttled — reschedule
+/// later" from an ordinary failure via [`is_backend_throttled`].
+#[derive(Debug)]
+struct BackendThrottled {
+    message: String,
+}
+
+impl std::fmt::Display for BackendThrottled {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "backend throttled the read: {}", self.message)
+    }
+}
+
+impl std::error::Error for BackendThrottled {}
+
+/// Build the [`io::Error`] denoting a backend-throttled read. Public so tests
+/// in dependent crates can fabricate throttled failures.
+pub fn throttled_error(message: impl Into<String>) -> io::Error {
+    io::Error::other(BackendThrottled {
+        message: message.into(),
+    })
+}
+
+/// Whether an error denotes a read the backend throttled (Dragonfly `429`).
+pub fn is_backend_throttled(err: &io::Error) -> bool {
+    err.get_ref()
+        .is_some_and(|inner| inner.is::<BackendThrottled>())
+}
+
+thread_local! {
+    /// Set while a metered read is being served when part of it was diverted
+    /// to a different target than the backend's static one — e.g. a Dragonfly
+    /// read that fell back to the origin — so the read is attributed to the
+    /// side that actually served it. Reads run synchronously on the calling
+    /// thread, so a thread-local carries this without any cross-read leakage.
+    static READ_SERVED_BY: std::cell::Cell<Option<nydus_telemetry::metrics::BackendTarget>> =
+        const { std::cell::Cell::new(None) };
+}
+
+/// Attribute the in-flight metered read to `target` instead of the backend's
+/// static [`BlobBackend::backend_target`].
+pub(crate) fn note_read_served_by(target: nydus_telemetry::metrics::BackendTarget) {
+    READ_SERVED_BY.with(|cell| cell.set(Some(target)));
+}
+
 /// A blob backend resolves blob data and metadata by content digest.
 pub trait BlobBackend: Send + Sync {
     /// Which side serves this backend's reads, used to attribute read and CRC
@@ -122,9 +171,13 @@ impl MeteredBackend {
         read: impl FnOnce() -> io::Result<T>,
     ) -> io::Result<T> {
         let start = std::time::Instant::now();
+        READ_SERVED_BY.with(|cell| cell.set(None));
         let result = read();
+        let target = READ_SERVED_BY
+            .with(|cell| cell.take())
+            .unwrap_or_else(|| self.inner.backend_target());
         nydus_telemetry::metrics::record_backend_read(
-            self.inner.backend_target(),
+            target,
             context.kind,
             bytes,
             start.elapsed(),
@@ -197,6 +250,14 @@ mod tests {
         let config: BackendConfig =
             serde_yaml::from_str("type: local\nconfig:\n  dir: /blobs\n").unwrap();
         assert!(build_backend(&config).is_ok());
+    }
+
+    #[test]
+    fn throttled_marker_survives_io_error_round_trip() {
+        let err = throttled_error("proxy answered 429");
+        assert!(is_backend_throttled(&err));
+        assert!(err.to_string().contains("429"));
+        assert!(!is_backend_throttled(&io::Error::other("ordinary failure")));
     }
 
     #[cfg(feature = "backend-registry")]

--- a/nydus-backend/src/lib.rs
+++ b/nydus-backend/src/lib.rs
@@ -107,15 +107,26 @@ thread_local! {
     /// to a different target than the backend's static one — e.g. a Dragonfly
     /// read that fell back to the origin — so the read is attributed to the
     /// side that actually served it. Reads run synchronously on the calling
-    /// thread, so a thread-local carries this without any cross-read leakage.
+    /// thread and the cell is reset when the next read starts, so it always
+    /// describes the most recent read; it deliberately outlives the read
+    /// itself so post-read validation (decode + CRC) can attribute failures
+    /// to the side that served the bytes via [`last_read_served_by`].
     static READ_SERVED_BY: std::cell::Cell<Option<nydus_telemetry::metrics::BackendTarget>> =
         const { std::cell::Cell::new(None) };
 }
 
 /// Attribute the in-flight metered read to `target` instead of the backend's
 /// static [`BlobBackend::backend_target`].
+#[cfg_attr(not(feature = "backend-registry"), allow(dead_code))]
 pub(crate) fn note_read_served_by(target: nydus_telemetry::metrics::BackendTarget) {
     READ_SERVED_BY.with(|cell| cell.set(Some(target)));
+}
+
+/// The side that actually served the most recent metered read on this thread,
+/// when it diverged from the backend's static target. Valid until the next
+/// read starts on this thread.
+pub fn last_read_served_by() -> Option<nydus_telemetry::metrics::BackendTarget> {
+    READ_SERVED_BY.with(|cell| cell.get())
 }
 
 /// A blob backend resolves blob data and metadata by content digest.
@@ -173,8 +184,10 @@ impl MeteredBackend {
         let start = std::time::Instant::now();
         READ_SERVED_BY.with(|cell| cell.set(None));
         let result = read();
+        // Peek rather than take: the override must survive until the caller's
+        // decode + CRC validation of these bytes (see `last_read_served_by`).
         let target = READ_SERVED_BY
-            .with(|cell| cell.take())
+            .with(|cell| cell.get())
             .unwrap_or_else(|| self.inner.backend_target());
         nydus_telemetry::metrics::record_backend_read(
             target,
@@ -258,6 +271,60 @@ mod tests {
         assert!(is_backend_throttled(&err));
         assert!(err.to_string().contains("429"));
         assert!(!is_backend_throttled(&io::Error::other("ordinary failure")));
+    }
+
+    /// A backend that optionally diverts each read's attribution to `serve_as`.
+    struct DivertingBackend {
+        serve_as: Option<nydus_telemetry::metrics::BackendTarget>,
+    }
+
+    impl BlobBackend for DivertingBackend {
+        fn backend_target(&self) -> nydus_telemetry::metrics::BackendTarget {
+            nydus_telemetry::metrics::BackendTarget::Proxy
+        }
+
+        fn blob_metadata(&self, _blob_id: &[u8; SHA256_DIGEST_SIZE]) -> io::Result<BlobMetadata> {
+            Err(io::Error::other("unused"))
+        }
+
+        fn read_range_into(
+            &self,
+            _blob_id: &[u8; SHA256_DIGEST_SIZE],
+            _offset: u64,
+            dst: &mut [u8],
+            _context: ReadContext,
+        ) -> io::Result<()> {
+            if let Some(target) = self.serve_as {
+                note_read_served_by(target);
+            }
+            dst.fill(0);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn served_by_override_survives_until_the_next_read() {
+        use nydus_telemetry::metrics::BackendTarget;
+
+        let mut dst = [0u8; 4];
+        let context = ReadContext::raw(ReadKind::OnDemand);
+
+        // A diverted read leaves its target visible after the read returns,
+        // so decode + CRC validation can attribute failures to it.
+        let diverted = metered(Arc::new(DivertingBackend {
+            serve_as: Some(BackendTarget::Origin),
+        }));
+        diverted
+            .read_range_into(&[0u8; SHA256_DIGEST_SIZE], 0, &mut dst, context)
+            .unwrap();
+        assert_eq!(last_read_served_by(), Some(BackendTarget::Origin));
+
+        // The next read resets the override.
+        let undiverted = metered(Arc::new(DivertingBackend { serve_as: None }));
+        undiverted
+            .read_range_into(&[0u8; SHA256_DIGEST_SIZE], 0, &mut dst, context)
+            .unwrap();
+        assert_eq!(last_read_served_by(), None);
     }
 
     #[cfg(feature = "backend-registry")]

--- a/nydus-backend/src/registry/dragonfly.rs
+++ b/nydus-backend/src/registry/dragonfly.rs
@@ -4,7 +4,10 @@
 //! endpoint, returning a streaming response. This bypasses plain HTTP and lets
 //! Dragonfly schedule P2P piece distribution directly; it is selected for blob
 //! `GET`s when a scheduler endpoint is configured, while every other request
-//! goes directly to the origin.
+//! goes directly to the origin. SDK errors are classified into the
+//! load-shedding policy's failure classes here; retries are owned by the
+//! policy loop in the parent module, so the SDK's internal retries are
+//! disabled to keep the policy's attempt counts exact.
 
 use std::time::Duration;
 
@@ -16,7 +19,9 @@ use dragonfly_client_request::{Body, Builder, GetRequest, Proxy, Request as _};
 
 use nydus_config::DragonflyConfig;
 
-use super::{runtime, RegistryError, Response};
+use super::{
+    runtime, DragonflyError, DragonflyFailure, DragonflyTransport, Response, RetryableCause,
+};
 use crate::ReadKind;
 
 /// The fallback request timeout when the configured timeout is `0` (disabled):
@@ -55,21 +60,16 @@ pub(crate) struct Dragonfly {
 impl Dragonfly {
     /// Create a new Dragonfly transport connected to the configured scheduler.
     /// `timeout` is the configured per-request timeout, `0s` (disabled)
-    /// falling back to [`DEFAULT_TIMEOUT`]; `max_retries` is the maximum
-    /// number of retry attempts the SDK performs per request.
-    pub(crate) fn new(
-        config: &DragonflyConfig,
-        timeout: Duration,
-        max_retries: u32,
-    ) -> std::io::Result<Dragonfly> {
+    /// falling back to [`DEFAULT_TIMEOUT`]. The SDK's internal retries are
+    /// disabled (`max_retries(0)`): the load-shedding policy in the parent
+    /// module owns retry counts, so they stay exact and observable.
+    pub(crate) fn new(config: &DragonflyConfig, timeout: Duration) -> std::io::Result<Dragonfly> {
         let endpoint = config.scheduler_endpoint.clone();
-        // The SDK builder takes a `u8` retry count; saturate larger values.
-        let max_retries = u8::try_from(max_retries).unwrap_or(u8::MAX);
         let client = runtime()
             .block_on(async move {
                 Builder::default()
                     .scheduler_endpoint(endpoint)
-                    .max_retries(max_retries)
+                    .max_retries(0)
                     .build()
                     .await
             })
@@ -84,15 +84,44 @@ impl Dragonfly {
         };
         Ok(Dragonfly { client, timeout })
     }
+}
 
+/// Classify an SDK error into the load-shedding policy's failure classes:
+/// a proxy `429` is `RateLimited`, a proxy `403` is `Forbidden`, and
+/// everything else is `Retryable` tagged with its cause — request timeout,
+/// dfdaemon connectivity, a proxy/backend `5xx`, or any other transport
+/// error.
+fn classify(err: &Error) -> DragonflyFailure {
+    match err {
+        Error::RequestTimeout(_) => DragonflyFailure::Retryable(RetryableCause::Timeout),
+        Error::DfdaemonError(_) => DragonflyFailure::Retryable(RetryableCause::Connect),
+        Error::ProxyError(proxy) => match proxy.status_code {
+            Some(StatusCode::TOO_MANY_REQUESTS) => DragonflyFailure::RateLimited,
+            Some(StatusCode::FORBIDDEN) => DragonflyFailure::Forbidden,
+            Some(code) if code.is_server_error() => {
+                DragonflyFailure::Retryable(RetryableCause::ServerError)
+            }
+            _ => DragonflyFailure::Retryable(RetryableCause::Other),
+        },
+        Error::BackendError(backend) => match backend.status_code {
+            Some(code) if code.is_server_error() => {
+                DragonflyFailure::Retryable(RetryableCause::ServerError)
+            }
+            _ => DragonflyFailure::Retryable(RetryableCause::Other),
+        },
+        _ => DragonflyFailure::Retryable(RetryableCause::Other),
+    }
+}
+
+impl DragonflyTransport for Dragonfly {
     /// Issue a blob `GET` through Dragonfly, attaching the priority and P2P
     /// hints derived from the read kind.
-    pub(crate) fn get(
+    fn get(
         &self,
         url: &str,
         mut headers: HeaderMap,
         kind: ReadKind,
-    ) -> Result<Response, RegistryError> {
+    ) -> Result<Response, DragonflyError> {
         let priority = priority(kind);
         if let Ok(value) = priority.to_string().parse() {
             headers.insert(HEADER_PRIORITY, value);
@@ -120,18 +149,71 @@ impl Dragonfly {
                     None => Box::new(tokio::io::empty()),
                 },
             }),
-            Err(Error::ProxyError(err)) => match err.status_code {
-                Some(StatusCode::TOO_MANY_REQUESTS) => {
-                    Err(RegistryError::TooManyRequests(format!("{err}")))
-                }
-                Some(StatusCode::FORBIDDEN) => Err(RegistryError::Forbidden(format!("{err}"))),
-                _ => Err(RegistryError::Io(std::io::Error::other(format!(
-                    "dragonfly error: {err}"
-                )))),
-            },
-            Err(err) => Err(RegistryError::Io(std::io::Error::other(format!(
-                "dragonfly error: {err}"
-            )))),
+            Err(err) => Err(DragonflyError {
+                failure: classify(&err),
+                message: err.to_string(),
+            }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dragonfly_client_request::errors::{BackendError, DfdaemonError, ProxyError};
+    use std::collections::HashMap;
+
+    fn proxy_error(status_code: Option<StatusCode>) -> Error {
+        Error::ProxyError(ProxyError {
+            message: Some("proxy".to_string()),
+            header: HashMap::new(),
+            status_code,
+        })
+    }
+
+    #[test]
+    fn classifies_sdk_errors() {
+        assert_eq!(
+            classify(&proxy_error(Some(StatusCode::TOO_MANY_REQUESTS))),
+            DragonflyFailure::RateLimited
+        );
+        assert_eq!(
+            classify(&proxy_error(Some(StatusCode::FORBIDDEN))),
+            DragonflyFailure::Forbidden
+        );
+        assert_eq!(
+            classify(&proxy_error(Some(StatusCode::BAD_GATEWAY))),
+            DragonflyFailure::Retryable(RetryableCause::ServerError)
+        );
+        assert_eq!(
+            classify(&proxy_error(Some(StatusCode::NOT_FOUND))),
+            DragonflyFailure::Retryable(RetryableCause::Other)
+        );
+        assert_eq!(
+            classify(&proxy_error(None)),
+            DragonflyFailure::Retryable(RetryableCause::Other)
+        );
+        assert_eq!(
+            classify(&Error::RequestTimeout("deadline exceeded".to_string())),
+            DragonflyFailure::Retryable(RetryableCause::Timeout)
+        );
+        assert_eq!(
+            classify(&Error::DfdaemonError(DfdaemonError {
+                message: Some("connection refused".to_string()),
+            })),
+            DragonflyFailure::Retryable(RetryableCause::Connect)
+        );
+        assert_eq!(
+            classify(&Error::BackendError(BackendError {
+                message: Some("origin 503".to_string()),
+                header: HashMap::new(),
+                status_code: Some(StatusCode::SERVICE_UNAVAILABLE),
+            })),
+            DragonflyFailure::Retryable(RetryableCause::ServerError)
+        );
+        assert_eq!(
+            classify(&Error::Internal("boom".to_string())),
+            DragonflyFailure::Retryable(RetryableCause::Other)
+        );
     }
 }

--- a/nydus-backend/src/registry/dragonfly.rs
+++ b/nydus-backend/src/registry/dragonfly.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::StatusCode;
 
-use dragonfly_client_request::errors::Error;
+use dragonfly_client_request::errors::{BackendError, Error, ProxyError};
 use dragonfly_client_request::{Body, Builder, GetRequest, Proxy, Request as _};
 
 use nydus_config::DragonflyConfig;
@@ -87,7 +87,7 @@ impl Dragonfly {
 }
 
 /// Classify an SDK error into the load-shedding policy's failure classes:
-/// a proxy `429` is `RateLimited`, a proxy `403` is `Forbidden`, and
+/// a proxy or backend `429` is `RateLimited`, a `403` is `Forbidden`, and
 /// everything else is `Retryable` tagged with its cause — request timeout,
 /// dfdaemon connectivity, a proxy/backend `5xx`, or any other transport
 /// error.
@@ -95,15 +95,10 @@ fn classify(err: &Error) -> DragonflyFailure {
     match err {
         Error::RequestTimeout(_) => DragonflyFailure::Retryable(RetryableCause::Timeout),
         Error::DfdaemonError(_) => DragonflyFailure::Retryable(RetryableCause::Connect),
-        Error::ProxyError(proxy) => match proxy.status_code {
+        Error::ProxyError(ProxyError { status_code, .. })
+        | Error::BackendError(BackendError { status_code, .. }) => match status_code {
             Some(StatusCode::TOO_MANY_REQUESTS) => DragonflyFailure::RateLimited,
             Some(StatusCode::FORBIDDEN) => DragonflyFailure::Forbidden,
-            Some(code) if code.is_server_error() => {
-                DragonflyFailure::Retryable(RetryableCause::ServerError)
-            }
-            _ => DragonflyFailure::Retryable(RetryableCause::Other),
-        },
-        Error::BackendError(backend) => match backend.status_code {
             Some(code) if code.is_server_error() => {
                 DragonflyFailure::Retryable(RetryableCause::ServerError)
             }

--- a/nydus-backend/src/registry/http.rs
+++ b/nydus-backend/src/registry/http.rs
@@ -18,6 +18,11 @@ use super::dns::SystemResolver;
 pub(crate) struct HTTP {
     /// The configured async HTTP client, wrapped with the retry middleware.
     client: ClientWithMiddleware,
+    /// The same client without the retry middleware, for callers that pace
+    /// their own retries (the Dragonfly fallback path).
+    raw_client: Client,
+    /// The configured retry budget ([`max_retries`](HttpConfig::max_retries)).
+    max_retries: u32,
 }
 
 impl HTTP {
@@ -74,14 +79,30 @@ impl HTTP {
             .map_err(|err| io::Error::other(format!("failed to build http client: {err}")))?;
 
         let retry_policy = ExponentialBackoff::builder().build_with_max_retries(config.max_retries);
+        let raw_client = client.clone();
         let client = ClientBuilder::new(client)
             .with(RetryTransientMiddleware::new_with_policy(retry_policy))
             .build();
-        Ok(HTTP { client })
+        Ok(HTTP {
+            client,
+            raw_client,
+            max_retries: config.max_retries,
+        })
     }
 
     /// The underlying async HTTP client.
     pub(crate) fn client(&self) -> &ClientWithMiddleware {
         &self.client
+    }
+
+    /// The async HTTP client without the retry middleware: one call issues
+    /// exactly one request attempt.
+    pub(crate) fn raw_client(&self) -> &Client {
+        &self.raw_client
+    }
+
+    /// The configured retry budget ([`max_retries`](HttpConfig::max_retries)).
+    pub(crate) fn max_retries(&self) -> u32 {
+        self.max_retries
     }
 }

--- a/nydus-backend/src/registry/mod.rs
+++ b/nydus-backend/src/registry/mod.rs
@@ -1513,6 +1513,36 @@ dragonfly:
     }
 
     #[test]
+    fn registry_error_to_io_error_preserves_dragonfly_messages() {
+        let too_many_requests: io::Error =
+            RegistryError::TooManyRequests("proxy answered 429".to_string()).into();
+        assert!(
+            too_many_requests.to_string().contains("too many requests"),
+            "unexpected error: {too_many_requests}"
+        );
+        assert!(
+            too_many_requests.to_string().contains("429"),
+            "unexpected error: {too_many_requests}"
+        );
+
+        let forbidden: io::Error =
+            RegistryError::Forbidden("proxy answered 403".to_string()).into();
+        assert!(
+            forbidden.to_string().contains("forbidden"),
+            "unexpected error: {forbidden}"
+        );
+        assert!(
+            forbidden.to_string().contains("403"),
+            "unexpected error: {forbidden}"
+        );
+
+        let inner = io::Error::new(io::ErrorKind::TimedOut, "timed out");
+        let passthrough: io::Error = RegistryError::Io(inner).into();
+        assert_eq!(passthrough.kind(), io::ErrorKind::TimedOut);
+        assert!(passthrough.to_string().contains("timed out"));
+    }
+
+    #[test]
     fn fallback_limiter_spaces_permits_by_the_interval() {
         let interval = Duration::from_millis(40);
         let limiter = FallbackLimiter::new(interval);

--- a/nydus-backend/src/registry/mod.rs
+++ b/nydus-backend/src/registry/mod.rs
@@ -120,6 +120,8 @@ enum RetryableCause {
     Connect,
     /// The proxy or the backend behind it answered HTTP 5xx.
     ServerError,
+    /// The response body failed mid-stream after a successful start.
+    Stream,
     /// Any other SDK transport error.
     Other,
 }
@@ -130,6 +132,7 @@ impl RetryableCause {
             RetryableCause::Timeout => "timeout",
             RetryableCause::Connect => "connect",
             RetryableCause::ServerError => "server_error",
+            RetryableCause::Stream => "stream",
             RetryableCause::Other => "other",
         }
     }
@@ -169,6 +172,7 @@ impl DragonflyFailure {
             DragonflyFailure::Retryable(RetryableCause::ServerError) => {
                 DragonflyErrorClass::ServerError
             }
+            DragonflyFailure::Retryable(RetryableCause::Stream) => DragonflyErrorClass::Stream,
             DragonflyFailure::Retryable(RetryableCause::Other) => DragonflyErrorClass::Other,
         }
     }
@@ -395,6 +399,28 @@ impl Response {
             let mut body = String::new();
             self.reader.read_to_string(&mut body).await?;
             Ok(body)
+        })
+    }
+
+    /// Drain the streaming body into memory, returning an equivalent response
+    /// backed by the buffered bytes. Pre-sizes the buffer from
+    /// `content-length` when present.
+    fn buffered(mut self) -> io::Result<Response> {
+        let capacity = self
+            .headers
+            .get(CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(0);
+        let body = runtime().block_on(async {
+            let mut body = Vec::with_capacity(capacity);
+            self.reader.read_to_end(&mut body).await?;
+            io::Result::Ok(body)
+        })?;
+        Ok(Response {
+            status: self.status,
+            headers: self.headers,
+            reader: Box::new(std::io::Cursor::new(body)),
         })
     }
 }
@@ -852,7 +878,12 @@ impl Registry {
     }
 
     /// Send a single blob `GET` attempt through the Dragonfly transport and
-    /// log its completion.
+    /// log its completion. The body is drained into memory here, before the
+    /// attempt counts as a success: the caller consumes the response only
+    /// after the policy loop has returned, so a mid-stream dfdaemon/backend
+    /// failure surfaced later would bypass the Dragonfly error metrics,
+    /// retries, and fallback entirely. Buffering also means no bytes are ever
+    /// exposed from an attempt that is later retried.
     fn request_dragonfly(
         &self,
         dragonfly: &dyn DragonflyTransport,
@@ -861,7 +892,14 @@ impl Registry {
         context: ReadContext,
     ) -> Result<Response, DragonflyError> {
         let start = Instant::now();
-        let result = dragonfly.get(url, headers.clone(), context.kind);
+        let result = dragonfly
+            .get(url, headers.clone(), context.kind)
+            .and_then(|response| {
+                response.buffered().map_err(|err| DragonflyError {
+                    failure: DragonflyFailure::Retryable(RetryableCause::Stream),
+                    message: format!("response body failed mid-stream: {err}"),
+                })
+            });
         let duration = start.elapsed();
 
         match result {
@@ -1426,6 +1464,7 @@ dragonfly:
             RetryableCause::Timeout,
             RetryableCause::Connect,
             RetryableCause::ServerError,
+            RetryableCause::Stream,
             RetryableCause::Other,
         ] {
             assert_eq!(
@@ -1721,6 +1760,74 @@ dragonfly:
         }
     }
 
+    /// A body that serves `data` and then fails instead of reaching EOF.
+    struct MidStreamFailingBody {
+        data: Vec<u8>,
+        pos: usize,
+    }
+
+    impl AsyncRead for MidStreamFailingBody {
+        fn poll_read(
+            mut self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<io::Result<()>> {
+            if self.pos < self.data.len() {
+                let n = buf.remaining().min(self.data.len() - self.pos);
+                let pos = self.pos;
+                buf.put_slice(&self.data[pos..pos + n]);
+                self.pos = pos + n;
+                std::task::Poll::Ready(Ok(()))
+            } else {
+                std::task::Poll::Ready(Err(io::Error::other("connection reset mid-stream")))
+            }
+        }
+    }
+
+    /// A transport handing out pre-built responses in order, counting calls.
+    struct SequencedTransport {
+        responses: Mutex<std::collections::VecDeque<Response>>,
+        calls: Arc<std::sync::atomic::AtomicU32>,
+    }
+
+    impl SequencedTransport {
+        fn new(
+            responses: impl IntoIterator<Item = Response>,
+        ) -> (SequencedTransport, Arc<std::sync::atomic::AtomicU32>) {
+            let calls = Arc::new(std::sync::atomic::AtomicU32::new(0));
+            let transport = SequencedTransport {
+                responses: Mutex::new(responses.into_iter().collect()),
+                calls: calls.clone(),
+            };
+            (transport, calls)
+        }
+    }
+
+    impl DragonflyTransport for SequencedTransport {
+        fn get(
+            &self,
+            _url: &str,
+            _headers: HeaderMap,
+            _kind: ReadKind,
+        ) -> Result<Response, DragonflyError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self
+                .responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("transport called more times than scripted"))
+        }
+    }
+
+    fn ok_response(reader: Box<dyn AsyncRead + Send + Unpin>) -> Response {
+        Response {
+            status: StatusCode::OK,
+            headers: HeaderMap::new(),
+            reader,
+        }
+    }
+
     const TEST_BLOB_ID: [u8; SHA256_DIGEST_SIZE] = [7u8; SHA256_DIGEST_SIZE];
 
     fn retryable() -> DragonflyFailure {
@@ -1786,6 +1893,12 @@ dragonfly:
             nydus_telemetry::metrics::backend_read_total(
                 nydus_telemetry::metrics::BackendTarget::Origin,
             ) > origin_before
+        );
+        // The override outlives the read so a subsequent CRC validation of
+        // these bytes is attributed to the origin as well.
+        assert_eq!(
+            crate::last_read_served_by(),
+            Some(nydus_telemetry::metrics::BackendTarget::Origin)
         );
     }
 
@@ -2037,6 +2150,85 @@ dragonfly:
         );
         assert_eq!(transport.calls(), 1);
         assert_eq!(origin.hits(), 2);
+    }
+
+    #[test]
+    fn mid_stream_body_failure_is_retried_by_the_policy() {
+        let body = b"whole body".to_vec();
+        let origin = OriginStub::serve(b"unused".to_vec());
+        // Attempt 1 starts streaming and dies mid-body; the policy must see
+        // it as a retryable failure and retry, never touching the origin.
+        let (transport, calls) = SequencedTransport::new(vec![
+            ok_response(Box::new(MidStreamFailingBody {
+                data: body[..4].to_vec(),
+                pos: 0,
+            })),
+            ok_response(Box::new(std::io::Cursor::new(body.clone()))),
+        ]);
+        let mut registry = scripted_registry(
+            &origin,
+            Arc::new(ScriptedTransport::new(vec![])),
+            Duration::ZERO,
+        );
+        registry.dragonfly = Some(Box::new(transport));
+
+        let stream_errors_before = nydus_telemetry::metrics::dragonfly_error_total(
+            nydus_telemetry::metrics::DragonflyErrorClass::Stream,
+            ReadKind::OnDemand,
+        );
+        let mut dst = vec![0u8; body.len()];
+        registry
+            .try_read(
+                &TEST_BLOB_ID,
+                0,
+                &mut dst,
+                ReadContext::raw(ReadKind::OnDemand),
+            )
+            .unwrap();
+
+        assert_eq!(dst, body);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(origin.hits(), 0);
+        assert!(
+            nydus_telemetry::metrics::dragonfly_error_total(
+                nydus_telemetry::metrics::DragonflyErrorClass::Stream,
+                ReadKind::OnDemand,
+            ) > stream_errors_before
+        );
+    }
+
+    #[test]
+    fn mid_stream_body_failure_exhausts_the_budget_then_falls_back() {
+        let body = b"0123456789".to_vec();
+        let origin = OriginStub::serve(body.clone());
+        // Every Dragonfly attempt dies mid-body; the on-demand budget
+        // (1 + 3 retries) drains, then the read falls back to the origin.
+        let (transport, calls) = SequencedTransport::new((0..4).map(|_| {
+            ok_response(Box::new(MidStreamFailingBody {
+                data: b"par".to_vec(),
+                pos: 0,
+            }))
+        }));
+        let mut registry = scripted_registry(
+            &origin,
+            Arc::new(ScriptedTransport::new(vec![])),
+            Duration::ZERO,
+        );
+        registry.dragonfly = Some(Box::new(transport));
+
+        let mut dst = vec![0u8; body.len()];
+        registry
+            .try_read(
+                &TEST_BLOB_ID,
+                0,
+                &mut dst,
+                ReadContext::raw(ReadKind::OnDemand),
+            )
+            .unwrap();
+
+        assert_eq!(dst, body);
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
+        assert_eq!(origin.hits(), 1);
     }
 
     #[test]

--- a/nydus-backend/src/registry/mod.rs
+++ b/nydus-backend/src/registry/mod.rs
@@ -11,7 +11,9 @@
 //!
 //! The HTTP transport helpers (connection building, DNS, the Dragonfly SDK
 //! client) live in this module's submodules; this file holds only the
-//! registry-specific logic.
+//! registry-specific logic, including the Dragonfly load-shedding policy that
+//! decides per read kind whether a failed Dragonfly read is retried, failed,
+//! or falls back to the origin through a throttle (see [`dragonfly_action`]).
 
 mod dns;
 #[cfg(feature = "backend-dragonfly-proxy")]
@@ -21,7 +23,7 @@ mod http;
 use std::collections::HashMap;
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, LazyLock, RwLock};
+use std::sync::{Arc, LazyLock, Mutex, RwLock};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use arc_swap::ArcSwapOption;
@@ -38,7 +40,7 @@ use tracing::debug;
 use url::Url;
 
 use crate::{BlobBackend, ReadContext, ReadKind};
-use nydus_config::RegistryConfig;
+use nydus_config::{DragonflyConfig, RegistryConfig};
 use nydus_format::blob::{BlobFooter, BlobMetadata, NYDUS_BLOB_FOOTER_SIZE};
 use nydus_format::utils::{hex_string, SHA256_DIGEST_SIZE};
 
@@ -86,12 +88,10 @@ enum RegistryError {
     UnexpectedStatus(StatusCode, String),
 
     /// The request was denied by Dragonfly (`403`).
-    #[cfg_attr(not(feature = "backend-dragonfly-proxy"), allow(dead_code))]
     #[error("forbidden: {0}")]
     Forbidden(String),
 
     /// The request was rate-limited by Dragonfly (`429`).
-    #[cfg_attr(not(feature = "backend-dragonfly-proxy"), allow(dead_code))]
     #[error("too many requests: {0}")]
     TooManyRequests(String),
 }
@@ -106,6 +106,264 @@ impl From<RegistryError> for io::Error {
 }
 
 type RegistryResult<T> = Result<T, RegistryError>;
+
+/// The underlying cause of a [`DragonflyFailure::Retryable`] failure. Carried
+/// for logging and metrics attribution only; the load-shedding policy treats
+/// every cause identically. Only the SDK transport (feature-gated) and tests
+/// construct these.
+#[cfg_attr(not(feature = "backend-dragonfly-proxy"), allow(dead_code))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RetryableCause {
+    /// The request timed out.
+    Timeout,
+    /// The local dfdaemon could not be reached.
+    Connect,
+    /// The proxy or the backend behind it answered HTTP 5xx.
+    ServerError,
+    /// Any other SDK transport error.
+    Other,
+}
+
+impl RetryableCause {
+    fn as_str(self) -> &'static str {
+        match self {
+            RetryableCause::Timeout => "timeout",
+            RetryableCause::Connect => "connect",
+            RetryableCause::ServerError => "server_error",
+            RetryableCause::Other => "other",
+        }
+    }
+}
+
+/// Classification of a failed Dragonfly read, driving the load-shedding
+/// policy in [`dragonfly_action`]. Only the SDK transport (feature-gated) and
+/// tests construct these.
+#[cfg_attr(not(feature = "backend-dragonfly-proxy"), allow(dead_code))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DragonflyFailure {
+    /// The Dragonfly proxy answered HTTP 429.
+    RateLimited,
+    /// The Dragonfly proxy answered HTTP 403.
+    Forbidden,
+    /// A transient failure the policy may retry.
+    Retryable(RetryableCause),
+}
+
+impl DragonflyFailure {
+    fn as_str(self) -> &'static str {
+        match self {
+            DragonflyFailure::RateLimited => "rate_limited",
+            DragonflyFailure::Forbidden => "forbidden",
+            DragonflyFailure::Retryable(cause) => cause.as_str(),
+        }
+    }
+
+    /// The metrics label class of this failure.
+    fn metrics_class(self) -> nydus_telemetry::metrics::DragonflyErrorClass {
+        use nydus_telemetry::metrics::DragonflyErrorClass;
+        match self {
+            DragonflyFailure::RateLimited => DragonflyErrorClass::RateLimited,
+            DragonflyFailure::Forbidden => DragonflyErrorClass::Forbidden,
+            DragonflyFailure::Retryable(RetryableCause::Timeout) => DragonflyErrorClass::Timeout,
+            DragonflyFailure::Retryable(RetryableCause::Connect) => DragonflyErrorClass::Connect,
+            DragonflyFailure::Retryable(RetryableCause::ServerError) => {
+                DragonflyErrorClass::ServerError
+            }
+            DragonflyFailure::Retryable(RetryableCause::Other) => DragonflyErrorClass::Other,
+        }
+    }
+}
+
+/// A classified error from the Dragonfly transport.
+#[derive(Debug)]
+struct DragonflyError {
+    failure: DragonflyFailure,
+    message: String,
+}
+
+impl std::fmt::Display for DragonflyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "dragonfly {}: {}", self.failure.as_str(), self.message)
+    }
+}
+
+impl DragonflyError {
+    /// Fold a policy-terminal Dragonfly failure into the error the caller
+    /// sees. A rate-limited prefetch carries the [`crate::throttled_error`]
+    /// marker so the storage layer can distinguish "throttled — reschedule
+    /// later" from an ordinary failure.
+    fn into_registry_error(self, kind: ReadKind) -> RegistryError {
+        match self.failure {
+            DragonflyFailure::RateLimited => match kind {
+                ReadKind::Prefetch => RegistryError::Io(crate::throttled_error(self.message)),
+                ReadKind::OnDemand => RegistryError::TooManyRequests(self.message),
+            },
+            DragonflyFailure::Forbidden => RegistryError::Forbidden(self.message),
+            DragonflyFailure::Retryable(cause) => RegistryError::Io(io::Error::other(format!(
+                "dragonfly {}: {}",
+                cause.as_str(),
+                self.message
+            ))),
+        }
+    }
+}
+
+/// The transport seam for Dragonfly reads: the SDK client in production,
+/// scripted fakes in tests. Unconditional (not feature-gated) so the policy
+/// loop and its tests compile without the `backend-dragonfly-proxy` feature.
+trait DragonflyTransport: Send + Sync {
+    /// Issue a blob `GET` through Dragonfly.
+    fn get(
+        &self,
+        url: &str,
+        headers: HeaderMap,
+        kind: ReadKind,
+    ) -> Result<Response, DragonflyError>;
+}
+
+/// Per-read-kind Dragonfly retry budgets, from the `registry.dragonfly`
+/// configuration.
+#[derive(Debug, Clone, Copy)]
+struct DragonflyPolicy {
+    /// Retries for a retryable prefetch failure before the read fails.
+    prefetch_max_retries: u32,
+    /// Retries for a retryable on-demand failure before falling back.
+    ondemand_max_retries: u32,
+}
+
+impl Default for DragonflyPolicy {
+    fn default() -> Self {
+        Self {
+            prefetch_max_retries: 10,
+            ondemand_max_retries: 3,
+        }
+    }
+}
+
+impl DragonflyPolicy {
+    /// The per-read-kind budgets from the `registry.dragonfly` configuration,
+    /// or the defaults when no Dragonfly section is configured.
+    fn from_config(config: Option<&DragonflyConfig>) -> Self {
+        config
+            .map(|dragonfly_config| DragonflyPolicy {
+                prefetch_max_retries: dragonfly_config.prefetch_max_retries,
+                ondemand_max_retries: dragonfly_config.ondemand_max_retries,
+            })
+            .unwrap_or_default()
+    }
+}
+
+/// The `[min, max]` window for the random delay before a Dragonfly prefetch
+/// retry. Prefetch retries are paced with this jitter so a burst of failing
+/// prefetch reads does not hammer a struggling Dragonfly proxy in lockstep;
+/// latency-sensitive on-demand retries are never delayed.
+const PREFETCH_RETRY_DELAY_MIN: Duration = Duration::from_millis(100);
+const PREFETCH_RETRY_DELAY_MAX: Duration = Duration::from_secs(1);
+
+/// A random delay inside the prefetch retry window, seeded from OS entropy
+/// via `RandomState` so no `rand` dependency is needed (same technique as the
+/// prefetch rescheduler in `nydus-storage`).
+fn prefetch_retry_delay() -> Duration {
+    use std::hash::{BuildHasher, Hasher};
+    let seed = std::collections::hash_map::RandomState::new()
+        .build_hasher()
+        .finish();
+    let span = PREFETCH_RETRY_DELAY_MAX - PREFETCH_RETRY_DELAY_MIN;
+    // The 900ms span is far below `u64::MAX` nanoseconds, so the cast is safe.
+    let span_nanos = span.as_nanos() as u64;
+    PREFETCH_RETRY_DELAY_MIN + Duration::from_nanos(seed % (span_nanos + 1))
+}
+
+/// What the load-shedding policy decides after one failed Dragonfly attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DragonflyAction {
+    /// Retry the read through Dragonfly.
+    Retry,
+    /// Give up on Dragonfly and fall back to the throttled origin path.
+    Fallback,
+    /// Fail the read without touching the origin.
+    Fail,
+}
+
+/// Decide what to do after a failed Dragonfly attempt. `attempts` counts the
+/// Dragonfly attempts made so far, including the one that just failed.
+///
+/// The policy: `Forbidden` (403) is terminal for both read kinds. A
+/// rate-limited (429) prefetch fails immediately — the caller reschedules it —
+/// while a rate-limited on-demand read falls back to the origin without
+/// retrying Dragonfly. Retryable failures (timeout, connect, 5xx, other) are
+/// retried up to the read kind's budget; when the budget is exhausted a
+/// prefetch fails and an on-demand read falls back. Prefetch reads never fall
+/// back, so a Dragonfly outage degrades prefetch instead of flooding the
+/// origin.
+fn dragonfly_action(
+    policy: DragonflyPolicy,
+    kind: ReadKind,
+    failure: DragonflyFailure,
+    attempts: u32,
+) -> DragonflyAction {
+    match failure {
+        DragonflyFailure::Forbidden => DragonflyAction::Fail,
+        DragonflyFailure::RateLimited => match kind {
+            ReadKind::Prefetch => DragonflyAction::Fail,
+            ReadKind::OnDemand => DragonflyAction::Fallback,
+        },
+        DragonflyFailure::Retryable(_) => {
+            let budget = match kind {
+                ReadKind::Prefetch => policy.prefetch_max_retries,
+                ReadKind::OnDemand => policy.ondemand_max_retries,
+            };
+            if attempts <= budget {
+                DragonflyAction::Retry
+            } else {
+                match kind {
+                    ReadKind::Prefetch => DragonflyAction::Fail,
+                    ReadKind::OnDemand => DragonflyAction::Fallback,
+                }
+            }
+        }
+    }
+}
+
+/// Shapes origin requests issued as Dragonfly fallbacks to one request per
+/// interval (1 QPS by default), per registry backend. Slots are handed out
+/// FIFO under a mutex; the wait happens outside the lock so a sleeping waiter
+/// never blocks the next caller from claiming its own later slot.
+struct FallbackLimiter {
+    /// The minimum spacing between two fallback requests; zero disables the
+    /// throttle.
+    interval: Duration,
+    /// The earliest instant the next fallback request may start.
+    next_slot: Mutex<Instant>,
+}
+
+impl FallbackLimiter {
+    fn new(interval: Duration) -> Self {
+        Self {
+            interval,
+            next_slot: Mutex::new(Instant::now()),
+        }
+    }
+
+    /// Block until this caller's slot arrives, returning how long it waited.
+    fn acquire(&self) -> Duration {
+        if self.interval.is_zero() {
+            return Duration::ZERO;
+        }
+        let now = Instant::now();
+        let slot = {
+            let mut next = self.next_slot.lock().unwrap();
+            let slot = (*next).max(now);
+            *next = slot + self.interval;
+            slot
+        };
+        let wait = slot.saturating_duration_since(now);
+        if !wait.is_zero() {
+            std::thread::sleep(wait);
+        }
+        wait
+    }
+}
 
 /// A response from the origin registry or the Dragonfly SDK: the status and
 /// headers up front, plus a streaming body.
@@ -229,9 +487,15 @@ pub(crate) struct Registry {
     redirect_urls: RwLock<HashMap<String, String>>,
     /// Direct HTTP transport to the origin registry.
     http: HTTP,
-    /// Routes blob `GET`s through the Dragonfly SDK when configured.
-    #[cfg(feature = "backend-dragonfly-proxy")]
-    dragonfly: Option<Dragonfly>,
+    /// Routes blob `GET`s through the Dragonfly SDK when configured. Always
+    /// `None` when the `backend-dragonfly-proxy` feature is off (the config
+    /// is rejected); kept unconditional so the policy loop and its tests
+    /// compile without the feature.
+    dragonfly: Option<Box<dyn DragonflyTransport>>,
+    /// Per-read-kind retry budgets of the Dragonfly load-shedding policy.
+    dragonfly_policy: DragonflyPolicy,
+    /// Shapes origin requests issued as Dragonfly fallbacks.
+    fallback_limiter: FallbackLimiter,
     /// Whether reads are served through the Dragonfly SDK, used to attribute
     /// backend read and CRC metrics.
     target: nydus_telemetry::metrics::BackendTarget,
@@ -248,34 +512,42 @@ impl Registry {
         let http = HTTP::new(&config.http)?;
 
         #[cfg(feature = "backend-dragonfly-proxy")]
-        let dragonfly = match &config.dragonfly {
-            Some(dragonfly_config) => Some(Dragonfly::new(
+        let dragonfly: Option<Box<dyn DragonflyTransport>> = match &config.dragonfly {
+            Some(dragonfly_config) => Some(Box::new(Dragonfly::new(
                 dragonfly_config,
                 config.http.timeout,
-                config.http.max_retries,
-            )?),
+            )?)),
             None => None,
         };
         #[cfg(not(feature = "backend-dragonfly-proxy"))]
-        if let Some(dragonfly_config) = &config.dragonfly {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!(
-                    "dragonfly.scheduler_endpoint is set ({}) but this build lacks \
-                     the `backend-dragonfly-proxy` feature",
-                    dragonfly_config.scheduler_endpoint
-                ),
-            ));
-        }
+        let dragonfly: Option<Box<dyn DragonflyTransport>> = match &config.dragonfly {
+            Some(dragonfly_config) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "dragonfly.scheduler_endpoint is set ({}) but this build lacks \
+                         the `backend-dragonfly-proxy` feature",
+                        dragonfly_config.scheduler_endpoint
+                    ),
+                ))
+            }
+            None => None,
+        };
 
-        #[cfg(feature = "backend-dragonfly-proxy")]
+        let dragonfly_policy = DragonflyPolicy::from_config(config.dragonfly.as_ref());
+        let fallback_limiter = FallbackLimiter::new(
+            config
+                .dragonfly
+                .as_ref()
+                .map(|dragonfly_config| dragonfly_config.fallback_interval)
+                .unwrap_or(Duration::ZERO),
+        );
+
         let target = if dragonfly.is_some() {
             nydus_telemetry::metrics::BackendTarget::Proxy
         } else {
             nydus_telemetry::metrics::BackendTarget::Origin
         };
-        #[cfg(not(feature = "backend-dragonfly-proxy"))]
-        let target = nydus_telemetry::metrics::BackendTarget::Origin;
 
         Ok(Registry {
             scheme,
@@ -289,8 +561,9 @@ impl Registry {
             token_expires_at: ArcSwapOption::from(None),
             redirect_urls: RwLock::new(HashMap::new()),
             http,
-            #[cfg(feature = "backend-dragonfly-proxy")]
             dragonfly,
+            dragonfly_policy,
+            fallback_limiter,
             target,
             first_read_done: AtomicBool::new(false),
         })
@@ -362,12 +635,13 @@ impl Registry {
     }
 
     /// Issue a request. Blob `GET`s ride the Dragonfly SDK when it is
-    /// configured, falling back to the origin when Dragonfly still fails
-    /// after its internal retries; everything else — and requests with
-    /// `allow_dragonfly` false (auth token fetches) — goes directly to the
-    /// origin. Each transport retries transient failures itself: the HTTP
-    /// client's retry middleware for the origin, the SDK for Dragonfly.
-    #[cfg_attr(not(feature = "backend-dragonfly-proxy"), allow(unused_variables))]
+    /// configured, driven by the load-shedding policy (see
+    /// [`dragonfly_action`]): retryable failures are retried up to the read
+    /// kind's budget, on-demand reads then fall back to the origin through
+    /// the fallback throttle, and prefetch reads fail without touching the
+    /// origin. Everything else — and requests with `allow_dragonfly` false
+    /// (auth token fetches) — goes directly to the origin, where the HTTP
+    /// client's retry middleware retries transient failures.
     fn request(
         &self,
         method: Method,
@@ -376,24 +650,112 @@ impl Registry {
         context: ReadContext,
         allow_dragonfly: bool,
     ) -> RegistryResult<Response> {
-        #[cfg(feature = "backend-dragonfly-proxy")]
         if allow_dragonfly && method == Method::GET {
             if let Some(dragonfly) = &self.dragonfly {
-                match self.request_dragonfly(dragonfly, url, headers.clone(), context) {
-                    Ok(response) => return Ok(response),
-                    Err(err) => {
-                        tracing::warn!(
-                            "dragonfly request failed, falling back to the origin: {err}"
-                        );
-                    }
-                }
+                return self.request_via_dragonfly(dragonfly.as_ref(), url, headers, context);
             }
         }
 
         self.request_http(method, url, headers, context)
     }
 
-    /// Send a request directly to the origin and log its completion.
+    /// Drive a blob `GET` through Dragonfly under the load-shedding policy,
+    /// retrying, failing, or falling back to the throttled origin path as
+    /// [`dragonfly_action`] dictates. Prefetch retries wait a random
+    /// [`PREFETCH_RETRY_DELAY_MIN`]–[`PREFETCH_RETRY_DELAY_MAX`] delay first;
+    /// on-demand retries go immediately. Every failed attempt is recorded to
+    /// the per-class Dragonfly error metrics.
+    fn request_via_dragonfly(
+        &self,
+        dragonfly: &dyn DragonflyTransport,
+        url: &str,
+        headers: HeaderMap,
+        context: ReadContext,
+    ) -> RegistryResult<Response> {
+        let mut attempts = 0u32;
+        let err = loop {
+            attempts += 1;
+            let err = match self.request_dragonfly(dragonfly, url, headers.clone(), context) {
+                Ok(response) => return Ok(response),
+                Err(err) => err,
+            };
+            nydus_telemetry::metrics::record_dragonfly_error(
+                err.failure.metrics_class(),
+                context.kind,
+            );
+
+            match dragonfly_action(self.dragonfly_policy, context.kind, err.failure, attempts) {
+                DragonflyAction::Retry => {
+                    tracing::warn!(
+                        "dragonfly request failed (attempt {attempts}), retrying: {err}"
+                    );
+                    if context.kind == ReadKind::Prefetch {
+                        std::thread::sleep(prefetch_retry_delay());
+                    }
+                }
+                DragonflyAction::Fallback => {
+                    tracing::warn!(
+                        "dragonfly request failed after {attempts} attempt(s), \
+                         falling back to the origin: {err}"
+                    );
+                    return self.fallback_request_http(Method::GET, url, headers, context);
+                }
+                DragonflyAction::Fail => break err,
+            }
+        };
+
+        tracing::warn!("dragonfly request failed terminally after {attempts} attempt(s): {err}");
+        Err(err.into_registry_error(context.kind))
+    }
+
+    /// Issue an origin request as a Dragonfly fallback. Retries are not left
+    /// to the HTTP client's retry middleware — its backoff would run under a
+    /// single fallback-throttle permit — but performed explicitly here: each
+    /// origin attempt (the first plus up to `http.max_retries` retries of
+    /// transient failures) waits for its own fallback-throttle slot, so actual
+    /// origin requests never exceed one per `fallback_interval`.
+    fn fallback_request_http(
+        &self,
+        method: Method,
+        url: &str,
+        headers: HeaderMap,
+        context: ReadContext,
+    ) -> RegistryResult<Response> {
+        // The origin serves (or terminally fails) this read now, so attribute
+        // it to the origin side of the proxy/origin split.
+        crate::note_read_served_by(nydus_telemetry::metrics::BackendTarget::Origin);
+
+        let mut attempts = 0u32;
+        let result = loop {
+            attempts += 1;
+            let waited = self.fallback_limiter.acquire();
+            nydus_telemetry::metrics::record_fallback_throttle_wait(waited);
+
+            let result = self.request_http_once(method.clone(), url, headers.clone(), context);
+            // Mirror the retry middleware's transient classification: retry
+            // transport errors and retryable statuses, pass everything else on.
+            let transient = match &result {
+                Ok(response) => {
+                    response.status.is_server_error()
+                        || response.status == StatusCode::REQUEST_TIMEOUT
+                        || response.status == StatusCode::TOO_MANY_REQUESTS
+                }
+                Err(_) => true,
+            };
+            if !transient || attempts > self.http.max_retries() {
+                break result;
+            }
+            tracing::warn!(
+                "fallback origin request failed transiently (attempt {attempts}), \
+                 retrying through the fallback throttle"
+            );
+        };
+        nydus_telemetry::metrics::record_fallback_read(result.is_err());
+        result
+    }
+
+    /// Send a request directly to the origin through the retrying client and
+    /// log its completion.
     fn request_http(
         &self,
         method: Method,
@@ -409,7 +771,43 @@ impl Registry {
                 .headers(headers.clone())
                 .send()
                 .await
+                .map_err(io::Error::other)
         });
+        self.finish_http_request(method, url, headers, context, start, result)
+    }
+
+    /// Send exactly one request attempt to the origin (no retry middleware)
+    /// and log its completion.
+    fn request_http_once(
+        &self,
+        method: Method,
+        url: &str,
+        headers: HeaderMap,
+        context: ReadContext,
+    ) -> RegistryResult<Response> {
+        let start = Instant::now();
+        let result = runtime().block_on(async {
+            self.http
+                .raw_client()
+                .request(method.clone(), url)
+                .headers(headers.clone())
+                .send()
+                .await
+                .map_err(io::Error::other)
+        });
+        self.finish_http_request(method, url, headers, context, start, result)
+    }
+
+    /// Log a completed origin request and wrap its outcome.
+    fn finish_http_request(
+        &self,
+        method: Method,
+        url: &str,
+        headers: HeaderMap,
+        context: ReadContext,
+        start: Instant,
+        result: Result<reqwest::Response, io::Error>,
+    ) -> RegistryResult<Response> {
         let duration = start.elapsed();
 
         match result {
@@ -448,20 +846,20 @@ impl Registry {
                     Some(&message),
                     duration,
                 );
-                Err(RegistryError::Io(io::Error::other(err)))
+                Err(RegistryError::Io(err))
             }
         }
     }
 
-    /// Send a blob `GET` through the Dragonfly SDK and log its completion.
-    #[cfg(feature = "backend-dragonfly-proxy")]
+    /// Send a single blob `GET` attempt through the Dragonfly transport and
+    /// log its completion.
     fn request_dragonfly(
         &self,
-        dragonfly: &Dragonfly,
+        dragonfly: &dyn DragonflyTransport,
         url: &str,
         headers: HeaderMap,
         context: ReadContext,
-    ) -> RegistryResult<Response> {
+    ) -> Result<Response, DragonflyError> {
         let start = Instant::now();
         let result = dragonfly.get(url, headers.clone(), context.kind);
         let duration = start.elapsed();
@@ -499,9 +897,10 @@ impl Registry {
         }
     }
 
-    /// Fill `dst` with the blob byte range. Transient failures are retried
-    /// inside each transport: the HTTP client's retry middleware for direct
-    /// reads, the SDK's internal retries for Dragonfly reads.
+    /// Fill `dst` with the blob byte range. Direct origin reads retry
+    /// transient failures inside the HTTP client's retry middleware;
+    /// Dragonfly reads are governed by the load-shedding policy in
+    /// [`Registry::request_via_dragonfly`].
     fn try_read(
         &self,
         blob_id: &[u8; SHA256_DIGEST_SIZE],
@@ -517,15 +916,24 @@ impl Registry {
         if let Some(redirect) = self.redirect_url(&hex) {
             let mut headers = HeaderMap::new();
             headers.insert(RANGE, range.parse().unwrap());
-            let response = self.request(Method::GET, &redirect, headers, context, true)?;
-            let status = response.status;
-            if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
-                // The signed link expired; drop it and fall through to re-resolve.
-                self.remove_redirect_url(&hex);
-            } else if status.is_success() {
-                return fill_exact(response, dst);
-            } else {
-                return Err(status_error(response));
+            match self.request(Method::GET, &redirect, headers, context, true) {
+                Ok(response) => {
+                    let status = response.status;
+                    if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
+                        // The signed link expired; drop it and fall through to re-resolve.
+                        self.remove_redirect_url(&hex);
+                    } else if status.is_success() {
+                        return fill_exact(response, dst);
+                    } else {
+                        return Err(status_error(response));
+                    }
+                }
+                // Dragonfly reports an expired signed link as a terminal 403
+                // error rather than a 403 response. The failure stays terminal
+                // for this attempt, but the stale URL must not be retried
+                // forever: drop it and fall through to re-resolve.
+                Err(RegistryError::Forbidden(_)) => self.remove_redirect_url(&hex),
+                Err(err) => return Err(err),
             }
         }
 
@@ -968,5 +1376,756 @@ dragonfly:
         // Token expires "now", within the refresh margin, so it is cleared.
         assert_eq!(registry.current_auth(), "");
         assert!(registry.cached_auth.read().unwrap().is_empty());
+    }
+
+    #[test]
+    fn policy_matrix_matches_the_load_shedding_table() {
+        use DragonflyAction::*;
+        use DragonflyFailure::*;
+        use ReadKind::*;
+
+        let policy = DragonflyPolicy::default();
+        let retryable = Retryable(RetryableCause::Timeout);
+
+        // (kind, failure, attempts) -> action, one row per cell of the table.
+        let cases = [
+            // Proxy 429: prefetch fails at once, ondemand falls back at once.
+            (Prefetch, RateLimited, 1, Fail),
+            (OnDemand, RateLimited, 1, Fallback),
+            // Proxy 403: terminal for both kinds.
+            (Prefetch, Forbidden, 1, Fail),
+            (OnDemand, Forbidden, 1, Fail),
+            // Retryable (timeout / connect / 5xx): prefetch retries ten
+            // times — 11 attempts total — then fails without fallback.
+            (Prefetch, retryable, 1, Retry),
+            (Prefetch, retryable, 10, Retry),
+            (Prefetch, retryable, 11, Fail),
+            // Ondemand retries three times — 4 attempts total — then falls back.
+            (OnDemand, retryable, 1, Retry),
+            (OnDemand, retryable, 2, Retry),
+            (OnDemand, retryable, 3, Retry),
+            (OnDemand, retryable, 4, Fallback),
+            // The failure class, not the attempt count, decides for 429/403:
+            // a class switch deep into a retryable budget is still terminal
+            // (or an immediate fallback) at that attempt.
+            (Prefetch, RateLimited, 2, Fail),
+            (OnDemand, RateLimited, 4, Fallback),
+            (Prefetch, Forbidden, 2, Fail),
+            (OnDemand, Forbidden, 4, Fail),
+        ];
+        for (kind, failure, attempts, want) in cases {
+            assert_eq!(
+                dragonfly_action(policy, kind, failure, attempts),
+                want,
+                "kind={kind:?} failure={failure:?} attempts={attempts}"
+            );
+        }
+
+        // Every retryable cause maps to the same decisions.
+        for cause in [
+            RetryableCause::Timeout,
+            RetryableCause::Connect,
+            RetryableCause::ServerError,
+            RetryableCause::Other,
+        ] {
+            assert_eq!(
+                dragonfly_action(policy, Prefetch, Retryable(cause), 11),
+                Fail
+            );
+            assert_eq!(
+                dragonfly_action(policy, OnDemand, Retryable(cause), 4),
+                Fallback
+            );
+        }
+    }
+
+    #[test]
+    fn prefetch_retry_delay_stays_inside_the_window() {
+        for _ in 0..64 {
+            let delay = prefetch_retry_delay();
+            assert!(
+                (PREFETCH_RETRY_DELAY_MIN..=PREFETCH_RETRY_DELAY_MAX).contains(&delay),
+                "delay {delay:?} outside the window"
+            );
+        }
+    }
+
+    #[test]
+    fn custom_retry_budgets_are_honored() {
+        use DragonflyAction::*;
+        use DragonflyFailure::*;
+        use ReadKind::*;
+
+        let policy = DragonflyPolicy {
+            prefetch_max_retries: 0,
+            ondemand_max_retries: 5,
+        };
+        let retryable = Retryable(RetryableCause::Timeout);
+
+        // A zero prefetch budget makes the first retryable failure terminal.
+        assert_eq!(dragonfly_action(policy, Prefetch, retryable, 1), Fail);
+
+        // Ondemand retries through the enlarged budget, then falls back.
+        for attempts in 1..=5 {
+            assert_eq!(
+                dragonfly_action(policy, OnDemand, retryable, attempts),
+                Retry,
+                "attempts={attempts}"
+            );
+        }
+        assert_eq!(dragonfly_action(policy, OnDemand, retryable, 6), Fallback);
+    }
+
+    #[test]
+    fn policy_budgets_come_from_the_dragonfly_config() {
+        let dragonfly: DragonflyConfig = serde_yaml::from_str(
+            "scheduler_endpoint: http://127.0.0.1:65000\n\
+             ondemand_max_retries: 5\n\
+             prefetch_max_retries: 0\n",
+        )
+        .unwrap();
+        let policy = DragonflyPolicy::from_config(Some(&dragonfly));
+        assert_eq!(policy.prefetch_max_retries, 0);
+        assert_eq!(policy.ondemand_max_retries, 5);
+
+        // No dragonfly section: the documented defaults.
+        let defaults = DragonflyPolicy::from_config(None);
+        assert_eq!(defaults.prefetch_max_retries, 10);
+        assert_eq!(defaults.ondemand_max_retries, 3);
+    }
+
+    #[test]
+    fn terminal_rate_limited_prefetch_carries_the_throttled_marker() {
+        let err = DragonflyError {
+            failure: DragonflyFailure::RateLimited,
+            message: "proxy answered 429".to_string(),
+        };
+        let io_err: io::Error = err.into_registry_error(ReadKind::Prefetch).into();
+        assert!(crate::is_backend_throttled(&io_err));
+
+        let err = DragonflyError {
+            failure: DragonflyFailure::Forbidden,
+            message: "denied".to_string(),
+        };
+        let io_err: io::Error = err.into_registry_error(ReadKind::Prefetch).into();
+        assert!(!crate::is_backend_throttled(&io_err));
+        assert!(io_err.to_string().contains("forbidden"));
+    }
+
+    #[test]
+    fn fallback_limiter_spaces_permits_by_the_interval() {
+        let interval = Duration::from_millis(40);
+        let limiter = FallbackLimiter::new(interval);
+
+        // Idle limiter grants (nearly) immediately.
+        let start = Instant::now();
+        limiter.acquire();
+        assert!(start.elapsed() < interval);
+
+        // Consecutive permits are spaced at least an interval apart.
+        limiter.acquire();
+        assert!(start.elapsed() >= interval);
+
+        // A zero interval disables the throttle.
+        let unthrottled = FallbackLimiter::new(Duration::ZERO);
+        let start = Instant::now();
+        for _ in 0..3 {
+            assert_eq!(unthrottled.acquire(), Duration::ZERO);
+        }
+        assert!(start.elapsed() < Duration::from_millis(20));
+    }
+
+    /// A scripted Dragonfly transport: pops one scripted outcome per `get`,
+    /// counting the calls. `Ok(body)` produces a `200` response serving the
+    /// bytes; `Err(failure)` produces a classified error.
+    struct ScriptedTransport {
+        script: Mutex<std::collections::VecDeque<Result<Vec<u8>, DragonflyFailure>>>,
+        calls: std::sync::atomic::AtomicU32,
+    }
+
+    impl ScriptedTransport {
+        fn new(
+            script: impl IntoIterator<Item = Result<Vec<u8>, DragonflyFailure>>,
+        ) -> ScriptedTransport {
+            ScriptedTransport {
+                script: Mutex::new(script.into_iter().collect()),
+                calls: std::sync::atomic::AtomicU32::new(0),
+            }
+        }
+
+        fn calls(&self) -> u32 {
+            self.calls.load(Ordering::SeqCst)
+        }
+    }
+
+    impl DragonflyTransport for ScriptedTransport {
+        fn get(
+            &self,
+            _url: &str,
+            _headers: HeaderMap,
+            _kind: ReadKind,
+        ) -> Result<Response, DragonflyError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let outcome = self
+                .script
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("transport called more times than scripted");
+            match outcome {
+                Ok(body) => Ok(Response {
+                    status: StatusCode::OK,
+                    headers: HeaderMap::new(),
+                    reader: Box::new(std::io::Cursor::new(body)),
+                }),
+                Err(failure) => Err(DragonflyError {
+                    failure,
+                    message: "scripted failure".to_string(),
+                }),
+            }
+        }
+    }
+
+    /// A minimal origin stub on a loopback listener: serves every request with
+    /// `status` and `body`, counting the requests served.
+    struct OriginStub {
+        addr: std::net::SocketAddr,
+        hits: Arc<std::sync::atomic::AtomicU32>,
+    }
+
+    impl OriginStub {
+        fn serve(body: Vec<u8>) -> OriginStub {
+            OriginStub::serve_with_status("206 Partial Content", body)
+        }
+
+        fn serve_with_status(status: &'static str, body: Vec<u8>) -> OriginStub {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+            let hits = Arc::new(std::sync::atomic::AtomicU32::new(0));
+            let hits_in_thread = hits.clone();
+            std::thread::spawn(move || {
+                for stream in listener.incoming() {
+                    let Ok(mut stream) = stream else { break };
+                    let body = body.clone();
+                    let hits = hits_in_thread.clone();
+                    std::thread::spawn(move || {
+                        use std::io::{Read, Write};
+                        // Read until the end of the request headers.
+                        let mut buf = Vec::new();
+                        let mut byte = [0u8; 1];
+                        while !buf.ends_with(b"\r\n\r\n") {
+                            match stream.read(&mut byte) {
+                                Ok(1) => buf.push(byte[0]),
+                                _ => return,
+                            }
+                        }
+                        hits.fetch_add(1, Ordering::SeqCst);
+                        let response = format!(
+                            "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                            body.len()
+                        );
+                        let _ = stream.write_all(response.as_bytes());
+                        let _ = stream.write_all(&body);
+                    });
+                }
+            });
+            OriginStub { addr, hits }
+        }
+
+        fn hits(&self) -> u32 {
+            self.hits.load(Ordering::SeqCst)
+        }
+    }
+
+    /// A loopback address with nothing listening behind it: bound to claim a
+    /// free port, then dropped so connections to it are refused.
+    fn dead_addr() -> std::net::SocketAddr {
+        std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+    }
+
+    /// A registry wired to the origin stub, with a scripted Dragonfly
+    /// transport and a configurable fallback throttle.
+    fn scripted_registry(
+        origin: &OriginStub,
+        transport: Arc<ScriptedTransport>,
+        fallback_interval: Duration,
+    ) -> Registry {
+        scripted_registry_at(origin.addr, transport, fallback_interval, 3)
+    }
+
+    /// A registry pointed at `addr` as its origin with `origin_max_retries`
+    /// HTTP retries, a scripted Dragonfly transport, and a configurable
+    /// fallback throttle.
+    fn scripted_registry_at(
+        addr: std::net::SocketAddr,
+        transport: Arc<ScriptedTransport>,
+        fallback_interval: Duration,
+        origin_max_retries: u32,
+    ) -> Registry {
+        let config: RegistryConfig = serde_yaml::from_str(&format!(
+            "addr: http://{addr}\nrepository: library/ubuntu\nhttp:\n  max_retries: {origin_max_retries}\n",
+        ))
+        .unwrap();
+        let mut registry = Registry::new(config).unwrap();
+        registry.dragonfly = Some(Box::new(SharedTransport(transport)));
+        registry.fallback_limiter = FallbackLimiter::new(fallback_interval);
+        registry.target = nydus_telemetry::metrics::BackendTarget::Proxy;
+        registry
+    }
+
+    /// Lets a test keep a handle on its [`ScriptedTransport`] after boxing it
+    /// into the registry.
+    struct SharedTransport(Arc<ScriptedTransport>);
+
+    impl DragonflyTransport for SharedTransport {
+        fn get(
+            &self,
+            url: &str,
+            headers: HeaderMap,
+            kind: ReadKind,
+        ) -> Result<Response, DragonflyError> {
+            self.0.get(url, headers, kind)
+        }
+    }
+
+    const TEST_BLOB_ID: [u8; SHA256_DIGEST_SIZE] = [7u8; SHA256_DIGEST_SIZE];
+
+    fn retryable() -> DragonflyFailure {
+        DragonflyFailure::Retryable(RetryableCause::Connect)
+    }
+
+    #[test]
+    fn ondemand_read_retries_dragonfly_then_falls_back_to_origin() {
+        let body = b"0123456789".to_vec();
+        let origin = OriginStub::serve(body.clone());
+        // 4 Dragonfly attempts (1 + 3 retries) all fail retryably.
+        let transport = Arc::new(ScriptedTransport::new(vec![
+            Err(retryable()),
+            Err(retryable()),
+            Err(retryable()),
+            Err(retryable()),
+        ]));
+        let registry = scripted_registry(&origin, transport.clone(), Duration::ZERO);
+
+        let mut dst = vec![0u8; body.len()];
+        registry
+            .try_read(
+                &TEST_BLOB_ID,
+                0,
+                &mut dst,
+                ReadContext::raw(ReadKind::OnDemand),
+            )
+            .unwrap();
+
+        assert_eq!(dst, body);
+        assert_eq!(transport.calls(), 4);
+        assert_eq!(origin.hits(), 1);
+    }
+
+    #[test]
+    fn fallback_reads_are_attributed_to_the_origin() {
+        let body = b"0123456789".to_vec();
+        let origin = OriginStub::serve(body.clone());
+        let transport = Arc::new(ScriptedTransport::new(vec![Err(
+            DragonflyFailure::RateLimited,
+        )]));
+        let registry = scripted_registry(&origin, transport, Duration::ZERO);
+        let metered = crate::metered(Arc::new(registry));
+
+        let origin_before = nydus_telemetry::metrics::backend_read_total(
+            nydus_telemetry::metrics::BackendTarget::Origin,
+        );
+        let mut dst = vec![0u8; body.len()];
+        metered
+            .read_range_into(
+                &TEST_BLOB_ID,
+                0,
+                &mut dst,
+                ReadContext::raw(ReadKind::OnDemand),
+            )
+            .unwrap();
+
+        assert_eq!(dst, body);
+        assert_eq!(origin.hits(), 1);
+        // The origin served this read, so the proxy/origin split attributes
+        // it to the origin even though the registry's static target is Proxy.
+        assert!(
+            nydus_telemetry::metrics::backend_read_total(
+                nydus_telemetry::metrics::BackendTarget::Origin,
+            ) > origin_before
+        );
+    }
+
+    #[test]
+    fn prefetch_read_fails_without_origin_fallback() {
+        let origin = OriginStub::serve(b"unused".to_vec());
+        // A 1-retry budget keeps the test fast (the default is 10, each
+        // prefetch retry sleeps a 100ms–1s jitter): 2 Dragonfly attempts
+        // (1 + 1 retry), then the read must fail.
+        let transport = Arc::new(ScriptedTransport::new(vec![
+            Err(retryable()),
+            Err(retryable()),
+        ]));
+        let mut registry = scripted_registry(&origin, transport.clone(), Duration::ZERO);
+        registry.dragonfly_policy = DragonflyPolicy {
+            prefetch_max_retries: 1,
+            ..DragonflyPolicy::default()
+        };
+
+        let mut dst = vec![0u8; 4];
+        let err = registry
+            .try_read(
+                &TEST_BLOB_ID,
+                0,
+                &mut dst,
+                ReadContext::raw(ReadKind::Prefetch),
+            )
+            .unwrap_err();
+
+        assert!(err.to_string().contains("dragonfly"));
+        assert_eq!(transport.calls(), 2);
+        assert_eq!(origin.hits(), 0);
+    }
+
+    #[test]
+    fn rate_limited_prefetch_fails_at_once_with_the_throttled_marker() {
+        let origin = OriginStub::serve(b"unused".to_vec());
+        let transport = Arc::new(ScriptedTransport::new(vec![Err(
+            DragonflyFailure::RateLimited,
+        )]));
+        let registry = scripted_registry(&origin, transport.clone(), Duration::ZERO);
+
+        let mut dst = vec![0u8; 4];
+        let err: io::Error = registry
+            .try_read(
+                &TEST_BLOB_ID,
+                0,
+                &mut dst,
+                ReadContext::raw(ReadKind::Prefetch),
+            )
+            .unwrap_err()
+            .into();
+
+        assert!(crate::is_backend_throttled(&err));
+        assert_eq!(transport.calls(), 1);
+        assert_eq!(origin.hits(), 0);
+    }
+
+    #[test]
+    fn forbidden_is_terminal_for_ondemand_reads() {
+        let origin = OriginStub::serve(b"unused".to_vec());
+        let transport = Arc::new(ScriptedTransport::new(vec![Err(
+            DragonflyFailure::Forbidden,
+        )]));
+        let registry = scripted_registry(&origin, transport.clone(), Duration::ZERO);
+
+        let mut dst = vec![0u8; 4];
+        let err = registry
+            .try_read(
+                &TEST_BLOB_ID,
+                0,
+                &mut dst,
+                ReadContext::raw(ReadKind::OnDemand),
+            )
+            .unwrap_err();
+
+        assert!(matches!(err, RegistryError::Forbidden(_)));
+        assert_eq!(transport.calls(), 1);
+        assert_eq!(origin.hits(), 0);
+    }
+
+    #[test]
+    fn forbidden_is_terminal_for_prefetch_reads() {
+        let origin = OriginStub::serve(b"unused".to_vec());
+        let transport = Arc::new(ScriptedTransport::new(vec![Err(
+            DragonflyFailure::Forbidden,
+        )]));
+        let registry = scripted_registry(&origin, transport.clone(), Duration::ZERO);
+
+        let mut dst = vec![0u8; 4];
+        let err = registry
+            .try_read(
+                &TEST_BLOB_ID,
+                0,
+                &mut dst,
+                ReadContext::raw(ReadKind::Prefetch),
+            )
+            .unwrap_err();
+
+        assert!(matches!(err, RegistryError::Forbidden(_)));
+        assert_eq!(transport.calls(), 1);
+        assert_eq!(origin.hits(), 0);
+    }
+
+    #[test]
+    fn retryable_read_succeeds_on_a_dragonfly_retry() {
+        for kind in [ReadKind::OnDemand, ReadKind::Prefetch] {
+            let body = b"retried".to_vec();
+            let origin = OriginStub::serve(b"unused".to_vec());
+            // Attempt 1 fails retryably; the retry succeeds on Dragonfly, so
+            // the origin is never touched.
+            let transport = Arc::new(ScriptedTransport::new(vec![
+                Err(retryable()),
+                Ok(body.clone()),
+            ]));
+            let registry = scripted_registry(&origin, transport.clone(), Duration::ZERO);
+
+            let start = Instant::now();
+            let mut dst = vec![0u8; body.len()];
+            registry
+                .try_read(&TEST_BLOB_ID, 0, &mut dst, ReadContext::raw(kind))
+                .unwrap();
+            let elapsed = start.elapsed();
+
+            assert_eq!(dst, body, "kind={kind:?}");
+            assert_eq!(transport.calls(), 2, "kind={kind:?}");
+            assert_eq!(origin.hits(), 0, "kind={kind:?}");
+            // Only the prefetch retry is paced by the jitter window;
+            // on-demand retries go immediately.
+            match kind {
+                ReadKind::Prefetch => assert!(
+                    elapsed >= PREFETCH_RETRY_DELAY_MIN,
+                    "prefetch retry skipped the jitter delay: {elapsed:?}"
+                ),
+                ReadKind::OnDemand => assert!(
+                    elapsed < PREFETCH_RETRY_DELAY_MIN,
+                    "on-demand retry must not be delayed: {elapsed:?}"
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn rate_limit_after_a_retryable_failure_falls_back_at_once() {
+        let body = b"0123456789".to_vec();
+        let origin = OriginStub::serve(body.clone());
+        // Attempt 1 is retryable; attempt 2 answers 429, which falls back
+        // immediately instead of burning the remaining retryable budget.
+        let transport = Arc::new(ScriptedTransport::new(vec![
+            Err(retryable()),
+            Err(DragonflyFailure::RateLimited),
+        ]));
+        let registry = scripted_registry(&origin, transport.clone(), Duration::ZERO);
+
+        let mut dst = vec![0u8; body.len()];
+        registry
+            .try_read(
+                &TEST_BLOB_ID,
+                0,
+                &mut dst,
+                ReadContext::raw(ReadKind::OnDemand),
+            )
+            .unwrap();
+
+        assert_eq!(dst, body);
+        assert_eq!(transport.calls(), 2);
+        assert_eq!(origin.hits(), 1);
+    }
+
+    #[test]
+    fn rate_limit_after_a_retryable_prefetch_fails_with_the_throttled_marker() {
+        let origin = OriginStub::serve(b"unused".to_vec());
+        // Attempt 1 is retryable; the 429 on attempt 2 is terminal for
+        // prefetch and carries the throttled marker for the rescheduler.
+        let transport = Arc::new(ScriptedTransport::new(vec![
+            Err(retryable()),
+            Err(DragonflyFailure::RateLimited),
+        ]));
+        let registry = scripted_registry(&origin, transport.clone(), Duration::ZERO);
+
+        let mut dst = vec![0u8; 4];
+        let err: io::Error = registry
+            .try_read(
+                &TEST_BLOB_ID,
+                0,
+                &mut dst,
+                ReadContext::raw(ReadKind::Prefetch),
+            )
+            .unwrap_err()
+            .into();
+
+        assert!(crate::is_backend_throttled(&err));
+        assert_eq!(transport.calls(), 2);
+        assert_eq!(origin.hits(), 0);
+    }
+
+    #[test]
+    fn fallback_origin_failure_surfaces_as_an_io_error() {
+        // Nothing listens on the origin address, so the fallback's connect is
+        // refused; zero origin retries keep the failure immediate.
+        let transport = Arc::new(ScriptedTransport::new(vec![Err(
+            DragonflyFailure::RateLimited,
+        )]));
+        let registry = scripted_registry_at(dead_addr(), transport.clone(), Duration::ZERO, 0);
+
+        let errors_before = nydus_telemetry::metrics::backend_fallback_read_error_total();
+        let mut dst = vec![0u8; 4];
+        let err = registry
+            .try_read(
+                &TEST_BLOB_ID,
+                0,
+                &mut dst,
+                ReadContext::raw(ReadKind::OnDemand),
+            )
+            .unwrap_err();
+
+        assert!(matches!(err, RegistryError::Io(_)), "unexpected: {err:?}");
+        assert_eq!(transport.calls(), 1);
+        assert!(nydus_telemetry::metrics::backend_fallback_read_error_total() > errors_before);
+    }
+
+    #[test]
+    fn fallback_gives_the_origin_its_http_retry_budget() {
+        // The origin answers every fallback attempt with a retryable 500.
+        let origin = OriginStub::serve_with_status("500 Internal Server Error", b"boom".to_vec());
+        let transport = Arc::new(ScriptedTransport::new(vec![Err(
+            DragonflyFailure::RateLimited,
+        )]));
+        // `http.max_retries: 1` gives the origin two attempts before the
+        // fallback read fails.
+        let registry = scripted_registry_at(origin.addr, transport.clone(), Duration::ZERO, 1);
+
+        let mut dst = vec![0u8; 4];
+        let err = registry
+            .try_read(
+                &TEST_BLOB_ID,
+                0,
+                &mut dst,
+                ReadContext::raw(ReadKind::OnDemand),
+            )
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                RegistryError::UnexpectedStatus(StatusCode::INTERNAL_SERVER_ERROR, _)
+            ),
+            "unexpected: {err:?}"
+        );
+        assert_eq!(transport.calls(), 1);
+        assert_eq!(origin.hits(), 2);
+    }
+
+    #[test]
+    fn consecutive_fallbacks_are_throttled() {
+        let body = b"abcd".to_vec();
+        let origin = OriginStub::serve(body.clone());
+        // Two reads, each rate-limited once, each falling back to the origin.
+        let transport = Arc::new(ScriptedTransport::new(vec![
+            Err(DragonflyFailure::RateLimited),
+            Err(DragonflyFailure::RateLimited),
+        ]));
+        let interval = Duration::from_millis(80);
+        let registry = scripted_registry(&origin, transport.clone(), interval);
+
+        let start = Instant::now();
+        let mut dst = vec![0u8; body.len()];
+        for _ in 0..2 {
+            registry
+                .try_read(
+                    &TEST_BLOB_ID,
+                    0,
+                    &mut dst,
+                    ReadContext::raw(ReadKind::OnDemand),
+                )
+                .unwrap();
+            assert_eq!(dst, body);
+        }
+
+        assert_eq!(origin.hits(), 2);
+        // The second fallback had to wait for the next interval slot.
+        assert!(start.elapsed() >= interval);
+    }
+
+    #[test]
+    fn cached_redirect_reads_ride_dragonfly() {
+        let body = b"redirected".to_vec();
+        let origin = OriginStub::serve(b"unused".to_vec());
+        let transport = Arc::new(ScriptedTransport::new(vec![Ok(body.clone())]));
+        let registry = scripted_registry(&origin, transport.clone(), Duration::ZERO);
+        let hex = hex_string(&TEST_BLOB_ID);
+        registry.set_redirect_url(&hex, "http://cdn.example.com/signed".to_string());
+
+        let mut dst = vec![0u8; body.len()];
+        registry
+            .try_read(
+                &TEST_BLOB_ID,
+                0,
+                &mut dst,
+                ReadContext::raw(ReadKind::OnDemand),
+            )
+            .unwrap();
+
+        assert_eq!(dst, body);
+        assert_eq!(transport.calls(), 1);
+        assert_eq!(origin.hits(), 0);
+    }
+
+    #[test]
+    fn forbidden_cached_redirect_is_evicted_and_re_resolved() {
+        let body = b"fresh".to_vec();
+        let origin = OriginStub::serve(b"unused".to_vec());
+        // The cached signed URL fails with a Dragonfly 403 (expired link);
+        // the read evicts it and re-resolves through the blob URL, which
+        // succeeds on Dragonfly.
+        let transport = Arc::new(ScriptedTransport::new(vec![
+            Err(DragonflyFailure::Forbidden),
+            Ok(body.clone()),
+        ]));
+        let registry = scripted_registry(&origin, transport.clone(), Duration::ZERO);
+        let hex = hex_string(&TEST_BLOB_ID);
+        registry.set_redirect_url(&hex, "http://cdn.example.com/expired".to_string());
+
+        let mut dst = vec![0u8; body.len()];
+        registry
+            .try_read(
+                &TEST_BLOB_ID,
+                0,
+                &mut dst,
+                ReadContext::raw(ReadKind::OnDemand),
+            )
+            .unwrap();
+
+        assert_eq!(dst, body);
+        assert_eq!(transport.calls(), 2);
+        assert!(registry.redirect_url(&hex).is_none());
+    }
+
+    #[test]
+    fn fallback_retries_are_throttled_per_attempt() {
+        // Every fallback attempt answers a retryable 500, so the read burns
+        // its full origin budget (1 + 1 retry); each attempt must wait for
+        // its own throttle slot.
+        let origin = OriginStub::serve_with_status("500 Internal Server Error", b"boom".to_vec());
+        let transport = Arc::new(ScriptedTransport::new(vec![Err(
+            DragonflyFailure::RateLimited,
+        )]));
+        let interval = Duration::from_millis(80);
+        let registry = scripted_registry_at(origin.addr, transport.clone(), interval, 1);
+
+        let start = Instant::now();
+        let mut dst = vec![0u8; 4];
+        let err = registry
+            .try_read(
+                &TEST_BLOB_ID,
+                0,
+                &mut dst,
+                ReadContext::raw(ReadKind::OnDemand),
+            )
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                RegistryError::UnexpectedStatus(StatusCode::INTERNAL_SERVER_ERROR, _)
+            ),
+            "unexpected: {err:?}"
+        );
+        assert_eq!(origin.hits(), 2);
+        // The retry had to wait for the next interval slot.
+        assert!(start.elapsed() >= interval);
     }
 }

--- a/nydus-config/src/lib.rs
+++ b/nydus-config/src/lib.rs
@@ -71,6 +71,43 @@ pub fn default_prefetch_timeout() -> Duration {
     Duration::from_secs(60 * 60)
 }
 
+/// Returns the default lower bound of the delay before a blob prefetch that
+/// was throttled by the backend (Dragonfly `429`) is re-attempted.
+#[inline]
+pub fn default_prefetch_retry_delay_min() -> Duration {
+    Duration::from_secs(6 * 60 * 60)
+}
+
+/// Returns the default upper bound of the delay before a blob prefetch that
+/// was throttled by the backend (Dragonfly `429`) is re-attempted.
+#[inline]
+pub fn default_prefetch_retry_delay_max() -> Duration {
+    Duration::from_secs(12 * 60 * 60)
+}
+
+/// Returns the default number of Dragonfly retry attempts for a retryable
+/// (timeout / connection / 5xx) on-demand read failure before falling back
+/// to the origin registry.
+#[inline]
+fn default_dragonfly_ondemand_max_retries() -> u32 {
+    3
+}
+
+/// Returns the default number of Dragonfly retry attempts for a retryable
+/// (timeout / connection / 5xx) prefetch read failure before the read fails.
+#[inline]
+fn default_dragonfly_prefetch_max_retries() -> u32 {
+    10
+}
+
+/// Returns the default minimum interval between origin requests issued as
+/// Dragonfly fallbacks: one second, i.e. the fallback path is shaped to
+/// 1 QPS per process.
+#[inline]
+fn default_dragonfly_fallback_interval() -> Duration {
+    Duration::from_secs(1)
+}
+
 /// The local backend configuration, serving blobs from a directory.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -128,7 +165,8 @@ pub struct RegistryConfig {
     pub auth: Option<String>,
 
     /// The HTTP client configuration: timeouts, retries, and TLS trust. The
-    /// timeout and retry limits also apply to Dragonfly SDK requests.
+    /// timeout also applies to Dragonfly SDK requests; retry counts for
+    /// Dragonfly reads are governed by the `dragonfly` policy knobs instead.
     #[serde(default)]
     pub http: HttpConfig,
 
@@ -153,7 +191,9 @@ pub struct HttpConfig {
     pub timeout: Duration,
 
     /// The maximum number of retry attempts per request, applied by the HTTP
-    /// client's retry middleware and by the Dragonfly SDK.
+    /// client's retry middleware on direct origin requests — including origin
+    /// requests issued as Dragonfly fallbacks, so the default of 3 is what
+    /// bounds "origin failing 3 attempts" before a fallback read errors out.
     #[serde(default = "default_registry_http_max_retries")]
     pub max_retries: u32,
 
@@ -243,6 +283,29 @@ impl TlsConfig {
 pub struct DragonflyConfig {
     /// The Dragonfly scheduler endpoint (gRPC), e.g. `http://127.0.0.1:65000`.
     pub scheduler_endpoint: String,
+
+    /// The number of Dragonfly retry attempts for a retryable (timeout,
+    /// connection, or 5xx) on-demand read failure before the read falls back
+    /// to the origin registry.
+    #[serde(default = "default_dragonfly_ondemand_max_retries")]
+    pub ondemand_max_retries: u32,
+
+    /// The number of Dragonfly retry attempts for a retryable (timeout,
+    /// connection, or 5xx) prefetch read failure before the read fails.
+    /// Prefetch reads never fall back to the origin, so a Dragonfly outage
+    /// degrades prefetch instead of flooding the registry.
+    #[serde(default = "default_dragonfly_prefetch_max_retries")]
+    pub prefetch_max_retries: u32,
+
+    /// The minimum interval between origin requests issued as Dragonfly
+    /// fallbacks, e.g. `1s` (the default, i.e. 1 QPS per process). `0s`
+    /// disables the throttle. Only fallback reads are shaped; direct reads
+    /// and auth token fetches are never throttled.
+    #[serde(
+        default = "default_dragonfly_fallback_interval",
+        with = "humantime_serde"
+    )]
+    pub fallback_interval: Duration,
 }
 
 /// The storage configuration: where downloaded blob data is kept.
@@ -277,6 +340,17 @@ pub struct PrefetchConfig {
     /// (the default), or all blobs.
     #[serde(default)]
     pub scope: PrefetchScope,
+
+    /// The lower bound of the random delay before a blob prefetch that was
+    /// throttled by the backend (Dragonfly `429`) is re-attempted, e.g. `6h`.
+    #[serde(default = "default_prefetch_retry_delay_min", with = "humantime_serde")]
+    pub retry_delay_min: Duration,
+
+    /// The upper bound of the random delay before a blob prefetch that was
+    /// throttled by the backend (Dragonfly `429`) is re-attempted, e.g. `12h`.
+    /// Must not be smaller than `retry_delay_min`.
+    #[serde(default = "default_prefetch_retry_delay_max", with = "humantime_serde")]
+    pub retry_delay_max: Duration,
 }
 
 /// The scope of blob prefetch: which blobs it pulls.
@@ -305,6 +379,8 @@ impl Default for PrefetchConfig {
             concurrent_blob_count: default_prefetch_concurrent_blob_count(),
             timeout: default_prefetch_timeout(),
             scope: PrefetchScope::default(),
+            retry_delay_min: default_prefetch_retry_delay_min(),
+            retry_delay_max: default_prefetch_retry_delay_max(),
         }
     }
 }
@@ -361,6 +437,11 @@ impl Config {
         if self.prefetch.concurrent_blob_count == 0 {
             return Err(Error::InvalidConfig(
                 "prefetch.concurrent_blob_count must be at least 1".to_string(),
+            ));
+        }
+        if self.prefetch.retry_delay_min > self.prefetch.retry_delay_max {
+            return Err(Error::InvalidConfig(
+                "prefetch.retry_delay_min must not exceed prefetch.retry_delay_max".to_string(),
             ));
         }
         Ok(())
@@ -500,6 +581,35 @@ config:
     }
 
     #[test]
+    fn dragonfly_policy_knobs_default_and_deserialize() {
+        let defaults: DragonflyConfig =
+            serde_yaml::from_str("scheduler_endpoint: http://127.0.0.1:65000\n").unwrap();
+        assert_eq!(
+            defaults.ondemand_max_retries,
+            default_dragonfly_ondemand_max_retries()
+        );
+        assert_eq!(
+            defaults.prefetch_max_retries,
+            default_dragonfly_prefetch_max_retries()
+        );
+        assert_eq!(
+            defaults.fallback_interval,
+            default_dragonfly_fallback_interval()
+        );
+
+        let yaml = r#"
+scheduler_endpoint: http://127.0.0.1:65000
+ondemand_max_retries: 5
+prefetch_max_retries: 0
+fallback_interval: 250ms
+"#;
+        let dragonfly: DragonflyConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(dragonfly.ondemand_max_retries, 5);
+        assert_eq!(dragonfly.prefetch_max_retries, 0);
+        assert_eq!(dragonfly.fallback_interval, Duration::from_millis(250));
+    }
+
+    #[test]
     fn registry_backend_defaults() {
         let yaml = r#"
 type: registry
@@ -613,6 +723,36 @@ scope: all
         );
         assert_eq!(prefetch.timeout, default_prefetch_timeout());
         assert_eq!(prefetch.scope, PrefetchScope::Ondemand);
+        assert_eq!(prefetch.retry_delay_min, default_prefetch_retry_delay_min());
+        assert_eq!(prefetch.retry_delay_max, default_prefetch_retry_delay_max());
+    }
+
+    #[test]
+    fn prefetch_retry_delay_deserializes() {
+        let yaml = "retry_delay_min: 30s\nretry_delay_max: 2m\n";
+        let prefetch: PrefetchConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(prefetch.retry_delay_min, Duration::from_secs(30));
+        assert_eq!(prefetch.retry_delay_max, Duration::from_secs(120));
+    }
+
+    #[test]
+    fn rejects_inverted_prefetch_retry_delay_window() {
+        let yaml = r#"
+backend:
+  type: local
+  config:
+    dir: /blobs
+storage:
+  dir: /cache
+prefetch:
+  retry_delay_min: 2h
+  retry_delay_max: 1h
+"#;
+
+        let err = Config::from_yaml(yaml).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("prefetch.retry_delay_min must not exceed prefetch.retry_delay_max"));
     }
 
     #[test]

--- a/nydus-core/src/lib.rs
+++ b/nydus-core/src/lib.rs
@@ -40,6 +40,7 @@ pub use reader::ErofsReader;
 use std::fs::{File, OpenOptions};
 use std::os::fd::{AsRawFd, RawFd};
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use nydus_config::Config;
@@ -68,6 +69,10 @@ pub struct NydusCore {
     zero_file: Arc<File>,
     flat_size: u64,
     trace_recorder: Arc<TraceRecorder>,
+    /// Stop flag of the detached background prefetch worker, raised on drop
+    /// so the worker exits its retry/reschedule loop instead of holding the
+    /// cache and backend alive forever after the core is gone.
+    prefetch_stop: Option<Arc<AtomicBool>>,
 }
 
 impl NydusCore {
@@ -84,6 +89,8 @@ impl NydusCore {
     /// spawned before returning: for an optimized image it streams the
     /// "ondemand" redirect blob first (priority) to warm the source blobs'
     /// caches in recorded access order, then prefetches the remaining blobs.
+    /// Dropping the core raises the worker's stop flag so it winds down
+    /// instead of retrying throttled prefetches forever.
     /// The worker shares the reader's blob cache set, so callers that want
     /// network access (e.g. the virtio-pmem backend) must construct the core
     /// while the desired network namespace is active so the spawned thread
@@ -111,6 +118,8 @@ impl NydusCore {
         let prefetch_concurrent_blob_count = config.prefetch.concurrent_blob_count;
         let prefetch_scope = config.prefetch.scope;
         let prefetch_timeout = config.prefetch.timeout;
+        let prefetch_retry_delay_min = config.prefetch.retry_delay_min;
+        let prefetch_retry_delay_max = config.prefetch.retry_delay_max;
         let backend = build_backend(&config.backend).context("failed to build blob backend")?;
         // The multi-device model hands each blob's cache file to the kernel
         // (as an EROFS device or fill target), so diskless mode cannot apply.
@@ -171,7 +180,10 @@ impl NydusCore {
         // set, so it keeps running (and keeps the caches alive) independently
         // of the returned core. The handle is detached: prefetch is
         // best-effort warmup and must never block core construction or
-        // teardown.
+        // teardown. The core retains only the worker's stop flag, raised on
+        // drop so the worker winds down instead of rescheduling throttled
+        // prefetches forever.
+        let mut prefetch_stop = None;
         if prefetch_scope != PrefetchScope::None {
             let prefetcher = BlobPrefetcher::new(
                 reader.blob_caches(),
@@ -179,9 +191,13 @@ impl NydusCore {
                 prefetch_concurrent_blob_count,
                 prefetch_scope,
                 prefetch_timeout,
+                prefetch_retry_delay_min,
+                prefetch_retry_delay_max,
             );
+            let stop_flag = prefetcher.stop_flag();
             match prefetcher.spawn() {
                 Ok(_handle) => {
+                    prefetch_stop = Some(stop_flag);
                     tracing::info!(
                         "nydus core: background prefetch started (scope={prefetch_scope:?})"
                     );
@@ -205,6 +221,7 @@ impl NydusCore {
             zero_file,
             flat_size,
             trace_recorder,
+            prefetch_stop,
         })
     }
 
@@ -326,5 +343,16 @@ impl NydusCore {
         }
 
         Ok(resolver.finish())
+    }
+}
+
+impl Drop for NydusCore {
+    /// Raise the background prefetch worker's stop flag so it stops starting
+    /// new work and exits its reschedule loop, instead of retrying throttled
+    /// prefetches forever after the core is gone.
+    fn drop(&mut self) {
+        if let Some(stop) = &self.prefetch_stop {
+            stop.store(true, Ordering::Relaxed);
+        }
     }
 }

--- a/nydus-storage/src/cache/mod.rs
+++ b/nydus-storage/src/cache/mod.rs
@@ -320,7 +320,9 @@ pub fn fetch_decode_validate_block_group_into<'a>(
 }
 
 /// Validate a decoded block group and, on CRC failure, attribute a CRC error metric to
-/// the backend that served the bytes.
+/// the backend that served the bytes. A read diverted from the backend's
+/// static target (e.g. a Dragonfly fallback to the origin) is attributed to
+/// the side that actually served it, via [`nydus_backend::last_read_served_by`].
 pub fn validate_block_group_with_metrics(
     backend: &Arc<dyn BlobBackend>,
     block_group: &BlobMetadataBlockGroup,
@@ -328,7 +330,9 @@ pub fn validate_block_group_with_metrics(
 ) -> io::Result<()> {
     if let Err(err) = validate_decoded_block_group(block_group, decoded) {
         if is_block_group_crc_mismatch(&err) {
-            nydus_telemetry::metrics::record_backend_crc_error(backend.backend_target());
+            let target =
+                nydus_backend::last_read_served_by().unwrap_or_else(|| backend.backend_target());
+            nydus_telemetry::metrics::record_backend_crc_error(target);
         }
         return Err(err);
     }
@@ -439,5 +443,51 @@ mod tests {
         let block_groups = vec![block_group(0, 4), block_group(4, 1)];
         let batches = plan_prefetch_batches(&block_groups, EROFS_BLOCK_SIZE as u64);
         assert_eq!(batches, vec![0..1, 1..2]);
+    }
+
+    /// A backend whose reads are never exercised; only its static target matters.
+    struct StaticTargetBackend;
+
+    impl BlobBackend for StaticTargetBackend {
+        fn backend_target(&self) -> nydus_telemetry::metrics::BackendTarget {
+            nydus_telemetry::metrics::BackendTarget::Proxy
+        }
+
+        fn blob_metadata(
+            &self,
+            _blob_id: &[u8; SHA256_DIGEST_SIZE],
+        ) -> io::Result<nydus_format::blob::BlobMetadata> {
+            Err(io::Error::other("unused"))
+        }
+
+        fn read_range_into(
+            &self,
+            _blob_id: &[u8; SHA256_DIGEST_SIZE],
+            _offset: u64,
+            _dst: &mut [u8],
+            _context: ReadContext,
+        ) -> io::Result<()> {
+            Err(io::Error::other("unused"))
+        }
+    }
+
+    #[test]
+    fn crc_failure_is_attributed_to_the_static_target_without_an_override() {
+        use nydus_telemetry::metrics::BackendTarget;
+
+        let backend: Arc<dyn BlobBackend> = Arc::new(StaticTargetBackend);
+        // A zeroed block has crc32c != 0, so a group declaring crc 0 mismatches.
+        let block_group = block_group(0, 1);
+        let decoded = vec![0u8; EROFS_BLOCK_SIZE as usize];
+        assert!(nydus_backend::last_read_served_by().is_none());
+
+        let proxy_before = nydus_telemetry::metrics::backend_crc_error_total(BackendTarget::Proxy);
+        let err = validate_block_group_with_metrics(&backend, &block_group, &decoded)
+            .expect_err("crc must mismatch");
+        assert!(is_block_group_crc_mismatch(&err));
+        assert_eq!(
+            nydus_telemetry::metrics::backend_crc_error_total(BackendTarget::Proxy),
+            proxy_before + 1
+        );
     }
 }

--- a/nydus-storage/src/prefetch.rs
+++ b/nydus-storage/src/prefetch.rs
@@ -3,15 +3,22 @@
 //! reads hit the cache instead of the backend.
 
 use std::io;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tracing::{info, warn};
 
+use nydus_backend::is_backend_throttled;
 use nydus_config::PrefetchScope;
+use nydus_telemetry::metrics::{inc_prefetch_reschedule, inc_prefetch_reschedule_run};
 
 use crate::cache::BlobCaches;
+
+/// How often the reschedule wait re-checks the stop flag while sleeping
+/// towards the next deadline.
+const RESCHEDULE_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Drives blob-level prefetch after a nydus filesystem is mounted.
 ///
@@ -22,6 +29,11 @@ use crate::cache::BlobCaches;
 ///    concurrently with a worker pool; otherwise stop after the priority blobs so the
 ///    backend bandwidth stays focused on the access-ordered hot set (e.g. an
 ///    optimized image's "ondemand" redirect blob).
+/// 3. Blobs whose prefetch the backend throttled (Dragonfly `429`, detected
+///    via [`is_backend_throttled`]) are rescheduled after a random delay in
+///    the configured window and re-attempted until they stop being throttled
+///    or the [stop flag](Self::stop_flag) is raised. Other failures are
+///    logged and skipped.
 pub struct BlobPrefetcher {
     caches: Arc<BlobCaches>,
     priority: Vec<u16>,
@@ -30,6 +42,13 @@ pub struct BlobPrefetcher {
     scope: PrefetchScope,
     /// Per-blob prefetch timeout; `0s` disables the bound.
     timeout: Duration,
+    /// The `[min, max]` window for the random delay before a throttled blob
+    /// prefetch is re-attempted.
+    retry_delay_min: Duration,
+    retry_delay_max: Duration,
+    /// Cooperative stop flag: once raised, no new prefetch work is started
+    /// and the reschedule loop exits.
+    stop: Arc<AtomicBool>,
 }
 
 /// The blob prefetch order: `priority` blobs stream first, sequentially and
@@ -45,12 +64,16 @@ pub struct PrefetchPlan {
 impl BlobPrefetcher {
     /// `plan` is typically the result of `ErofsReader::prefetch_plan`, and
     /// `blobs` the matching cache set (`ErofsReader::blob_caches`).
+    /// `retry_delay_min ..= retry_delay_max` is the window for the random
+    /// delay before a throttled blob prefetch is re-attempted.
     pub fn new(
         caches: Arc<BlobCaches>,
         plan: PrefetchPlan,
         threads: usize,
         scope: PrefetchScope,
         timeout: Duration,
+        retry_delay_min: Duration,
+        retry_delay_max: Duration,
     ) -> Self {
         Self {
             caches,
@@ -59,7 +82,21 @@ impl BlobPrefetcher {
             threads: threads.max(1),
             scope,
             timeout,
+            retry_delay_min,
+            retry_delay_max: retry_delay_max.max(retry_delay_min),
+            stop: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// A handle to this prefetcher's stop flag. Storing `true` makes the
+    /// prefetcher stop starting new work and exit its reschedule loop, so a
+    /// detached prefetch thread can be wound down on unmount.
+    pub fn stop_flag(&self) -> Arc<AtomicBool> {
+        self.stop.clone()
+    }
+
+    fn stopped(&self) -> bool {
+        self.stop.load(Ordering::Relaxed)
     }
 
     /// Spawn a background thread that drives the whole prefetch workflow. The
@@ -72,19 +109,27 @@ impl BlobPrefetcher {
 
     /// Drive the whole prefetch workflow synchronously on the calling thread:
     /// priority blobs sequentially in declared order, then (only when the scope
-    /// is [`PrefetchScope::All`]) the remaining blobs through a worker pool.
-    /// Per-blob failures are logged and skipped.
-    pub fn run(self) {
+    /// is [`PrefetchScope::All`]) the remaining blobs through a worker pool,
+    /// then delayed retries of throttled blobs. Per-blob failures other than
+    /// backend throttling are logged and skipped.
+    pub fn run(mut self) {
         if self.scope == PrefetchScope::None {
             return;
         }
+
+        // Blobs the backend throttled, awaiting a delayed retry.
+        let mut throttled: Vec<u16> = Vec::new();
 
         // Phase 1: priority blobs, sequential, in declared order. Under the
         // default "ondemand" scope only the redirect blob is warmed (it
         // streams the access-ordered hot set into the source caches);
         // non-redirect priority blobs are skipped so the backend bandwidth is
         // not spent pulling whole source blobs.
-        for blob_index in self.priority {
+        for blob_index in &self.priority {
+            let blob_index = *blob_index;
+            if self.stopped() {
+                return;
+            }
             if self.scope != PrefetchScope::All {
                 match self.caches.is_redirect(blob_index) {
                     Ok(true) => {}
@@ -100,44 +145,306 @@ impl BlobPrefetcher {
                 .prefetch_blob(blob_index, self.threads, self.timeout)
             {
                 Ok(()) => info!("prefetched priority blob {}", blob_index),
+                Err(err) if is_backend_throttled(&err) => {
+                    inc_prefetch_reschedule();
+                    warn!(
+                        "backend throttled prefetch of priority blob {}, rescheduling: {}",
+                        blob_index, err
+                    );
+                    throttled.push(blob_index);
+                }
                 Err(err) => warn!("failed to prefetch priority blob {}: {}", blob_index, err),
             }
         }
 
         // Phase 2: remaining blobs, concurrent worker pool. Skipped unless the
         // scope is "all".
-        if self.scope != PrefetchScope::All || self.rest.is_empty() {
-            return;
+        if self.scope == PrefetchScope::All && !self.rest.is_empty() {
+            let worker_count = self.threads.min(self.rest.len());
+            let queue = Arc::new(Mutex::new(std::mem::take(&mut self.rest)));
+            let throttled_shared = Arc::new(Mutex::new(Vec::new()));
+            let timeout = self.timeout;
+            let mut handles = Vec::with_capacity(worker_count);
+            for _ in 0..worker_count {
+                let blobs = self.caches.clone();
+                let queue = queue.clone();
+                let throttled_shared = throttled_shared.clone();
+                let stop = self.stop.clone();
+                let handle = thread::Builder::new()
+                    .name("nydus_prefetch_worker".to_string())
+                    .spawn(move || loop {
+                        if stop.load(Ordering::Relaxed) {
+                            break;
+                        }
+                        let blob_index = {
+                            let mut guard = queue.lock().unwrap();
+                            guard.pop()
+                        };
+                        match blob_index {
+                            Some(blob_index) => match blobs.prefetch_blob(blob_index, 1, timeout) {
+                                Ok(()) => info!("prefetched blob {}", blob_index),
+                                Err(err) if is_backend_throttled(&err) => {
+                                    inc_prefetch_reschedule();
+                                    warn!(
+                                        "backend throttled prefetch of blob {}, rescheduling: {}",
+                                        blob_index, err
+                                    );
+                                    throttled_shared.lock().unwrap().push(blob_index);
+                                }
+                                Err(err) => {
+                                    warn!("failed to prefetch blob {}: {}", blob_index, err)
+                                }
+                            },
+                            None => break,
+                        }
+                    });
+                match handle {
+                    Ok(handle) => handles.push(handle),
+                    Err(err) => warn!("failed to spawn prefetch worker: {}", err),
+                }
+            }
+            for handle in handles {
+                let _ = handle.join();
+            }
+            throttled.append(&mut throttled_shared.lock().unwrap());
         }
-        let worker_count = self.threads.min(self.rest.len());
-        let queue = Arc::new(Mutex::new(self.rest));
-        let timeout = self.timeout;
-        let mut handles = Vec::with_capacity(worker_count);
-        for _ in 0..worker_count {
-            let blobs = self.caches.clone();
-            let queue = queue.clone();
-            let handle = thread::Builder::new()
-                .name("nydus_prefetch_worker".to_string())
-                .spawn(move || loop {
-                    let blob_index = {
-                        let mut guard = queue.lock().unwrap();
-                        guard.pop()
-                    };
-                    match blob_index {
-                        Some(blob_index) => match blobs.prefetch_blob(blob_index, 1, timeout) {
-                            Ok(()) => info!("prefetched blob {}", blob_index),
-                            Err(err) => warn!("failed to prefetch blob {}: {}", blob_index, err),
-                        },
-                        None => break,
-                    }
-                });
-            match handle {
-                Ok(handle) => handles.push(handle),
-                Err(err) => warn!("failed to spawn prefetch worker: {}", err),
+
+        // Phase 3: delayed retries of throttled blobs. Each blob gets a fresh
+        // random deadline inside the retry window; retries that get throttled
+        // again are rescheduled, other failures are dropped. The cross-process
+        // prefetch flock and group-map skip logic inside `prefetch_blob` make
+        // a rescheduled prefetch behind another node's progress nearly free.
+        let mut queue: Vec<(Instant, u16)> = throttled
+            .into_iter()
+            .map(|blob_index| (Instant::now() + self.retry_delay(), blob_index))
+            .collect();
+        while !queue.is_empty() {
+            queue.sort_by_key(|(deadline, _)| *deadline);
+            let (deadline, blob_index) = queue.remove(0);
+            while Instant::now() < deadline {
+                if self.stopped() {
+                    return;
+                }
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                thread::sleep(remaining.min(RESCHEDULE_POLL_INTERVAL));
+            }
+            if self.stopped() {
+                return;
+            }
+            inc_prefetch_reschedule_run();
+            match self
+                .caches
+                .prefetch_blob(blob_index, self.threads, self.timeout)
+            {
+                Ok(()) => info!("prefetched rescheduled blob {}", blob_index),
+                Err(err) if is_backend_throttled(&err) => {
+                    inc_prefetch_reschedule();
+                    warn!(
+                        "backend throttled rescheduled prefetch of blob {}, rescheduling again: {}",
+                        blob_index, err
+                    );
+                    queue.push((Instant::now() + self.retry_delay(), blob_index));
+                }
+                Err(err) => warn!(
+                    "failed to prefetch rescheduled blob {}, giving up: {}",
+                    blob_index, err
+                ),
             }
         }
-        for handle in handles {
-            let _ = handle.join();
+    }
+
+    /// A random delay inside the configured retry window, seeded from OS
+    /// entropy via `RandomState` so no `rand` dependency is needed.
+    fn retry_delay(&self) -> Duration {
+        let span = self.retry_delay_max.saturating_sub(self.retry_delay_min);
+        if span.is_zero() {
+            return self.retry_delay_min;
         }
+        use std::hash::{BuildHasher, Hasher};
+        let seed = std::collections::hash_map::RandomState::new()
+            .build_hasher()
+            .finish();
+        // The default window (6h span) is far below `u64::MAX` nanoseconds
+        // (~584 years); clamp anyway so pathological configs cannot overflow.
+        let span_nanos = u64::try_from(span.as_nanos()).unwrap_or(u64::MAX);
+        self.retry_delay_min + Duration::from_nanos(seed % span_nanos.saturating_add(1))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use std::sync::atomic::AtomicUsize;
+
+    use nydus_backend::{throttled_error, BlobBackend, Local, ReadContext};
+    use nydus_format::blob::{BlobMetadata, BlobMetadataChunk, BlobMetadataGroup};
+    use nydus_format::utils::{sha256_bytes, write_minimal_full_blob, SHA256_DIGEST_SIZE};
+    use tempfile::tempdir;
+
+    /// Wraps a local backend and fails the first `failures` data reads with
+    /// the given error builder, then delegates, counting every read attempt.
+    struct FlakyBackend {
+        inner: Local,
+        failures: usize,
+        error: fn() -> io::Error,
+        attempts: AtomicUsize,
+    }
+
+    impl FlakyBackend {
+        fn new(dir: &Path, failures: usize, error: fn() -> io::Error) -> Arc<Self> {
+            Arc::new(Self {
+                inner: Local::new(dir.to_path_buf()),
+                failures,
+                error,
+                attempts: AtomicUsize::new(0),
+            })
+        }
+
+        fn attempts(&self) -> usize {
+            self.attempts.load(Ordering::SeqCst)
+        }
+    }
+
+    impl BlobBackend for FlakyBackend {
+        fn blob_metadata(&self, blob_id: &[u8; SHA256_DIGEST_SIZE]) -> io::Result<BlobMetadata> {
+            self.inner.blob_metadata(blob_id)
+        }
+
+        fn read_range_into(
+            &self,
+            blob_id: &[u8; SHA256_DIGEST_SIZE],
+            offset: u64,
+            dst: &mut [u8],
+            ctx: ReadContext,
+        ) -> io::Result<()> {
+            let attempt = self.attempts.fetch_add(1, Ordering::SeqCst);
+            if attempt < self.failures {
+                return Err((self.error)());
+            }
+            self.inner.read_range_into(blob_id, offset, dst, ctx)
+        }
+    }
+
+    /// A single-blob prefetcher over a `FlakyBackend`, with a tight retry
+    /// window so tests run in milliseconds.
+    fn prefetcher_over(
+        backend: Arc<FlakyBackend>,
+        backend_dir: &Path,
+        cache_dir: &Path,
+        payload: &[u8],
+        meta: &BlobMetadata,
+    ) -> BlobPrefetcher {
+        let full_blob_id = write_minimal_full_blob(backend_dir, payload, meta, true);
+        let caches = Arc::new(
+            BlobCaches::new([(0u16, full_blob_id)], backend, Some(cache_dir), None).unwrap(),
+        );
+        BlobPrefetcher::new(
+            caches,
+            PrefetchPlan {
+                priority: vec![0],
+                rest: Vec::new(),
+            },
+            1,
+            PrefetchScope::All,
+            Duration::ZERO,
+            Duration::from_millis(30),
+            Duration::from_millis(60),
+        )
+    }
+
+    fn test_payload() -> (Vec<u8>, BlobMetadata) {
+        let payload = vec![0xabu8; 4096];
+        let data_blob_id = sha256_bytes(&payload);
+        let meta = BlobMetadata::from_parts(
+            data_blob_id,
+            1,
+            vec![BlobMetadataGroup::new(0, 1, 0, 4096, crc32c::crc32c(&payload)).unwrap()],
+            vec![BlobMetadataChunk::new(*blake3::hash(&payload).as_bytes(), 0, 1).unwrap()],
+        )
+        .unwrap();
+        (payload, meta)
+    }
+
+    #[test]
+    fn throttled_prefetch_is_rescheduled_and_retried() {
+        let backend_dir = tempdir().unwrap();
+        let cache_dir = tempdir().unwrap();
+        let (payload, meta) = test_payload();
+        // The first data read is throttled; the delayed retry succeeds.
+        let backend = FlakyBackend::new(backend_dir.path(), 1, || {
+            throttled_error("proxy answered 429")
+        });
+        let prefetcher = prefetcher_over(
+            backend.clone(),
+            backend_dir.path(),
+            cache_dir.path(),
+            &payload,
+            &meta,
+        );
+
+        let reschedules_before = nydus_telemetry::metrics::prefetch_reschedule_total();
+        let runs_before = nydus_telemetry::metrics::prefetch_reschedule_run_total();
+        let start = Instant::now();
+        prefetcher.run();
+
+        // One throttled attempt plus the successful delayed retry.
+        assert!(backend.attempts() >= 2, "attempts={}", backend.attempts());
+        // The retry waited out (at least) the minimum delay.
+        assert!(start.elapsed() >= Duration::from_millis(30));
+        assert!(nydus_telemetry::metrics::prefetch_reschedule_total() > reschedules_before);
+        assert!(nydus_telemetry::metrics::prefetch_reschedule_run_total() > runs_before);
+    }
+
+    #[test]
+    fn non_throttled_failure_is_not_rescheduled() {
+        let backend_dir = tempdir().unwrap();
+        let cache_dir = tempdir().unwrap();
+        let (payload, meta) = test_payload();
+        // Always fail with an ordinary error: log-and-skip, no reschedule.
+        let backend = FlakyBackend::new(backend_dir.path(), usize::MAX, || {
+            io::Error::other("ordinary failure")
+        });
+        let prefetcher = prefetcher_over(
+            backend.clone(),
+            backend_dir.path(),
+            cache_dir.path(),
+            &payload,
+            &meta,
+        );
+
+        let start = Instant::now();
+        prefetcher.run();
+
+        // No delayed retry: exactly the initial attempt, and no retry-window
+        // sleep.
+        assert_eq!(backend.attempts(), 1);
+        assert!(start.elapsed() < Duration::from_millis(30));
+    }
+
+    #[test]
+    fn raised_stop_flag_prevents_rescheduled_retries() {
+        let backend_dir = tempdir().unwrap();
+        let cache_dir = tempdir().unwrap();
+        let (payload, meta) = test_payload();
+        let backend = FlakyBackend::new(backend_dir.path(), usize::MAX, || {
+            throttled_error("proxy answered 429")
+        });
+        let prefetcher = prefetcher_over(
+            backend.clone(),
+            backend_dir.path(),
+            cache_dir.path(),
+            &payload,
+            &meta,
+        );
+
+        // Raise the stop flag before running: the initial pass is skipped
+        // entirely and run() returns without sleeping towards a retry.
+        prefetcher.stop_flag().store(true, Ordering::SeqCst);
+        let start = Instant::now();
+        prefetcher.run();
+
+        assert_eq!(backend.attempts(), 0);
+        assert!(start.elapsed() < Duration::from_millis(30));
     }
 }

--- a/nydus-storage/src/prefetch.rs
+++ b/nydus-storage/src/prefetch.rs
@@ -278,8 +278,10 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
 
     use nydus_backend::{throttled_error, BlobBackend, Local, ReadContext};
-    use nydus_format::blob::{BlobMetadata, BlobMetadataChunk, BlobMetadataGroup};
-    use nydus_format::utils::{sha256_bytes, write_minimal_full_blob, SHA256_DIGEST_SIZE};
+    use nydus_format::blob::{
+        BlobMetadata, BlobMetadataBlockGroup, BlobMetadataChunk, BlobMetadataCompressor,
+    };
+    use nydus_format::utils::{write_minimal_full_blob, SHA256_DIGEST_SIZE};
     use tempfile::tempdir;
 
     /// Wraps a local backend and fails the first `failures` data reads with
@@ -355,12 +357,11 @@ mod tests {
 
     fn test_payload() -> (Vec<u8>, BlobMetadata) {
         let payload = vec![0xabu8; 4096];
-        let data_blob_id = sha256_bytes(&payload);
-        let meta = BlobMetadata::from_parts(
-            data_blob_id,
+        let meta = BlobMetadata::new(
+            BlobMetadataCompressor::None,
             1,
-            vec![BlobMetadataGroup::new(0, 1, 0, 4096, crc32c::crc32c(&payload)).unwrap()],
             vec![BlobMetadataChunk::new(*blake3::hash(&payload).as_bytes(), 0, 1).unwrap()],
+            vec![BlobMetadataBlockGroup::new(0, 1, 0, 4096, crc32c::crc32c(&payload)).unwrap()],
         )
         .unwrap();
         (payload, meta)

--- a/nydus-telemetry/src/metrics.rs
+++ b/nydus-telemetry/src/metrics.rs
@@ -50,6 +50,61 @@ pub enum ReadKind {
     Prefetch,
 }
 
+impl ReadKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            ReadKind::OnDemand => "ondemand",
+            ReadKind::Prefetch => "prefetch",
+        }
+    }
+
+    const ALL: [ReadKind; 2] = [ReadKind::OnDemand, ReadKind::Prefetch];
+}
+
+/// Classification of a failed Dragonfly SDK read, labelling the
+/// `backend_dragonfly_read_errors` counter. Mirrors the failure classes the
+/// registry backend's load-shedding policy distinguishes. Defined here so
+/// this crate stays a dependency leaf.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DragonflyErrorClass {
+    /// The Dragonfly proxy answered HTTP 429.
+    RateLimited,
+    /// The Dragonfly proxy answered HTTP 403.
+    Forbidden,
+    /// The request timed out.
+    Timeout,
+    /// The local dfdaemon could not be reached.
+    Connect,
+    /// The proxy or the backend behind it answered HTTP 5xx.
+    ServerError,
+    /// Any other SDK transport error.
+    Other,
+}
+
+impl DragonflyErrorClass {
+    fn as_str(self) -> &'static str {
+        match self {
+            DragonflyErrorClass::RateLimited => "rate_limited",
+            DragonflyErrorClass::Forbidden => "forbidden",
+            DragonflyErrorClass::Timeout => "timeout",
+            DragonflyErrorClass::Connect => "connect",
+            DragonflyErrorClass::ServerError => "server_error",
+            DragonflyErrorClass::Other => "other",
+        }
+    }
+
+    /// All classes, used to pre-create label series so every class appears in
+    /// the exposition output even before it is first hit.
+    const ALL: [DragonflyErrorClass; 6] = [
+        DragonflyErrorClass::RateLimited,
+        DragonflyErrorClass::Forbidden,
+        DragonflyErrorClass::Timeout,
+        DragonflyErrorClass::Connect,
+        DragonflyErrorClass::ServerError,
+        DragonflyErrorClass::Other,
+    ];
+}
+
 /// A FUSE filesystem operation, mirroring nydus `StatsFop` for label parity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FsOp {
@@ -137,6 +192,14 @@ struct Metrics {
     backend_redirect_read_count: IntCounter,
     backend_redirect_read_bytes: IntCounter,
 
+    backend_dragonfly_read_errors: IntCounterVec,
+    backend_fallback_read_count: IntCounter,
+    backend_fallback_read_errors: IntCounter,
+    backend_fallback_throttle_wait: Histogram,
+
+    prefetch_reschedule_count: IntCounter,
+    prefetch_reschedule_run_count: IntCounter,
+
     fs_op_count: IntCounterVec,
     fs_op_errors: IntCounterVec,
     fs_read_latency: Histogram,
@@ -202,6 +265,25 @@ impl Metrics {
         for op in FsOp::ALL {
             fs_op_count.with_label_values(&[op.as_str()]);
             fs_op_errors.with_label_values(&[op.as_str()]);
+        }
+
+        let backend_dragonfly_read_errors = IntCounterVec::new(
+            Opts::new(
+                "backend_dragonfly_read_errors",
+                "Failed Dragonfly SDK reads by error class and read kind",
+            ),
+            &["class", "kind"],
+        )
+        .expect("valid counter vec");
+        registry
+            .register(Box::new(backend_dragonfly_read_errors.clone()))
+            .expect("register");
+
+        // Pre-create every class/kind series so they appear at zero.
+        for class in DragonflyErrorClass::ALL {
+            for kind in ReadKind::ALL {
+                backend_dragonfly_read_errors.with_label_values(&[class.as_str(), kind.as_str()]);
+            }
         }
 
         Self {
@@ -304,6 +386,32 @@ impl Metrics {
                 &registry,
                 "backend_redirect_read_bytes",
                 "Bytes of ondemand (redirect) blob data fetched from the backend",
+            ),
+            backend_dragonfly_read_errors,
+            backend_fallback_read_count: counter(
+                &registry,
+                "backend_fallback_read_count",
+                "Origin requests issued as Dragonfly fallbacks",
+            ),
+            backend_fallback_read_errors: counter(
+                &registry,
+                "backend_fallback_read_errors",
+                "Failed origin requests issued as Dragonfly fallbacks",
+            ),
+            backend_fallback_throttle_wait: histogram(
+                &registry,
+                "backend_fallback_throttle_wait",
+                "Seconds a Dragonfly fallback waited on the origin throttle",
+            ),
+            prefetch_reschedule_count: counter(
+                &registry,
+                "prefetch_reschedule_count",
+                "Blob prefetches rescheduled after a throttled (429) backend failure",
+            ),
+            prefetch_reschedule_run_count: counter(
+                &registry,
+                "prefetch_reschedule_run_count",
+                "Re-attempts of previously rescheduled blob prefetches",
             ),
             fs_op_count,
             fs_op_errors,
@@ -538,6 +646,45 @@ pub fn inc_cache_redirect_skip_block_group() {
     METRICS.cache_redirect_skip_block_group.inc();
 }
 
+/// Record a failed Dragonfly SDK read, attributed to its error class and to
+/// the kind of read (on-demand or prefetch) that hit it.
+pub fn record_dragonfly_error(class: DragonflyErrorClass, kind: ReadKind) {
+    METRICS
+        .backend_dragonfly_read_errors
+        .with_label_values(&[class.as_str(), kind.as_str()])
+        .inc();
+}
+
+/// Record an origin request issued as a Dragonfly fallback. These reads also
+/// count towards the regular origin counters via [`record_backend_read`];
+/// this pair isolates the fallback volume operators watch during Dragonfly
+/// degradation.
+pub fn record_fallback_read(is_err: bool) {
+    METRICS.backend_fallback_read_count.inc();
+    if is_err {
+        METRICS.backend_fallback_read_errors.inc();
+    }
+}
+
+/// Record how long a Dragonfly fallback waited on the origin throttle before
+/// its request was allowed to start.
+pub fn record_fallback_throttle_wait(wait: Duration) {
+    METRICS
+        .backend_fallback_throttle_wait
+        .observe(wait.as_secs_f64());
+}
+
+/// Record a blob prefetch rescheduled for a delayed retry after a throttled
+/// (429) backend failure.
+pub fn inc_prefetch_reschedule() {
+    METRICS.prefetch_reschedule_count.inc();
+}
+
+/// Record the execution of a previously rescheduled blob prefetch.
+pub fn inc_prefetch_reschedule_run() {
+    METRICS.prefetch_reschedule_run_count.inc();
+}
+
 /// How many caches currently claim the blob `cache_key`, for tests. The gauge
 /// itself is process-global and other tests move it concurrently, so the
 /// refcount is what can be asserted deterministically.
@@ -639,6 +786,42 @@ pub fn backend_redirect_read_bytes_total() -> u64 {
     METRICS.backend_redirect_read_bytes.get()
 }
 
+/// Current count of failed Dragonfly reads for one error class and read kind.
+pub fn dragonfly_error_total(class: DragonflyErrorClass, kind: ReadKind) -> u64 {
+    METRICS
+        .backend_dragonfly_read_errors
+        .with_label_values(&[class.as_str(), kind.as_str()])
+        .get()
+}
+
+/// Current count of origin requests issued as Dragonfly fallbacks.
+pub fn backend_fallback_read_total() -> u64 {
+    METRICS.backend_fallback_read_count.get()
+}
+
+/// Current count of failed origin requests issued as Dragonfly fallbacks.
+pub fn backend_fallback_read_error_total() -> u64 {
+    METRICS.backend_fallback_read_errors.get()
+}
+
+/// Current count of backend reads attributed to `target`.
+pub fn backend_read_total(target: BackendTarget) -> u64 {
+    match target {
+        BackendTarget::Origin => METRICS.backend_origin_read_count.get(),
+        BackendTarget::Proxy => METRICS.backend_proxy_read_count.get(),
+    }
+}
+
+/// Current count of blob prefetches rescheduled after a throttled failure.
+pub fn prefetch_reschedule_total() -> u64 {
+    METRICS.prefetch_reschedule_count.get()
+}
+
+/// Current count of re-attempts of rescheduled blob prefetches.
+pub fn prefetch_reschedule_run_total() -> u64 {
+    METRICS.prefetch_reschedule_run_count.get()
+}
+
 /// Encode all metrics in the Prometheus text exposition format.
 pub fn encode_text() -> String {
     let metric_families = METRICS.registry.gather();
@@ -689,6 +872,49 @@ mod tests {
         );
         let text = encode_text();
         assert!(text.contains("backend_prefetch_read_high_latency_count"));
+    }
+
+    #[test]
+    fn dragonfly_policy_metrics_move_and_expose() {
+        let errors_before =
+            dragonfly_error_total(DragonflyErrorClass::RateLimited, ReadKind::Prefetch);
+        let fallbacks_before = backend_fallback_read_total();
+        let fallback_errors_before = backend_fallback_read_error_total();
+        let reschedules_before = prefetch_reschedule_total();
+        let reschedule_runs_before = prefetch_reschedule_run_total();
+
+        record_dragonfly_error(DragonflyErrorClass::RateLimited, ReadKind::Prefetch);
+        record_fallback_read(false);
+        record_fallback_read(true);
+        record_fallback_throttle_wait(Duration::from_millis(10));
+        inc_prefetch_reschedule();
+        inc_prefetch_reschedule_run();
+
+        assert_eq!(
+            dragonfly_error_total(DragonflyErrorClass::RateLimited, ReadKind::Prefetch),
+            errors_before + 1
+        );
+        assert_eq!(backend_fallback_read_total(), fallbacks_before + 2);
+        assert_eq!(
+            backend_fallback_read_error_total(),
+            fallback_errors_before + 1
+        );
+        assert_eq!(prefetch_reschedule_total(), reschedules_before + 1);
+        assert_eq!(prefetch_reschedule_run_total(), reschedule_runs_before + 1);
+
+        let text = encode_text();
+        assert!(
+            text.contains(r#"backend_dragonfly_read_errors{class="rate_limited",kind="prefetch"}"#)
+        );
+        // Series for classes never hit are pre-created at zero.
+        assert!(
+            text.contains(r#"backend_dragonfly_read_errors{class="forbidden",kind="ondemand"}"#)
+        );
+        assert!(text.contains("backend_fallback_read_count"));
+        assert!(text.contains("backend_fallback_read_errors"));
+        assert!(text.contains("backend_fallback_throttle_wait"));
+        assert!(text.contains("prefetch_reschedule_count"));
+        assert!(text.contains("prefetch_reschedule_run_count"));
     }
 
     #[test]

--- a/nydus-telemetry/src/metrics.rs
+++ b/nydus-telemetry/src/metrics.rs
@@ -77,6 +77,8 @@ pub enum DragonflyErrorClass {
     Connect,
     /// The proxy or the backend behind it answered HTTP 5xx.
     ServerError,
+    /// The response body failed mid-stream after a successful start.
+    Stream,
     /// Any other SDK transport error.
     Other,
 }
@@ -89,18 +91,20 @@ impl DragonflyErrorClass {
             DragonflyErrorClass::Timeout => "timeout",
             DragonflyErrorClass::Connect => "connect",
             DragonflyErrorClass::ServerError => "server_error",
+            DragonflyErrorClass::Stream => "stream",
             DragonflyErrorClass::Other => "other",
         }
     }
 
     /// All classes, used to pre-create label series so every class appears in
     /// the exposition output even before it is first hit.
-    const ALL: [DragonflyErrorClass; 6] = [
+    const ALL: [DragonflyErrorClass; 7] = [
         DragonflyErrorClass::RateLimited,
         DragonflyErrorClass::Forbidden,
         DragonflyErrorClass::Timeout,
         DragonflyErrorClass::Connect,
         DragonflyErrorClass::ServerError,
+        DragonflyErrorClass::Stream,
         DragonflyErrorClass::Other,
     ];
 }
@@ -809,6 +813,14 @@ pub fn backend_read_total(target: BackendTarget) -> u64 {
     match target {
         BackendTarget::Origin => METRICS.backend_origin_read_count.get(),
         BackendTarget::Proxy => METRICS.backend_proxy_read_count.get(),
+    }
+}
+
+/// Current count of CRC validation failures attributed to `target`.
+pub fn backend_crc_error_total(target: BackendTarget) -> u64 {
+    match target {
+        BackendTarget::Origin => METRICS.backend_origin_crc_check_errors.get(),
+        BackendTarget::Proxy => METRICS.backend_proxy_crc_check_errors.get(),
     }
 }
 

--- a/nydus/src/bin/nydus/fuse.rs
+++ b/nydus/src/bin/nydus/fuse.rs
@@ -4,7 +4,8 @@ use nydus::error::{Context, Error, Result};
 use nydus::fuse::{ErofsFs, FuseService, TermSignalMask};
 use nydus_backend::{build_backend, BlobBackend, Local};
 use nydus_config::{
-    default_prefetch_concurrent_blob_count, default_prefetch_timeout, Config, PrefetchScope,
+    default_prefetch_concurrent_blob_count, default_prefetch_retry_delay_max,
+    default_prefetch_retry_delay_min, default_prefetch_timeout, Config, PrefetchScope,
 };
 use nydus_core::ErofsReader;
 use nydus_storage::prefetch::BlobPrefetcher;
@@ -192,31 +193,40 @@ impl FuseCommand {
                 .and_then(|config| config.storage.dir.clone())
         };
 
-        let (prefetch_scope, prefetch_concurrent_blob_count, prefetch_timeout) =
-            match storage_config.as_ref() {
-                Some(config) => {
-                    // `--prefetch` forces prefetch on when the config disables it.
-                    let scope = if config.prefetch.scope == PrefetchScope::None && self.prefetch {
-                        PrefetchScope::default()
-                    } else {
-                        config.prefetch.scope
-                    };
-                    (
-                        scope,
-                        config.prefetch.concurrent_blob_count,
-                        config.prefetch.timeout,
-                    )
-                }
-                None => (
-                    if self.prefetch {
-                        PrefetchScope::default()
-                    } else {
-                        PrefetchScope::None
-                    },
-                    default_prefetch_concurrent_blob_count(),
-                    default_prefetch_timeout(),
-                ),
-            };
+        let (
+            prefetch_scope,
+            prefetch_concurrent_blob_count,
+            prefetch_timeout,
+            prefetch_retry_delay_min,
+            prefetch_retry_delay_max,
+        ) = match storage_config.as_ref() {
+            Some(config) => {
+                // `--prefetch` forces prefetch on when the config disables it.
+                let scope = if config.prefetch.scope == PrefetchScope::None && self.prefetch {
+                    PrefetchScope::default()
+                } else {
+                    config.prefetch.scope
+                };
+                (
+                    scope,
+                    config.prefetch.concurrent_blob_count,
+                    config.prefetch.timeout,
+                    config.prefetch.retry_delay_min,
+                    config.prefetch.retry_delay_max,
+                )
+            }
+            None => (
+                if self.prefetch {
+                    PrefetchScope::default()
+                } else {
+                    PrefetchScope::None
+                },
+                default_prefetch_concurrent_blob_count(),
+                default_prefetch_timeout(),
+                default_prefetch_retry_delay_min(),
+                default_prefetch_retry_delay_max(),
+            ),
+        };
 
         // Build the blob backend. A direct `--blob <path>` is self-contained and
         // needs no backend. Otherwise a `--bootstrap` is served by either an
@@ -280,6 +290,7 @@ impl FuseCommand {
 
         let session = FuseService::mount(fs, mountpoint, &config)?;
 
+        let mut prefetch_stop = None;
         if prefetch_scope == PrefetchScope::None {
             info!("blob prefetch disabled (enable with --prefetch or the config's prefetch.scope)");
         } else if cache_dir.is_none() {
@@ -291,12 +302,18 @@ impl FuseCommand {
                 prefetch_concurrent_blob_count,
                 prefetch_scope,
                 prefetch_timeout,
+                prefetch_retry_delay_min,
+                prefetch_retry_delay_max,
             );
+            let stop = prefetcher.stop_flag();
             match prefetcher.spawn() {
-                Ok(_handle) => info!(
-                    "started blob prefetch (concurrent_blob_count={}, scope={:?})",
-                    prefetch_concurrent_blob_count, prefetch_scope
-                ),
+                Ok(_handle) => {
+                    prefetch_stop = Some(stop);
+                    info!(
+                        "started blob prefetch (concurrent_blob_count={}, scope={:?})",
+                        prefetch_concurrent_blob_count, prefetch_scope
+                    );
+                }
                 Err(err) => warn!("failed to start blob prefetch: {}", err),
             }
         }
@@ -315,6 +332,12 @@ impl FuseCommand {
         };
 
         let join_result = session.serve()?;
+
+        // The filesystem is unmounted: wind down the detached prefetch thread
+        // (it may be sleeping towards a rescheduled throttled-blob retry).
+        if let Some(stop) = prefetch_stop {
+            stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
 
         // Tear down the metrics server before reporting the mount result.
         if let Some(server) = api_server {

--- a/tests/e2e/dragonfly_test.go
+++ b/tests/e2e/dragonfly_test.go
@@ -1,0 +1,318 @@
+package e2e
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type dragonflyEnv struct {
+	nydusBin      string
+	configPath    string
+	bootstrap     string
+	mountpoint    string
+	workDir       string
+	cacheDir      string
+	dragonflyMode string
+}
+
+func loadDragonflyEnv(t *testing.T) dragonflyEnv {
+	t.Helper()
+	workDir := envOr("WORK_DIR", "/tmp/nydus-dragonfly")
+	configPath := os.Getenv("NYDUS_CONFIG")
+	bootstrap := os.Getenv("BOOTSTRAP_PATH")
+	require.NotEmpty(t, configPath, "NYDUS_CONFIG must be set")
+	require.NotEmpty(t, bootstrap, "BOOTSTRAP_PATH must be set")
+
+	cacheDir := os.Getenv("NYDUS_CACHE_DIR")
+	if cacheDir == "" {
+		cacheDir = filepath.Join(workDir, "cache")
+	}
+
+	return dragonflyEnv{
+		nydusBin:      envOr("NYDUS_BIN", mustLookupExecutable(t, "nydus")),
+		configPath:    configPath,
+		bootstrap:     bootstrap,
+		mountpoint:    filepath.Join(workDir, "mnt"),
+		workDir:       workDir,
+		cacheDir:      cacheDir,
+		dragonflyMode: envOr("DRAGONFLY_MODE", "sdk-proxy-fallback"),
+	}
+}
+
+func (e dragonflyEnv) startFuse(t *testing.T) func() {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(e.mountpoint, 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(e.workDir, "logs"), 0o755))
+
+	cmd := exec.Command(
+		e.nydusBin,
+		"fuse",
+		"--bootstrap", e.bootstrap,
+		"--config", e.configPath,
+		"--mountpoint", e.mountpoint,
+		"--log-level", "debug",
+		"--log-dir", filepath.Join(e.workDir, "logs"),
+	)
+
+	return startFuseMount(t, cmd, e.mountpoint, "nydus fuse with dragonfly")
+}
+
+func readMountedFile(t *testing.T, mountpoint string) (string, []byte, error) {
+	t.Helper()
+	candidates := []string{"etc/os-release", "etc/passwd", "etc/group", "usr/bin/env"}
+	for _, rel := range candidates {
+		path := filepath.Join(mountpoint, rel)
+		data, err := os.ReadFile(path)
+		if err == nil && len(data) > 0 {
+			return rel, data, nil
+		}
+	}
+
+	var chosen string
+	err := filepath.WalkDir(mountpoint, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(mountpoint, path)
+		if relErr != nil {
+			return nil
+		}
+		if strings.HasPrefix(rel, "proc/") || strings.HasPrefix(rel, "sys/") {
+			return nil
+		}
+		chosen = rel
+		return io.EOF
+	})
+	if err == io.EOF && chosen != "" {
+		path := filepath.Join(mountpoint, chosen)
+		data, readErr := os.ReadFile(path)
+		return chosen, data, readErr
+	}
+
+	return "", nil, os.ErrNotExist
+}
+
+func killDfdaemon(t *testing.T) {
+	t.Helper()
+	_ = exec.Command("pkill", "-f", "dfdaemon").Run()
+	// give process supervisor-free background processes a moment to exit.
+	time.Sleep(2 * time.Second)
+}
+
+func TestDragonflyE2E(t *testing.T) {
+	env := loadDragonflyEnv(t)
+
+	// In strict mode the origin configured in the nydus config is the
+	// injectable proxy: it forwards to the local registry so the initial
+	// read (and Dragonfly back-to-source) succeeds, and later injects hard
+	// failures so origin fallback cannot succeed either.
+	strict := strings.Contains(env.dragonflyMode, "strict")
+	if strict {
+		_, stopProxy := newInjectableProxy(t, strings.TrimPrefix(proxyControlURL, "http://"))
+		defer stopProxy()
+	}
+
+	cleanup := env.startFuse(t)
+
+	relPath, firstData, err := readMountedFile(t, env.mountpoint)
+	require.NoError(t, err, "initial FUSE read must succeed")
+	require.NotEmpty(t, firstData, "initial read should return data")
+
+	killDfdaemon(t)
+	wipeCacheDir(env.cacheDir)
+	if strict {
+		// Fail every origin blob fetch from now on: with Dragonfly down and
+		// the origin hard-failing, strict mode must surface a read error.
+		postInject(t, http.StatusServiceUnavailable, -1)
+	}
+
+	cleanup()
+	cleanup = env.startFuse(t)
+	defer cleanup()
+
+	dataAfterFailure, err := os.ReadFile(filepath.Join(env.mountpoint, relPath))
+	if strict {
+		require.Error(t, err, "strict mode should fail once Dragonfly is down")
+		return
+	}
+
+	require.NoError(t, err, "fallback mode should keep reads alive through origin fallback")
+	require.NotEmpty(t, dataAfterFailure)
+	require.NotEmpty(t, firstData)
+}
+
+type injectableProxy struct {
+	targetURL *url.URL
+	proxy     *httputil.ReverseProxy
+
+	mu        sync.Mutex
+	status    int
+	remaining int
+}
+
+const proxyControlURL = "http://127.0.0.1:18080"
+
+func newInjectableProxy(t *testing.T, addr string) (*injectableProxy, func()) {
+	t.Helper()
+	targetURL, err := url.Parse(envOr("PROXY_TARGET_URL", "http://127.0.0.1:5000"))
+	require.NoError(t, err)
+
+	p := &injectableProxy{targetURL: targetURL}
+	p.proxy = httputil.NewSingleHostReverseProxy(targetURL)
+	p.proxy.Transport = &http.Transport{TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12}}
+	p.proxy.Director = func(req *http.Request) {
+		req.URL.Scheme = p.targetURL.Scheme
+		req.URL.Host = p.targetURL.Host
+		req.Host = p.targetURL.Host
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_test/inject", p.inject)
+	mux.HandleFunc("/_test/clear", p.clear)
+	mux.HandleFunc("/", p.serve)
+
+	ln, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(ln) }()
+
+	return p, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	}
+}
+
+func (p *injectableProxy) inject(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	var body struct {
+		Status int `json:"status"`
+		Count  int `json:"count"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	p.mu.Lock()
+	p.status = body.Status
+	p.remaining = body.Count
+	p.mu.Unlock()
+	w.WriteHeader(http.StatusOK)
+}
+
+func (p *injectableProxy) clear(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	p.mu.Lock()
+	p.status = 0
+	p.remaining = 0
+	p.mu.Unlock()
+	w.WriteHeader(http.StatusOK)
+}
+
+func (p *injectableProxy) serve(w http.ResponseWriter, r *http.Request) {
+	p.mu.Lock()
+	// Only blob GETs are injected: HEAD blob-size probes stay healthy so the
+	// tests exercise the data-read policy, not metadata recovery.
+	inject := p.status > 0 && p.remaining != 0 && r.Method == http.MethodGet &&
+		strings.Contains(r.URL.Path, "/blobs/")
+	if inject {
+		if p.remaining > 0 {
+			p.remaining--
+		}
+		status := p.status
+		p.mu.Unlock()
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, "injected error")
+		return
+	}
+	p.mu.Unlock()
+	p.proxy.ServeHTTP(w, r)
+}
+
+func postInject(t *testing.T, status, count int) {
+	t.Helper()
+	payload, err := json.Marshal(map[string]int{"status": status, "count": count})
+	require.NoError(t, err)
+	resp, err := http.Post(proxyControlURL+"/_test/inject", "application/json", strings.NewReader(string(payload)))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func clearInject(t *testing.T) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, proxyControlURL+"/_test/clear", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestProxyErrorSimulation(t *testing.T) {
+	env := loadDragonflyEnv(t)
+	configPath := os.Getenv("NYDUS_PROXY_ERROR_CONFIG")
+	require.NotEmpty(t, configPath, "NYDUS_PROXY_ERROR_CONFIG must be set")
+	env.configPath = configPath
+
+	_, stopProxy := newInjectableProxy(t, strings.TrimPrefix(proxyControlURL, "http://"))
+	defer stopProxy()
+
+	// The 403 case runs first while dfdaemon's piece cache is still cold, so
+	// its back-to-source fetches are guaranteed to see the injected failure.
+	// It injects with no budget: every origin blob GET (Dragonfly
+	// back-to-source and the direct fallback path alike) is denied, so the
+	// read must surface an error no matter which path serves it.
+	t.Run("status_403_terminal", func(t *testing.T) {
+		postInject(t, http.StatusForbidden, -1)
+		defer clearInject(t)
+		wipeCacheDir(env.cacheDir)
+		cleanup := env.startFuse(t)
+		defer cleanup()
+		_, _, err := readMountedFile(t, env.mountpoint)
+		require.Error(t, err)
+	})
+
+	t.Run("status_429_ondemand_fallback", func(t *testing.T) {
+		postInject(t, http.StatusTooManyRequests, 1)
+		defer clearInject(t)
+		wipeCacheDir(env.cacheDir)
+		cleanup := env.startFuse(t)
+		defer cleanup()
+		_, data, err := readMountedFile(t, env.mountpoint)
+		require.NoError(t, err)
+		require.NotEmpty(t, data)
+	})
+
+	t.Run("status_503_retry_or_fallback", func(t *testing.T) {
+		postInject(t, http.StatusServiceUnavailable, 3)
+		defer clearInject(t)
+		wipeCacheDir(env.cacheDir)
+		cleanup := env.startFuse(t)
+		defer cleanup()
+		_, data, err := readMountedFile(t, env.mountpoint)
+		require.NoError(t, err)
+		require.NotEmpty(t, data)
+	})
+}

--- a/tests/e2e/dragonfly_test.go
+++ b/tests/e2e/dragonfly_test.go
@@ -44,7 +44,12 @@ func loadDragonflyEnv(t *testing.T) dragonflyEnv {
 	}
 
 	return dragonflyEnv{
-		nydusBin:      envOr("NYDUS_BIN", mustLookupExecutable(t, "nydus")),
+		nydusBin: func() string {
+			if bin := os.Getenv("NYDUS_BIN"); bin != "" {
+				return bin
+			}
+			return mustLookupExecutable(t, "nydus")
+		}(),
 		configPath:    configPath,
 		bootstrap:     bootstrap,
 		mountpoint:    filepath.Join(workDir, "mnt"),

--- a/tests/e2e/fanotify_test.go
+++ b/tests/e2e/fanotify_test.go
@@ -757,13 +757,6 @@ func nonDigitTrim(s string) string {
 	return s
 }
 
-func envOr(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return def
-}
-
 func findFile(root, name string) string {
 	var found string
 	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -85,6 +85,15 @@ func lookupExecutable(name string) (string, error) {
 	return "", fmt.Errorf("%s not found in target/{release,debug}/ or on PATH", name)
 }
 
+// envOr returns the value of the named environment variable, or def when it
+// is unset or empty.
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
 // mustLookupCErofsFuse is a test helper that wraps lookupCErofsFuseExecutable and fails the test if the erofsfuse executable is not found.
 func mustLookupCErofsFuse(t *testing.T) string {
 	p, err := lookupCErofsFuseExecutable()

--- a/tests/e2e/uffd_fault_test.go
+++ b/tests/e2e/uffd_fault_test.go
@@ -555,14 +555,37 @@ func (c *uffdFaultClient) ack(t *testing.T) {
 	require.Equal(t, c.deviceSize, size)
 }
 
-// touchAsync reads mem[off] on a separate goroutine (the read blocks in the
-// kernel until the fault is resolved) and delivers the byte on the channel.
-func (c *uffdFaultClient) touchAsync(off uint64) <-chan byte {
+// touchAsync faults mem[off] in on a separate goroutine and delivers the
+// resolved byte on the channel. The touch reads the byte through
+// process_vm_readv(2) on the own process instead of a direct load: the kernel
+// resolves the missing page through the same userfaultfd path, but the Go
+// runtime sees the goroutine blocked in a syscall, so a concurrent
+// stop-the-world (e.g. a GC triggered by an allocation elsewhere in the test)
+// completes while the fault is outstanding. A direct load would wedge the OS
+// thread at a non-preemptible page fault, and any stop-the-world would then
+// deadlock the tests that serve their own faults in-process (zerocopy): the
+// serving goroutine blocks in gcStart waiting for the faulting thread, which
+// only resumes once the fault it is waiting on gets served.
+func (c *uffdFaultClient) touchAsync(t *testing.T, off uint64) <-chan byte {
 	ch := make(chan byte, 1)
 	c.touchers.Add(1)
 	go func() {
 		defer c.touchers.Done()
-		ch <- c.mem[off]
+		var b [1]byte
+		local := []unix.Iovec{{Base: &b[0], Len: 1}}
+		remote := []unix.RemoteIovec{{Base: uintptr(unsafe.Pointer(&c.mem[off])), Len: 1}}
+		for {
+			n, err := unix.ProcessVMReadv(os.Getpid(), local, remote, 0)
+			if err == unix.EINTR {
+				continue
+			}
+			if err != nil || n != 1 {
+				t.Errorf("process_vm_readv touch at device offset %#x: n=%d err=%v", off, n, err)
+				return
+			}
+			break
+		}
+		ch <- b[0]
 	}()
 	return ch
 }
@@ -756,13 +779,13 @@ func TestUffdRealFaultCopy(t *testing.T) {
 
 	// Cold: the very first fault must complete within the single-fault
 	// deadline and return the right byte.
-	first := waitUffdTouch(t, c.touchAsync(0), uffdFaultDeadline, "cold fault at device offset 0")
+	first := waitUffdTouch(t, c.touchAsync(t, 0), uffdFaultDeadline, "cold fault at device offset 0")
 	require.Equal(t, expected[0], first, "cold fault returned a wrong byte")
 
 	// Touch every fault window under an explicit per-fault deadline, then
 	// snapshot the whole device.
 	for off := uint64(0); off < c.deviceSize; off += c.faultSize {
-		waitUffdTouch(t, c.touchAsync(off), uffdFaultDeadline, fmt.Sprintf("cold fault at device offset %#x", off))
+		waitUffdTouch(t, c.touchAsync(t, off), uffdFaultDeadline, fmt.Sprintf("cold fault at device offset %#x", off))
 	}
 	cold := c.snapshotWithDeadline(t, uffdCaseDeadline, "cold full-device read")
 	requireSameUffdBytes(t, expected, cold, "cold fault-populated memory vs device reference")
@@ -828,7 +851,7 @@ func TestUffdRealFaultZeropage(t *testing.T) {
 	target := c.deviceSize - uint64(c.blockSize)
 	require.GreaterOrEqual(t, target, last.deviceOffset, "tail block must be inside the zero hole")
 
-	b := waitUffdTouch(t, c.touchAsync(target), uffdFaultDeadline, "zero-page fault at device tail")
+	b := waitUffdTouch(t, c.touchAsync(t, target), uffdFaultDeadline, "zero-page fault at device tail")
 	require.Zero(t, b, "zero hole must fault in as zero")
 	page := c.mem[target : target+uint64(c.blockSize)]
 	require.Equal(t, make([]byte, c.blockSize), page, "the whole tail block must be zero after the fault")
@@ -849,7 +872,7 @@ func TestUffdRealFaultZerocopy(t *testing.T) {
 	expected := fetchUffdDeviceBytes(t, f.socketPath, 0, c.deviceSize)
 
 	// Fault 1: non-zero data at device offset 0 (EROFS metadata).
-	ch := c.touchAsync(0)
+	ch := c.touchAsync(t, 0)
 	ranges, _ := c.serveOneZerocopyFault(t)
 	require.NotEmpty(t, ranges)
 	b := waitUffdTouch(t, ch, uffdFaultDeadline, "zerocopy fault at device offset 0")
@@ -858,7 +881,7 @@ func TestUffdRealFaultZerocopy(t *testing.T) {
 
 	// Fault 2: the device tail hole must map as zero pages.
 	tailOff := c.deviceSize - faultSize
-	ch = c.touchAsync(tailOff)
+	ch = c.touchAsync(t, tailOff)
 	_, _ = c.serveOneZerocopyFault(t)
 	b = waitUffdTouch(t, ch, uffdFaultDeadline, "zerocopy fault at device tail")
 	require.Zero(t, b)
@@ -1416,7 +1439,7 @@ func TestUffdLifecycle(t *testing.T) {
 
 		c := newUffdFaultClient(t, f, uffdHandshakeFlagCopy, uint64(uffdSmokeRequestBlock), 0)
 		c.ack(t)
-		b := waitUffdTouch(t, c.touchAsync(0), uffdFaultDeadline, "cold fault after service restart")
+		b := waitUffdTouch(t, c.touchAsync(t, 0), uffdFaultDeadline, "cold fault after service restart")
 		expected := fetchUffdDeviceBytes(t, f.socketPath, 0, uint64(uffdSmokeRequestBlock))
 		require.Equal(t, expected[0], b, "restarted service must resolve faults for new sessions")
 	})


### PR DESCRIPTION
This PR implements proper error handling for Dragonfly backend with differentiated retry policies for prefetch vs on-demand reads. Adds configurable retry budgets, fallback throttling, and proper error classification, plus a new E2E test workflow to validate the changes.

* Prefetch reads retry up to 10 times before failing without fallback, while on-demand reads retry 3 times then fall back to origin registry. Rate limiting (429) triggers immediate fallback for on-demand reads and immediate failure for prefetch. Forbidden errors (403) are terminal for both read types.

* Adds fallback limiter to throttle consecutive origin requests with configurable interval. Implements proper error propagation with throttled marker for rate limiting scenarios. Updates telemetry metrics to track backend read attribution between proxy and origin.

Example workflow run: https://github.com/bergwolf/nydus/actions/runs/32847782111