### PR TITLE
Add crate readmes

### DIFF
--- a/nydus-backend/README.md
+++ b/nydus-backend/README.md
@@ -1,0 +1,26 @@
+# nydus-backend
+
+Data-plane blob backends for
+[Nydus](https://github.com/dragonflyoss/nydus): local directory and OCI
+registry, with optional Dragonfly SDK P2P reads.
+
+Every API here returns `io::Result` so the OS errno survives to the service
+edges; this crate does not depend on the control-plane error type.
+Backend-private errors (registry auth, Dragonfly classification) are matched
+for retry decisions internally and fold into `io::Error` at the trait
+boundary.
+
+## Features
+
+| Feature | Description |
+| --- | --- |
+| `backend-registry` | Container image registry backend (OCI distribution). |
+| `backend-dragonfly-proxy` | Dragonfly P2P SDK proxy support for the registry backend. |
+
+All features are disabled by default, keeping the dependency footprint
+minimal (local backend only).
+
+## License
+
+Apache-2.0. This crate is part of the
+[Nydus](https://github.com/dragonflyoss/nydus) project.

--- a/nydus-config/README.md
+++ b/nydus-config/README.md
@@ -1,0 +1,19 @@
+# nydus-config
+
+YAML storage configuration for
+[Nydus](https://github.com/dragonflyoss/nydus): the typed schema, loading and
+validation.
+
+The schema sections mirror the crates that consume them — `BackendConfig` for
+`nydus-backend`, `StorageConfig` and `PrefetchConfig` for `nydus-storage` —
+so the data plane consumes these structs directly as constructor settings
+while the control plane loads and validates the file.
+
+It also owns the package identity — the name and the git commit constants
+baked in by its build script — the CLI version flag parser built on them, and
+the binary's default directories.
+
+## License
+
+Apache-2.0. This crate is part of the
+[Nydus](https://github.com/dragonflyoss/nydus) project.

--- a/nydus-core/README.md
+++ b/nydus-core/README.md
@@ -1,0 +1,24 @@
+# nydus-core
+
+The [Nydus](https://github.com/dragonflyoss/nydus) image reader: EROFS
+reading and path resolution over the data-plane crates, plus the
+`NydusCore`/`Blobs` runtime entry points the services drive.
+
+Every view this crate assembles from the data plane
+(`nydus-storage`/`nydus-backend`) exists to let a kernel or FUSE mount the
+image:
+
+- the file-tree reader (`reader` + `entry`) behind FUSE and image
+  inspection;
+- the flattened device views (`NydusCore` / `Blobs`) that NBD / ublk /
+  fanotify / userfaultfd hand to the kernel EROFS driver.
+
+For microVM virtio-pmem use cases, `NydusCore` exposes the device table
+needed to wire up pmem devices backed by the host-side cache data files, and
+a `Blobs::fetch` entry point that guarantees a block-aligned range is decoded
+and resident before the guest touches it.
+
+## License
+
+Apache-2.0. This crate is part of the
+[Nydus](https://github.com/dragonflyoss/nydus) project.

--- a/nydus-error/README.md
+++ b/nydus-error/README.md
@@ -1,27 +1,24 @@
-# nydus-core
+# nydus-error
 
-Runtime core APIs for EROFS-based Nydus images.
+The [Nydus](https://github.com/dragonflyoss/nydus) error contract: the
+project-wide `Error`/`Result` and the `Context` extension trait.
 
-This crate provides the host-side building blocks used to serve Nydus images
-at runtime:
+Nydus splits errors along two planes:
 
-- `metadata`: EROFS on-disk metadata parsing (superblock, inodes, blob
-  metadata and footers).
-- `storage`: on-demand blob cache, storage backends (`local`, and `registry`
-  behind the `backend-registry` feature) and background prefetching.
-- `fs`: an EROFS image reader (`ErofsReader`).
-- `core`: the high-level `NydusCore` entry point exposing the device
-  table and block-aligned `fetch` APIs for microVM virtio-pmem use cases.
+- The data plane (`storage`, `fs`, and the FUSE/fanotify/NBD/UFFD read
+  paths) keeps `std::io::Result`: those errors must carry an OS errno so the
+  service edges can answer the kernel with a meaningful POSIX code.
+- Everything else (image building, config parsing, CLI, service setup)
+  returns `Result` with the project-wide `Error` defined here.
 
-## Features
+`Error` wraps `io::Error` transparently, so data-plane failures cross into
+the control plane with a plain `?`. Use `Context` to attach human-readable
+context while keeping the source chain intact.
 
-| Feature | Description |
-| --- | --- |
-| `backend-registry` | Container image registry backend (OCI distribution). |
-| `backend-dragonfly-proxy` | Dragonfly P2P SDK proxy support for the registry backend. |
-
-All features are disabled by default, keeping the dependency footprint
-minimal (local backend only).
+Following the std guidance that an error exposes its cause either through
+`source()` or through `Display` but not both, `Display` prints only the
+outermost layer. Print edges (logs, `eprintln!`) must format errors with
+`Error::report` to keep the whole cause chain on one line.
 
 ## License
 

--- a/nydus-format/README.md
+++ b/nydus-format/README.md
@@ -1,0 +1,19 @@
+# nydus-format
+
+On-disk format layer for [Nydus](https://github.com/dragonflyoss/nydus)
+images: blob layout (footer, blob meta), EROFS metadata structures, and the
+byte-level utilities they share.
+
+- `blob`: the blob-level layout — footer, blob metadata, feature flags.
+- `erofs`: zero-copy views of EROFS on-disk metadata (superblock, inodes,
+  dirents).
+- `utils`: digests, alignment and other byte-level helpers.
+
+This crate sits below both of nydus's error planes: the data plane
+(`io::Result`) and the control plane consume the same parsers here and
+convert errors at their own boundaries.
+
+## License
+
+Apache-2.0. This crate is part of the
+[Nydus](https://github.com/dragonflyoss/nydus) project.

--- a/nydus-storage/README.md
+++ b/nydus-storage/README.md
@@ -1,0 +1,21 @@
+# nydus-storage
+
+Local data plane for [Nydus](https://github.com/dragonflyoss/nydus) images:
+sparse blob caches, block group-level fill tracking, background prefetch and
+on-demand access tracing.
+
+- `cache`: sparse local blob caches over the dense decoded block address
+  space.
+- `block_group_map`: group-level fill tracking for cached blobs.
+- `prefetch`: background prefetch scheduling.
+- `access_trace`: on-demand access tracing.
+
+Every API here returns `io::Result` so the OS errno survives to the service
+edges; this crate does not depend on the control-plane error type. Remote
+reads come through the `nydus-backend` crate; the assembly that wires
+configs, bootstraps and caches together lives above, in `nydus-core`.
+
+## License
+
+Apache-2.0. This crate is part of the
+[Nydus](https://github.com/dragonflyoss/nydus) project.

--- a/nydus-telemetry/README.md
+++ b/nydus-telemetry/README.md
@@ -1,0 +1,26 @@
+# nydus-telemetry
+
+Process-wide telemetry for [Nydus](https://github.com/dragonflyoss/nydus),
+following the observability pillars:
+
+- `metrics`: the process-wide Prometheus registry and every metric the daemon
+  exports.
+- `logging` (feature `logging`): `tracing`-subscriber installation (stdout +
+  rolling files + panic hook). Only binaries enable this — libraries emit
+  through the `tracing` facade and never install subscribers.
+
+This crate is a dependency leaf: it does not depend on other nydus crates, so
+every layer (data plane and control plane alike) can record metrics.
+
+## Features
+
+| Feature | Description |
+| --- | --- |
+| `logging` | `tracing`-subscriber installation for binaries. |
+
+All features are disabled by default.
+
+## License
+
+Apache-2.0. This crate is part of the
+[Nydus](https://github.com/dragonflyoss/nydus) project.

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# publish-crates.sh — Publish the nydus workspace crates to crates.io in
+# dependency order, skipping crate versions that are already published.
+#
+# Usage:
+#   ./scripts/publish-crates.sh --dry-run   # verify packaging only, no upload
+#   ./scripts/publish-crates.sh             # confirm, then publish
+#   ./scripts/publish-crates.sh --yes       # publish without confirmation
+#
+# Requires a crates.io token (`cargo login` or CARGO_REGISTRY_TOKEN).
+
+set -euo pipefail
+
+PROJ_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJ_DIR"
+
+# Dependency order: every crate appears after all workspace crates it uses.
+CRATES=(
+    nydus-format
+    nydus-telemetry
+    nydus-error
+    nydus-config
+    nydus-backend
+    nydus-storage
+    nydus-core
+    nydus
+)
+
+DRY_RUN=0
+ASSUME_YES=0
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        -y|--yes)  ASSUME_YES=1 ;;
+        *) echo "usage: $0 [--dry-run] [--yes]" >&2; exit 2 ;;
+    esac
+done
+
+crate_version() {
+    sed -n 's/^version = "\(.*\)"/\1/p' "$1/Cargo.toml" | head -1
+}
+
+# True if name@version is already in the crates.io sparse index.
+published() {
+    local name=$1 version=$2
+    local prefix="${name:0:2}/${name:2:2}" # index layout for names >= 4 chars
+    curl -fsSL "https://index.crates.io/${prefix}/${name}" 2>/dev/null |
+        grep -qF "\"vers\":\"${version}\""
+}
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "error: working tree is dirty; commit or stash before publishing" >&2
+    exit 1
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    # Packages the whole workspace and verifies inter-dependent crates against
+    # the packaged (not yet published) sources; nothing is uploaded.
+    cargo package --workspace
+    exit 0
+fi
+
+echo "About to publish to crates.io:"
+for crate in "${CRATES[@]}"; do
+    version="$(crate_version "$crate")"
+    if published "$crate" "$version"; then
+        echo "  ${crate}@${version} (already published, will skip)"
+    else
+        echo "  ${crate}@${version}"
+    fi
+done
+
+if [[ "$ASSUME_YES" -ne 1 ]]; then
+    read -r -p "Continue? [y/N] " answer
+    [[ "$answer" == [yY] ]] || { echo "aborted" >&2; exit 1; }
+fi
+
+for crate in "${CRATES[@]}"; do
+    version="$(crate_version "$crate")"
+    if published "$crate" "$version"; then
+        echo "==> ${crate}@${version} already on crates.io, skipping"
+        continue
+    fi
+    echo "==> publishing ${crate}@${version}"
+    # cargo blocks until the new version is visible in the index, so each
+    # later crate in the list can resolve the ones published before it.
+    cargo publish -p "$crate"
+done
+
+echo "All crates published."
+


### PR DESCRIPTION
We are missing a lot of readme files for the crates. Now add them.

Also add a helper script to publish crates on crates.io.