### PR TITLE
chore: fix RUSTSEC-2026-0258 by updating h2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
Update h2 from 0.4.12 to 0.4.16 to address RUSTSEC-2026-0258 and restore the cargo-deny check.
fix https://github.com/dragonflyoss/nydus/actions/runs/33781953347/job/100737532777?pr=2064