### PR TITLE
[v3] release: bump version to 3.0.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2877,7 +2877,7 @@ dependencies = [
 
 [[package]]
 name = "nydus"
-version = "0.1.0"
+version = "3.0.0-alpha.1"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-backend"
-version = "0.1.0"
+version = "3.0.0-alpha.1"
 dependencies = [
  "arc-swap",
  "blake3",
@@ -2945,7 +2945,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-config"
-version = "0.1.0"
+version = "3.0.0-alpha.1"
 dependencies = [
  "clap",
  "humantime-serde",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-core"
-version = "0.1.0"
+version = "3.0.0-alpha.1"
 dependencies = [
  "libc",
  "memmap2",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-error"
-version = "0.1.0"
+version = "3.0.0-alpha.1"
 dependencies = [
  "libc",
  "nydus-format",
@@ -2985,7 +2985,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-format"
-version = "0.1.0"
+version = "3.0.0-alpha.1"
 dependencies = [
  "bitflags 2.11.0",
  "blake3",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-storage"
-version = "0.1.0"
+version = "3.0.0-alpha.1"
 dependencies = [
  "blake3",
  "crc32c",
@@ -3021,7 +3021,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-telemetry"
-version = "0.1.0"
+version = "3.0.0-alpha.1"
 dependencies = [
  "prometheus",
  "rolling-file",

--- a/nydus-backend/Cargo.toml
+++ b/nydus-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus-backend"
-version = "0.1.0"
+version = "3.0.0-alpha.1"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"
@@ -23,19 +23,16 @@ backend-registry = [
   "dep:tokio-util",
 ]
 # Dragonfly P2P SDK proxy support for the registry backend.
-backend-dragonfly-proxy = [
-  "backend-registry",
-  "dep:dragonfly-client-request",
-]
+backend-dragonfly-proxy = ["backend-registry", "dep:dragonfly-client-request"]
 
 [dependencies]
 arc-swap = { version = "1", optional = true }
 dragonfly-client-request = { version = "=1.4.0", optional = true }
 futures = { version = "0.3", optional = true }
 libc = { workspace = true }
-nydus-config = { version = "0.1.0", path = "../nydus-config" }
-nydus-format = { version = "0.1.0", path = "../nydus-format" }
-nydus-telemetry = { version = "0.1.0", path = "../nydus-telemetry" }
+nydus-config = { version = "3.0.0-alpha.1", path = "../nydus-config" }
+nydus-format = { version = "3.0.0-alpha.1", path = "../nydus-format" }
+nydus-telemetry = { version = "3.0.0-alpha.1", path = "../nydus-telemetry" }
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls",
   "stream",
@@ -50,7 +47,7 @@ tokio = { workspace = true, features = [
   "net",
   "rt",
   "rt-multi-thread",
-  "sync"
+  "sync",
 ], optional = true }
 tokio-util = { version = "0.7", features = ["io"], optional = true }
 tracing = { workspace = true }

--- a/nydus-config/Cargo.toml
+++ b/nydus-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus-config"
-version = "0.1.0"
+version = "3.0.0-alpha.1"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 clap = { workspace = true }
 humantime-serde = "1"
-nydus-error = { version = "0.1.0", path = "../nydus-error" }
+nydus-error = { version = "3.0.0-alpha.1", path = "../nydus-error" }
 rustls-pki-types = { version = "1", features = ["std"] }
 serde = { workspace = true }
 serde_yaml = "0.9"

--- a/nydus-core/Cargo.toml
+++ b/nydus-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus-core"
-version = "0.1.0"
+version = "3.0.0-alpha.1"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"
@@ -12,11 +12,11 @@ readme = "README.md"
 zstd = "0.13"
 libc = { workspace = true }
 memmap2 = { workspace = true }
-nydus-backend = { version = "0.1.0", path = "../nydus-backend" }
-nydus-config = { version = "0.1.0", path = "../nydus-config" }
-nydus-error = { version = "0.1.0", path = "../nydus-error" }
-nydus-format = { version = "0.1.0", path = "../nydus-format" }
-nydus-storage = { version = "0.1.0", path = "../nydus-storage" }
+nydus-backend = { version = "3.0.0-alpha.1", path = "../nydus-backend" }
+nydus-config = { version = "3.0.0-alpha.1", path = "../nydus-config" }
+nydus-error = { version = "3.0.0-alpha.1", path = "../nydus-error" }
+nydus-format = { version = "3.0.0-alpha.1", path = "../nydus-format" }
+nydus-storage = { version = "3.0.0-alpha.1", path = "../nydus-storage" }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/nydus-error/Cargo.toml
+++ b/nydus-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus-error"
-version = "0.1.0"
+version = "3.0.0-alpha.1"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ readme = "README.md"
 default = []
 
 [dependencies]
-nydus-format = { version = "0.1.0", path = "../nydus-format" }
+nydus-format = { version = "3.0.0-alpha.1", path = "../nydus-format" }
 serde_json = { workspace = true }
 serde_yaml = "0.9"
 thiserror = { workspace = true }

--- a/nydus-format/Cargo.toml
+++ b/nydus-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus-format"
-version = "0.1.0"
+version = "3.0.0-alpha.1"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"

--- a/nydus-storage/Cargo.toml
+++ b/nydus-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus-storage"
-version = "0.1.0"
+version = "3.0.0-alpha.1"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"
@@ -12,10 +12,10 @@ readme = "README.md"
 crc32c = "0.6"
 libc = { workspace = true }
 memmap2 = { workspace = true }
-nydus-backend = { version = "0.1.0", path = "../nydus-backend" }
-nydus-config = { version = "0.1.0", path = "../nydus-config" }
-nydus-format = { version = "0.1.0", path = "../nydus-format" }
-nydus-telemetry = { version = "0.1.0", path = "../nydus-telemetry" }
+nydus-backend = { version = "3.0.0-alpha.1", path = "../nydus-backend" }
+nydus-config = { version = "3.0.0-alpha.1", path = "../nydus-config" }
+nydus-format = { version = "3.0.0-alpha.1", path = "../nydus-format" }
+nydus-telemetry = { version = "3.0.0-alpha.1", path = "../nydus-telemetry" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/nydus-telemetry/Cargo.toml
+++ b/nydus-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus-telemetry"
-version = "0.1.0"
+version = "3.0.0-alpha.1"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"
@@ -31,7 +31,7 @@ tracing-panic = { version = "0.1.2", optional = true }
 tracing-subscriber = { version = "0.3", features = [
   "chrono",
   "env-filter",
-  "time"
+  "time",
 ], optional = true }
 
 [dev-dependencies]

--- a/nydus/Cargo.toml
+++ b/nydus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus"
-version = "0.1.0"
+version = "3.0.0-alpha.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "EROFS-oriented image tooling and runtime core APIs for Nydus images."
@@ -33,11 +33,7 @@ cli = [
 ]
 # Device-level userfaultfd service for microVM virtio-pmem use cases.
 # This is intentionally not part of the default or builtin core path.
-uffd = [
-  "dep:sendfd",
-  "dep:signal-hook",
-  "dep:tokio",
-]
+uffd = ["dep:sendfd", "dep:signal-hook", "dep:tokio"]
 # Serve an EROFS multi-device image on demand through fanotify pre-content
 # hooks (FAN_CLASS_PRE_CONTENT + FAN_PRE_ACCESS). Requires Linux >= 6.15.
 fanotify = ["dep:signal-hook"]
@@ -72,13 +68,13 @@ hyper-util = { version = "0.1", features = ["tokio"], optional = true }
 libc = { workspace = true }
 libublk = { version = "0.4", default-features = false, optional = true }
 memmap2 = { workspace = true }
-nydus-backend = { version = "0.1.0", path = "../nydus-backend" }
-nydus-config = { version = "0.1.0", path = "../nydus-config" }
-nydus-error = { version = "0.1.0", path = "../nydus-error" }
-nydus-format = { version = "0.1.0", path = "../nydus-format" }
-nydus-core = { version = "0.1.0", path = "../nydus-core" }
-nydus-storage = { version = "0.1.0", path = "../nydus-storage" }
-nydus-telemetry = { version = "0.1.0", path = "../nydus-telemetry", features = [
+nydus-backend = { version = "3.0.0-alpha.1", path = "../nydus-backend" }
+nydus-config = { version = "3.0.0-alpha.1", path = "../nydus-config" }
+nydus-error = { version = "3.0.0-alpha.1", path = "../nydus-error" }
+nydus-format = { version = "3.0.0-alpha.1", path = "../nydus-format" }
+nydus-core = { version = "3.0.0-alpha.1", path = "../nydus-core" }
+nydus-storage = { version = "3.0.0-alpha.1", path = "../nydus-storage" }
+nydus-telemetry = { version = "3.0.0-alpha.1", path = "../nydus-telemetry", features = [
   "logging",
 ] }
 serde = { workspace = true }
@@ -98,7 +94,7 @@ tokio = { workspace = true, features = [
   "net",
   "rt",
   "rt-multi-thread",
-  "sync"
+  "sync",
 ], optional = true }
 tracing = { workspace = true }
 uuid = { version = "1", features = ["v4"], optional = true }


### PR DESCRIPTION
Update all nydus crate versions from 0.1.0 to 3.0.0-alpha.1 in preparation for the upcoming major release. This includes the main nydus binary and all sub-crates (backend, config, core, error, format, storage, telemetry).

The version bump reflects significant changes and new features being introduced in the 3.0.0 release cycle.
