### PR TITLE
feat(nydusify): report RAFS version during check

### DIFF
--- a/nydusify/internal/nydusfs/image.go
+++ b/nydusify/internal/nydusfs/image.go
@@ -63,6 +63,20 @@ type Image struct {
 	Bootstrap *ocispec.Descriptor
 }
 
+// RAFSVersion returns the bootstrap layer's declared RAFS version. Plain OCI
+// images have no RAFS version; legacy nydus images without the annotation
+// report "unknown".
+func (img *Image) RAFSVersion() string {
+	if img.Kind != KindNydus || img.Bootstrap == nil {
+		return ""
+	}
+	version := img.Bootstrap.Annotations[nydus.LayerAnnotationNydusFsVersion]
+	if version == "" {
+		return "unknown"
+	}
+	return version
+}
+
 // LoadImage pulls ref through provider and parses it into a single-platform
 // Image. The reference must be non-empty. pullOpt selects which data layers
 // are downloaded. reg selects which registry side's TLS/HTTP settings to use.
@@ -76,7 +90,16 @@ func LoadImage(ctx context.Context, provider *remote.Provider, ref string, platf
 	if err != nil {
 		return nil, errors.Wrap(err, "parse")
 	}
-	log.G(ctx).Infof("parsed %s as a %s image", ref, img.Kind)
+	if version := img.RAFSVersion(); version != "" {
+		log.G(ctx).Infof(
+			"parsed %s as %s image (RAFS version %s)",
+			ref,
+			img.Kind,
+			version,
+		)
+	} else {
+		log.G(ctx).Infof("parsed %s as %s image", ref, img.Kind)
+	}
 	return img, nil
 }
 

--- a/nydusify/internal/nydusfs/image_test.go
+++ b/nydusify/internal/nydusfs/image_test.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package nydusfs
+
+import (
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/dragonflyoss/nydus/nydusify/pkg/nydus"
+)
+
+func TestRAFSVersion(t *testing.T) {
+	bootstrap := ocispec.Descriptor{Annotations: map[string]string{
+		nydus.LayerAnnotationNydusFsVersion: "7",
+	}}
+	if got := (&Image{Kind: KindNydus, Bootstrap: &bootstrap}).RAFSVersion(); got != "7" {
+		t.Fatalf("RAFS version = %q, want 7", got)
+	}
+	if got := (&Image{Kind: KindNydus, Bootstrap: &ocispec.Descriptor{}}).RAFSVersion(); got != "unknown" {
+		t.Fatalf("missing RAFS version = %q, want unknown", got)
+	}
+	if got := (&Image{Kind: KindOCI}).RAFSVersion(); got != "" {
+		t.Fatalf("OCI RAFS version = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
Report the bootstrap layer's declared RAFS version in the existing Nydus image parsing log.            
