### PR TITLE
nydusify: rename Image.RAFSVersion to FsVersion and return an ok flag

### DIFF
--- a/nydusify/go.mod
+++ b/nydusify/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.5
 	golang.org/x/sync v0.9.0
 	golang.org/x/sys v0.27.0
@@ -29,6 +30,7 @@ require (
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/docker-credential-helpers v0.9.7 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
@@ -39,6 +41,7 @@ require (
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/nydusify/go.sum
+++ b/nydusify/go.sum
@@ -31,6 +31,7 @@ github.com/containerd/typeurl/v2 v2.2.3/go.mod h1:95ljDnPfD3bAbDJRugOiShd/DlAAsx
 github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=
 github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
@@ -94,6 +95,7 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
@@ -108,6 +110,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/urfave/cli/v2 v2.27.5 h1:WoHEJLdsXr6dDWoJgMq/CboDmyY/8HMMH1fTECbih+w=
 github.com/urfave/cli/v2 v2.27.5/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=

--- a/nydusify/internal/nydusfs/image.go
+++ b/nydusify/internal/nydusfs/image.go
@@ -32,6 +32,7 @@ type ImageKind int
 const (
 	// KindOCI is a regular OCI image.
 	KindOCI ImageKind = iota
+
 	// KindNydus is a nydus (nydus-compatible) image with a bootstrap layer.
 	KindNydus
 )
@@ -63,18 +64,21 @@ type Image struct {
 	Bootstrap *ocispec.Descriptor
 }
 
-// RAFSVersion returns the bootstrap layer's declared RAFS version. Plain OCI
-// images have no RAFS version; legacy nydus images without the annotation
-// report "unknown".
-func (img *Image) RAFSVersion() string {
+// FsVersion returns the nydus fs-version declared by the bootstrap layer's
+// nydus.LayerAnnotationNydusFsVersion annotation. ok is false for plain OCI
+// images, which have no fs-version. Legacy nydus images that predate the
+// annotation report nydus.NydusFsVersionUnknown with ok set to true.
+func (img *Image) FsVersion() (string, bool) {
 	if img.Kind != KindNydus || img.Bootstrap == nil {
-		return ""
+		return "", false
 	}
+
 	version := img.Bootstrap.Annotations[nydus.LayerAnnotationNydusFsVersion]
 	if version == "" {
-		return "unknown"
+		return nydus.NydusFsVersionUnknown, true
 	}
-	return version
+
+	return version, true
 }
 
 // LoadImage pulls ref through provider and parses it into a single-platform
@@ -86,13 +90,15 @@ func LoadImage(ctx context.Context, provider *remote.Provider, ref string, platf
 	if err != nil {
 		return nil, errors.Wrap(err, "pull")
 	}
+
 	img, err := parseImage(ctx, provider.ContentStore(), ref, desc, platformMC)
 	if err != nil {
 		return nil, errors.Wrap(err, "parse")
 	}
-	if version := img.RAFSVersion(); version != "" {
+
+	if version, ok := img.FsVersion(); ok {
 		log.G(ctx).Infof(
-			"parsed %s as %s image (RAFS version %s)",
+			"parsed %s as %s image (fs-version %s)",
 			ref,
 			img.Kind,
 			version,
@@ -100,6 +106,7 @@ func LoadImage(ctx context.Context, provider *remote.Provider, ref string, platf
 	} else {
 		log.G(ctx).Infof("parsed %s as %s image", ref, img.Kind)
 	}
+
 	return img, nil
 }
 

--- a/nydusify/internal/nydusfs/image_test.go
+++ b/nydusify/internal/nydusfs/image_test.go
@@ -10,21 +10,64 @@ import (
 	"testing"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/dragonflyoss/nydus/nydusify/pkg/nydus"
 )
 
-func TestRAFSVersion(t *testing.T) {
-	bootstrap := ocispec.Descriptor{Annotations: map[string]string{
-		nydus.LayerAnnotationNydusFsVersion: "7",
-	}}
-	if got := (&Image{Kind: KindNydus, Bootstrap: &bootstrap}).RAFSVersion(); got != "7" {
-		t.Fatalf("RAFS version = %q, want 7", got)
+func TestFsVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		img  *Image
+		run  func(t *testing.T, version string, ok bool)
+	}{
+		{
+			name: "nydus image with annotation",
+			img: &Image{
+				Kind: KindNydus,
+				Bootstrap: &ocispec.Descriptor{Annotations: map[string]string{
+					nydus.LayerAnnotationNydusFsVersion: nydus.NydusFsVersion,
+				}},
+			},
+			run: func(t *testing.T, version string, ok bool) {
+				assert := assert.New(t)
+				assert.True(ok)
+				assert.Equal(nydus.NydusFsVersion, version)
+			},
+		},
+		{
+			name: "nydus image without annotation",
+			img:  &Image{Kind: KindNydus, Bootstrap: &ocispec.Descriptor{}},
+			run: func(t *testing.T, version string, ok bool) {
+				assert := assert.New(t)
+				assert.True(ok)
+				assert.Equal(nydus.NydusFsVersionUnknown, version)
+			},
+		},
+		{
+			name: "nydus image without bootstrap",
+			img:  &Image{Kind: KindNydus},
+			run: func(t *testing.T, version string, ok bool) {
+				assert := assert.New(t)
+				assert.False(ok)
+				assert.Empty(version)
+			},
+		},
+		{
+			name: "oci image",
+			img:  &Image{Kind: KindOCI},
+			run: func(t *testing.T, version string, ok bool) {
+				assert := assert.New(t)
+				assert.False(ok)
+				assert.Empty(version)
+			},
+		},
 	}
-	if got := (&Image{Kind: KindNydus, Bootstrap: &ocispec.Descriptor{}}).RAFSVersion(); got != "unknown" {
-		t.Fatalf("missing RAFS version = %q, want unknown", got)
-	}
-	if got := (&Image{Kind: KindOCI}).RAFSVersion(); got != "" {
-		t.Fatalf("OCI RAFS version = %q, want empty", got)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			version, ok := tc.img.FsVersion()
+			tc.run(t, version, ok)
+		})
 	}
 }

--- a/nydusify/pkg/nydus/constants.go
+++ b/nydusify/pkg/nydus/constants.go
@@ -36,18 +36,26 @@ const (
 
 	// LayerAnnotationNydusBlob marks a layer as a nydus data blob.
 	LayerAnnotationNydusBlob = "containerd.io/snapshot/nydus-blob"
+
 	// LayerAnnotationNydusBlobOptimized marks a nydus data blob as the ondemand
 	// blob appended by `nydusify optimize`. It holds a rearranged copy of data
 	// already present in the other blobs and describes no filesystem tree of
 	// its own.
 	LayerAnnotationNydusBlobOptimized = "containerd.io/snapshot/nydus-blob-optimized"
+
 	// LayerAnnotationNydusBootstrap marks a layer as the nydus bootstrap.
 	LayerAnnotationNydusBootstrap = "containerd.io/snapshot/nydus-bootstrap"
+
 	// LayerAnnotationNydusFsVersion marks a bootstrap layer as a nydus pmem
 	// image for snapshotters that dispatch by nydus fs-version annotations.
 	LayerAnnotationNydusFsVersion = "containerd.io/snapshot/nydus-fs-version"
+
 	// NydusFsVersion is the pseudo nydus fs-version used for nydus pmem images.
 	NydusFsVersion = "7"
+
+	// NydusFsVersionUnknown is reported for nydus images whose bootstrap layer
+	// predates LayerAnnotationNydusFsVersion and therefore declares no version.
+	NydusFsVersionUnknown = "unknown"
 
 	// LayerAnnotationUncompressed holds the uncompressed digest (diff id) of a
 	// layer, following the containerd convention.
@@ -58,8 +66,10 @@ const (
 const (
 	// DefaultChunkSize is the default nydus file chunk size in bytes.
 	DefaultChunkSize = 1 << 20
+
 	// DefaultBlockGroupSize is the default block group uncompressed size in bytes.
 	DefaultBlockGroupSize = 4 << 20
+
 	// DefaultCompressor is the default chunk data compressor.
 	DefaultCompressor = "zstd"
 )


### PR DESCRIPTION


Rewrite TestFsVersion as a table-driven test covering all four cases and adopt testify for assertions.

## Overview
The bootstrap annotation is `containerd.io/snapshot/nydus-fs-version`, so name the accessor after it and use "fs-version" in log output instead of "RAFS version".

Return (version, ok) rather than overloading the empty string: ok is false for OCI images and nydus images without a bootstrap, while legacy nydus images that predate the annotation report the new
nydus.NydusFsVersionUnknown constant with ok set to true.
## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [x] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.