### PR TITLE
[v3] layout: remove EROFS_FEATURE_COMPAT_NYDUS_NO_XATTR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ GO_TEST_ENV = $(SUDO) env "PATH=$(CURDIR)/target/release:$(dir $(GO_BIN)):$(PATH
 	"EROFS_C_FUSE=$(EROFS_C_FUSE)" \
 	"EROFS_MKFS=$(EROFS_MKFS)"
 TEST_SUPPORT_FILES = harness.go optimize.go diff.go
-E2E_TEST_FILES = roundtrip_test.go $(TEST_SUPPORT_FILES)
+E2E_TEST_FILES = roundtrip_test.go no_xattr_test.go $(TEST_SUPPORT_FILES)
 TOOCI_TEST_FILES = tooci_test.go $(TEST_SUPPORT_FILES)
 UFFD_TEST_FILES = uffd_test.go uffd_fault_test.go $(TEST_SUPPORT_FILES)
 UBLK_TEST_FILES = ublk_test.go $(TEST_SUPPORT_FILES)
@@ -109,7 +109,7 @@ test:
 	$(CARGO) test --workspace
 
 # Run end-to-end integration tests (requires root, builds release first).
-# Only runs tests/e2e/roundtrip_test.go.
+# Runs roundtrip and automatic no-xattr tests with their shared helpers.
 test-e2e: release nydusify
 	@test -n "$(GO_BIN)" || { echo "go not found; set GO=/abs/path/to/go or GO_BIN=/abs/path/to/go"; exit 1; }
 	cd tests/e2e && \

--- a/docs/nydus.md
+++ b/docs/nydus.md
@@ -1084,6 +1084,40 @@ Within the bootstrap region:
 - the metadata area starts at block 1 and contains inode bodies, xattrs, chunk
 	index arrays and directory data.
 
+### Automatic FUSE xattr optimization
+
+Build, merge, and optimize record `trusted.nydus.no_xattr` with the exact value
+`1` on the bootstrap's root inode when the final tree contains no FUSE-visible
+xattrs. This is an EROFS inode xattr inside the bootstrap bytes, not an xattr
+on the host bootstrap file, an EROFS feature bit, or a blob footer flag.
+
+The shared build/merge/optimize flattening traversal accumulates whether any
+emitted inode has visible xattrs and finalizes the root marker before metadata
+layout. No separate inode-list scan is needed. Inherited root markers are
+replaced or removed, so an upper layer's marker
+cannot hide attributes on surviving lower-layer inodes. Root `trusted.nydus.*`
+attributes are internal and excluded from the decision; attributes on all
+other inodes count, including empty values and internal-looking names, because
+FUSE only hides that namespace on the root inode. Visible attributes are always
+serialized, regardless of the optimization.
+
+Bootstrap renderers preserve the finalized attributes and do not recompute
+the marker. Code that constructs inode lists directly or changes visible xattrs
+after flattening must finalize or invalidate the root marker before rendering.
+Adding root internal prefetch attributes does not change the decision.
+
+FUSE reads the root marker once during initialization. The exact name and value
+enable `ENOSYS` replies for getxattr/listxattr, allowing Linux FUSE to stop
+forwarding subsequent requests for each operation. Missing or unknown values
+do not enable the optimization. There is no CLI or environment override and no
+full-tree mount-time scan. Root metadata read errors fail initialization rather
+than being mistaken for absence of xattrs.
+
+The marker is present in embedded, standalone, merged, and optimized bootstraps
+when their final tree qualifies. It is hidden by the existing root internal
+xattr filter and omitted from exported OCI tar attributes. Non-FUSE readers
+and native EROFS mounts do not use it to disable xattr support.
+
 ## On-disk Metadata Design
 
 ### Superblock

--- a/nydus-format/src/erofs/mod.rs
+++ b/nydus-format/src/erofs/mod.rs
@@ -43,10 +43,6 @@ pub const EROFS_SLOTSIZE: u32 = 1 << EROFS_ISLOTBITS;
 // Feature flags.
 pub const EROFS_FEATURE_COMPAT_SB_CHKSUM: u32 = 0x0000_0001;
 pub const EROFS_FEATURE_COMPAT_MTIME: u32 = 0x0000_0002;
-/// Nydus-private compat bit: no inode in this image carries any xattr, so a
-/// userspace server can answer xattr requests with ENOSYS (which makes the
-/// kernel stop sending them). Compat bits are ignored by kernel EROFS.
-pub const EROFS_FEATURE_COMPAT_NYDUS_NO_XATTR: u32 = 0x2000_0000;
 /// RAFS v6 marker: RAFS v6 bootstraps embed a private extension superblock
 /// and always set this compat bit; pure-EROFS nydus (rafs v7) bootstraps
 /// never do. This crate does not read RAFS v6 images — the bit exists only
@@ -107,6 +103,7 @@ pub const EROFS_NULL_ADDR: u64 = u64::MAX;
 
 /// Nydus internal xattr suffix for prefetch blobs ("trusted.nydus.prefetch.blobs").
 pub const NYDUS_XATTR_SUFFIX_PREFETCH_BLOBS: &[u8] = b"nydus.prefetch.blobs";
+pub const NYDUS_XATTR_SUFFIX_NO_XATTR: &[u8] = b"nydus.no_xattr";
 
 /// Cast a byte slice to a reference of `T` (`#[repr(C, packed)]`).
 ///

--- a/nydus/src/bin/nydus/fuse.rs
+++ b/nydus/src/bin/nydus/fuse.rs
@@ -275,7 +275,7 @@ impl FuseCommand {
         .context("failed to open EROFS image")?;
 
         let reader = Arc::new(reader);
-        let fs = ErofsFs::new(reader.clone());
+        let fs = ErofsFs::new(reader.clone()).context("failed to initialize FUSE filesystem")?;
         let mut config = FuseConfig::default();
         // Matches nydus v2's fuse_kern_mount: a container rootfs is read by uids
         // other than the daemon's, setuid binaries in the image have to keep

--- a/nydus/src/build/bootstrap.rs
+++ b/nydus/src/build/bootstrap.rs
@@ -9,7 +9,7 @@ use crate::build::inode::{
 use nydus_error::{Context, Error, Result};
 use nydus_format::erofs::{
     ErofsDeviceSlot, EROFS_BLOCK_SIZE, EROFS_DEVICESLOT_SIZE, EROFS_FT_DIR, EROFS_SB_BASE_SIZE,
-    EROFS_SUPER_OFFSET, EROFS_XATTR_INDEX_TRUSTED,
+    EROFS_SUPER_OFFSET,
 };
 use nydus_format::utils::align_up_usize;
 use std::io::Write;
@@ -129,7 +129,6 @@ pub fn render_flattened_bootstrap_to(
         epoch,
         &flattened_slots,
         uuid,
-        has_visible_xattrs(inodes),
     )?;
     writer
         .write_all(&head)
@@ -405,7 +404,6 @@ fn render_bootstrap_inner(
         epoch,
         device_slots,
         uuid,
-        has_visible_xattrs(inodes),
     )?;
 
     Ok(bootstrap)
@@ -431,17 +429,6 @@ fn alloc_inodes(layout: &mut MetadataLayout, inodes: &mut [InodeInfo], epoch: u6
         inode.meta_offset = offset;
         inode.nid = nid;
     }
-}
-
-/// Whether any inode carries a user-visible xattr. Nydus-internal xattrs
-/// (trusted.nydus.*) are hidden from readers, so they alone do not
-/// disqualify the image-wide no-xattr shortcut.
-fn has_visible_xattrs(inodes: &[InodeInfo]) -> bool {
-    inodes.iter().any(|inode| {
-        inode.xattrs.iter().any(|entry| {
-            !(entry.name_index == EROFS_XATTR_INDEX_TRUSTED && entry.suffix.starts_with(b"nydus."))
-        })
-    })
 }
 
 pub(crate) fn set_parent_nids(inodes: &mut [InodeInfo]) {

--- a/nydus/src/build/image.rs
+++ b/nydus/src/build/image.rs
@@ -6,8 +6,7 @@ use crc32c::crc32c_append;
 use nydus_error::{Error, Result};
 use nydus_format::erofs::{
     ErofsDeviceSlot, ErofsSuperblock, EROFS_BLOCK_SIZE, EROFS_DEVICESLOT_SIZE,
-    EROFS_FEATURE_COMPAT_MTIME, EROFS_FEATURE_COMPAT_NYDUS_NO_XATTR,
-    EROFS_FEATURE_COMPAT_SB_CHKSUM, EROFS_FEATURE_INCOMPAT_48BIT,
+    EROFS_FEATURE_COMPAT_MTIME, EROFS_FEATURE_COMPAT_SB_CHKSUM, EROFS_FEATURE_INCOMPAT_48BIT,
     EROFS_FEATURE_INCOMPAT_CHUNKED_FILE, EROFS_FEATURE_INCOMPAT_DEVICE_TABLE, EROFS_SB_BASE_SIZE,
     EROFS_SUPER_OFFSET,
 };
@@ -36,7 +35,6 @@ pub(crate) fn write_image(
     epoch: u64,
     device_slots: &[ErofsDeviceSlot],
     uuid: &[u8; 16],
-    has_xattrs: bool,
 ) -> Result<()> {
     let block_size = EROFS_BLOCK_SIZE as usize;
     let meta_blkaddr = device_table_meta_blkaddr(device_slots.len())?;
@@ -51,7 +49,6 @@ pub(crate) fn write_image(
         epoch,
         device_slots,
         uuid,
-        has_xattrs,
     )?;
     image.write_all(&head)?;
 
@@ -79,17 +76,13 @@ pub(crate) fn fill_image_head(
     epoch: u64,
     device_slots: &[ErofsDeviceSlot],
     uuid: &[u8; 16],
-    has_xattrs: bool,
 ) -> Result<()> {
     let block_size = EROFS_BLOCK_SIZE as usize;
     let meta_blkaddr = device_table_meta_blkaddr(device_slots.len())?;
     let meta_blocks = metadata_len.div_ceil(block_size);
     let total_blocks = meta_blkaddr as u64 + meta_blocks as u64;
 
-    let mut feature_compat = EROFS_FEATURE_COMPAT_MTIME | EROFS_FEATURE_COMPAT_SB_CHKSUM;
-    if !has_xattrs {
-        feature_compat |= EROFS_FEATURE_COMPAT_NYDUS_NO_XATTR;
-    }
+    let feature_compat = EROFS_FEATURE_COMPAT_MTIME | EROFS_FEATURE_COMPAT_SB_CHKSUM;
     let mut feature_incompat =
         EROFS_FEATURE_INCOMPAT_CHUNKED_FILE | EROFS_FEATURE_INCOMPAT_DEVICE_TABLE;
     // The `*_hi` halves of chunk index and device slot addresses are only
@@ -201,7 +194,7 @@ mod tests {
     #[test]
     fn write_image_sets_erofs_superblock_checksum() {
         let mut image = Vec::new();
-        write_image(&mut image, &[], 0, 1, 0, &[], &[0u8; 16], false).unwrap();
+        write_image(&mut image, &[], 0, 1, 0, &[], &[0u8; 16]).unwrap();
 
         let sb_offset = EROFS_SUPER_OFFSET as usize;
         let feature_compat =
@@ -211,7 +204,10 @@ mod tests {
         checksum_bytes[4..8].fill(0);
 
         assert_ne!(checksum, 0);
-        assert_ne!(feature_compat & EROFS_FEATURE_COMPAT_SB_CHKSUM, 0);
+        assert_eq!(
+            feature_compat,
+            EROFS_FEATURE_COMPAT_MTIME | EROFS_FEATURE_COMPAT_SB_CHKSUM
+        );
         assert_eq!(checksum, !crc32c_append(0u32, &checksum_bytes));
     }
 
@@ -237,17 +233,7 @@ mod tests {
             .collect();
 
         let mut image = Vec::new();
-        write_image(
-            &mut image,
-            &[0u8; 64],
-            0,
-            1,
-            0,
-            &device_slots,
-            &[0u8; 16],
-            false,
-        )
-        .unwrap();
+        write_image(&mut image, &[0u8; 64], 0, 1, 0, &device_slots, &[0u8; 16]).unwrap();
 
         let sb_offset = EROFS_SUPER_OFFSET as usize;
         let meta_blkaddr =

--- a/nydus/src/build/inode.rs
+++ b/nydus/src/build/inode.rs
@@ -7,7 +7,8 @@ use nydus_format::erofs::{
     ErofsInodeExtended, XattrEntry, EROFS_BLKSZBITS, EROFS_BLOCK_SIZE, EROFS_CHUNK_INDEX_SIZE,
     EROFS_FT_DIR, EROFS_INODE_CHUNK_BASED, EROFS_INODE_COMPACT_SIZE, EROFS_INODE_EXTENDED_SIZE,
     EROFS_INODE_FLAT_INLINE, EROFS_INODE_FLAT_PLAIN, EROFS_XATTR_ENTRY_HEADER_SIZE,
-    EROFS_XATTR_IBODY_HEADER_SIZE, EROFS_XATTR_INDEX_TRUSTED, NYDUS_XATTR_SUFFIX_PREFETCH_BLOBS,
+    EROFS_XATTR_IBODY_HEADER_SIZE, EROFS_XATTR_INDEX_TRUSTED, NYDUS_XATTR_SUFFIX_NO_XATTR,
+    NYDUS_XATTR_SUFFIX_PREFETCH_BLOBS,
 };
 use nydus_format::utils::align_up_usize;
 use std::collections::{HashMap, HashSet};
@@ -210,6 +211,23 @@ pub fn set_root_prefetch_blobs_xattr(inode: &mut InodeInfo, blob_indexes: &[u16]
     Ok(())
 }
 
+fn set_root_no_xattr_marker(root: &mut InodeInfo, no_xattr: bool) {
+    root.xattrs.retain(|entry| {
+        !(entry.name_index == EROFS_XATTR_INDEX_TRUSTED
+            && entry.suffix == NYDUS_XATTR_SUFFIX_NO_XATTR)
+    });
+    if no_xattr {
+        root.xattrs.push(XattrEntry {
+            name_index: EROFS_XATTR_INDEX_TRUSTED,
+            suffix: NYDUS_XATTR_SUFFIX_NO_XATTR.to_vec(),
+            value: b"1".to_vec(),
+        });
+    }
+    root.xattrs.sort_by(|left, right| {
+        (left.name_index, &left.suffix).cmp(&(right.name_index, &right.suffix))
+    });
+}
+
 /// Build the in-memory inode tree from a source directory.
 ///
 /// Walks `source` recursively and returns one [`InodeInfo`] per filesystem
@@ -312,7 +330,16 @@ pub(crate) fn flatten_tree<C, N: TreeNode<C>>(root: N, ctx: &mut C) -> Result<Ve
     let mut inodes = Vec::new();
     let mut ino_counter = 0u32;
     let mut hardlink_map = HashMap::new();
-    flatten_tree_node(root, ctx, &mut inodes, &mut ino_counter, &mut hardlink_map)?;
+    let mut has_visible_xattrs = false;
+    flatten_tree_node(
+        root,
+        ctx,
+        &mut inodes,
+        &mut ino_counter,
+        &mut hardlink_map,
+        &mut has_visible_xattrs,
+    )?;
+    set_root_no_xattr_marker(&mut inodes[0], !has_visible_xattrs);
     Ok(inodes)
 }
 
@@ -327,6 +354,7 @@ fn flatten_tree_node<C, N: TreeNode<C>>(
     inodes: &mut Vec<InodeInfo>,
     ino_counter: &mut u32,
     hardlink_map: &mut HashMap<N::LinkKey, usize>,
+    has_visible_xattrs: &mut bool,
 ) -> Result<usize> {
     let link_key = node.link_key()?;
     if let Some(key) = link_key {
@@ -339,6 +367,17 @@ fn flatten_tree_node<C, N: TreeNode<C>>(
     *ino_counter += 1;
     let ino = *ino_counter;
     let inode_index = inodes.len();
+
+    if !*has_visible_xattrs {
+        *has_visible_xattrs = if inode_index == 0 {
+            attrs.xattrs.iter().any(|entry| {
+                !(entry.name_index == EROFS_XATTR_INDEX_TRUSTED
+                    && entry.suffix.starts_with(b"nydus."))
+            })
+        } else {
+            !attrs.xattrs.is_empty()
+        };
+    }
 
     if let Some(children) = node.children(ctx)? {
         // Push the directory before its children to keep DFS pre-order; the
@@ -367,7 +406,14 @@ fn flatten_tree_node<C, N: TreeNode<C>>(
         let mut child_entries = Vec::with_capacity(children.len());
         let mut subdir_count = 0u32;
         for (name, child) in children {
-            let child_index = flatten_tree_node(child, ctx, inodes, ino_counter, hardlink_map)?;
+            let child_index = flatten_tree_node(
+                child,
+                ctx,
+                inodes,
+                ino_counter,
+                hardlink_map,
+                has_visible_xattrs,
+            )?;
             let file_type = mode_to_erofs_file_type(inodes[child_index].mode);
             if file_type == EROFS_FT_DIR {
                 subdir_count += 1;
@@ -843,7 +889,7 @@ fn read_xattrs_from_path(path: &Path) -> Vec<XattrEntry> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nydus_format::erofs::EROFS_XATTR_INDEX_USER;
+    use nydus_format::erofs::{ErofsInode, EROFS_XATTR_INDEX_USER};
 
     fn root_inode_with_xattrs(xattrs: Vec<XattrEntry>) -> InodeInfo {
         InodeInfo {
@@ -900,5 +946,234 @@ mod tests {
                 && entry.suffix.as_slice() == b"keep"
                 && entry.value.as_slice() == b"value"
         }));
+    }
+
+    #[test]
+    fn no_xattr_marker_is_replaced_without_changing_other_attributes() {
+        let mut root = root_inode_with_xattrs(vec![XattrEntry {
+            name_index: EROFS_XATTR_INDEX_USER,
+            suffix: b"visible".to_vec(),
+            value: Vec::new(),
+        }]);
+        set_root_prefetch_blobs_xattr(&mut root, &[1]).unwrap();
+        for enabled in [true, true, false, false, true] {
+            set_root_no_xattr_marker(&mut root, enabled);
+            let markers: Vec<_> = root
+                .xattrs
+                .iter()
+                .filter(|entry| entry.suffix == NYDUS_XATTR_SUFFIX_NO_XATTR)
+                .collect();
+            assert_eq!(markers.len(), usize::from(enabled));
+            assert!(markers.iter().all(|entry| entry.value == b"1"));
+            assert!(root.xattrs.iter().any(|entry| {
+                entry.name_index == EROFS_XATTR_INDEX_USER
+                    && entry.suffix == b"visible"
+                    && entry.value.is_empty()
+            }));
+            assert!(root.xattrs.iter().any(|entry| {
+                entry.suffix == NYDUS_XATTR_SUFFIX_PREFETCH_BLOBS && entry.value == b"1"
+            }));
+        }
+    }
+
+    struct XattrTestNode {
+        xattrs: Vec<XattrEntry>,
+        children: Option<NamedChildren<Self>>,
+        link_key: Option<u64>,
+    }
+
+    impl TreeNode<usize> for XattrTestNode {
+        type LinkKey = u64;
+
+        fn attrs(&mut self) -> Result<NodeAttrs> {
+            Ok(NodeAttrs {
+                mode: if self.children.is_some() {
+                    0o040755
+                } else {
+                    0o100644
+                },
+                uid: 0,
+                gid: 0,
+                size: 0,
+                mtime: 0,
+                mtime_nsec: 0,
+                nlink: 2,
+                xattrs: std::mem::take(&mut self.xattrs),
+            })
+        }
+
+        fn link_key(&mut self) -> Result<Option<Self::LinkKey>> {
+            Ok(self.link_key)
+        }
+
+        fn children(&mut self, visited: &mut usize) -> Result<Option<NamedChildren<Self>>> {
+            *visited += 1;
+            Ok(self.children.take())
+        }
+
+        fn leaf_data(&mut self, _visited: &mut usize) -> Result<InodeData> {
+            Ok(InodeData::RegularFile {
+                chunk_index_entries: Vec::new(),
+                chunk_size_bits: EROFS_BLKSZBITS as u32,
+            })
+        }
+    }
+
+    #[test]
+    fn no_xattr_is_tracked_during_flattening_and_preserved_by_rendering() {
+        use crate::build::bootstrap::{render_bootstrap, render_flattened_bootstrap};
+        use nydus_core::ErofsReader;
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("bootstrap");
+        for (at_root, name_index, suffix, visible) in [
+            (
+                true,
+                EROFS_XATTR_INDEX_TRUSTED,
+                b"nydus.prefetch.blobs".as_slice(),
+                false,
+            ),
+            (true, EROFS_XATTR_INDEX_USER, b"visible".as_slice(), true),
+            (true, EROFS_XATTR_INDEX_TRUSTED, b"visible".as_slice(), true),
+            (false, EROFS_XATTR_INDEX_USER, b"visible".as_slice(), true),
+            (
+                false,
+                EROFS_XATTR_INDEX_TRUSTED,
+                NYDUS_XATTR_SUFFIX_NO_XATTR,
+                true,
+            ),
+        ] {
+            let entry = XattrEntry {
+                name_index,
+                suffix: suffix.to_vec(),
+                value: Vec::new(),
+            };
+            let mut root = XattrTestNode {
+                xattrs: vec![XattrEntry {
+                    name_index: EROFS_XATTR_INDEX_TRUSTED,
+                    suffix: NYDUS_XATTR_SUFFIX_NO_XATTR.to_vec(),
+                    value: b"stale".to_vec(),
+                }],
+                children: Some(vec![(
+                    b"child".to_vec(),
+                    XattrTestNode {
+                        xattrs: Vec::new(),
+                        children: None,
+                        link_key: None,
+                    },
+                )]),
+                link_key: None,
+            };
+            if at_root {
+                root.xattrs.push(entry.clone());
+            } else {
+                root.children.as_mut().unwrap()[0]
+                    .1
+                    .xattrs
+                    .push(entry.clone());
+            }
+            let mut visited = 0;
+            let mut inodes = flatten_tree(root, &mut visited).unwrap();
+            assert_eq!(visited, 2);
+            assert_eq!(
+                inodes[0].xattrs.iter().any(|entry| {
+                    entry.suffix == NYDUS_XATTR_SUFFIX_NO_XATTR && entry.value == b"1"
+                }),
+                !visible,
+            );
+            assert!(inodes[usize::from(!at_root)].xattrs.contains(&entry));
+
+            for flattened in [false, true, false] {
+                if flattened {
+                    set_root_prefetch_blobs_xattr(&mut inodes[0], &[1]).unwrap();
+                }
+                let bytes = if flattened {
+                    render_flattened_bootstrap(&mut inodes, 0, &[], &[0; 16]).unwrap()
+                } else {
+                    render_bootstrap(&mut inodes, 0, &[], &[0; 16]).unwrap()
+                };
+                fs::write(&path, bytes).unwrap();
+                let reader = ErofsReader::open_metadata_only(&path).unwrap();
+                let root_nid = reader.superblock().root_nid();
+                let root = reader.inode(root_nid).unwrap();
+                let xattrs = reader.read_xattrs(root_nid, &root).unwrap();
+                assert_eq!(
+                    xattrs.iter().any(|(name, value)| {
+                        name == b"trusted.nydus.no_xattr" && value == b"1"
+                    }),
+                    !visible,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn no_xattr_tracking_handles_empty_trees_and_hardlinks() {
+        for with_xattr in [false, true] {
+            for child_count in [0, 2] {
+                let children = (0..child_count)
+                    .map(|index| {
+                        (
+                            format!("link{index}").into_bytes(),
+                            XattrTestNode {
+                                xattrs: if with_xattr {
+                                    vec![XattrEntry {
+                                        name_index: EROFS_XATTR_INDEX_USER,
+                                        suffix: b"visible".to_vec(),
+                                        value: Vec::new(),
+                                    }]
+                                } else {
+                                    Vec::new()
+                                },
+                                children: None,
+                                link_key: Some(1),
+                            },
+                        )
+                    })
+                    .collect();
+                let root = XattrTestNode {
+                    xattrs: Vec::new(),
+                    children: Some(children),
+                    link_key: None,
+                };
+                let mut visited = 0;
+                let inodes = flatten_tree(root, &mut visited).unwrap();
+                assert_eq!(visited, if child_count == 0 { 1 } else { 2 });
+                assert_eq!(inodes.len(), visited);
+                assert_eq!(
+                    inodes[0].xattrs.iter().any(|entry| {
+                        entry.suffix == NYDUS_XATTR_SUFFIX_NO_XATTR && entry.value == b"1"
+                    }),
+                    child_count == 0 || !with_xattr,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn serialize_inode_preserves_xattrs() {
+        let inode = root_inode_with_xattrs(vec![XattrEntry {
+            name_index: EROFS_XATTR_INDEX_USER,
+            suffix: b"key".to_vec(),
+            value: b"value".to_vec(),
+        }]);
+
+        let bytes = serialize_inode(&inode, 0);
+        let parsed = ErofsInode::parse(&bytes).unwrap();
+        let entry_offset = parsed.header_size() + EROFS_XATTR_IBODY_HEADER_SIZE;
+
+        assert_eq!(parsed.xattr_size(), erofs_xattr_ibody_size(&inode.xattrs));
+        assert_eq!(bytes[entry_offset], 3);
+        assert_eq!(bytes[entry_offset + 1], EROFS_XATTR_INDEX_USER);
+        assert_eq!(
+            u16::from_le_bytes(
+                bytes[entry_offset + 2..entry_offset + 4]
+                    .try_into()
+                    .unwrap()
+            ),
+            5
+        );
+        assert_eq!(&bytes[entry_offset + 4..entry_offset + 7], b"key");
+        assert_eq!(&bytes[entry_offset + 7..entry_offset + 12], b"value");
     }
 }

--- a/nydus/src/build/merge.rs
+++ b/nydus/src/build/merge.rs
@@ -628,6 +628,151 @@ mod tests {
     }
 
     #[test]
+    fn no_xattr_marker_is_recomputed_after_merge_and_optimize() {
+        use crate::build::{build_image, BuildImageOptions};
+        use nydus_format::blob::BlobMetadataCompressor;
+        use nydus_format::erofs::is_nydus_xattr;
+        use nydus_format::utils::hex_string;
+        use std::collections::HashSet;
+
+        for (operation, source_has_xattrs, expected_no_xattr) in [
+            ("keep", true, false),
+            ("without-xattrs", false, true),
+            ("whiteout", true, true),
+            ("replace", true, true),
+            ("opaque", true, true),
+        ] {
+            let directory = tempfile::tempdir().unwrap();
+            let lower = directory.path().join("lower");
+            let upper = directory.path().join("upper");
+            fs::create_dir_all(lower.join("nested")).unwrap();
+            fs::create_dir_all(upper.join("nested")).unwrap();
+            fs::write(lower.join("nested/entry"), vec![b'x'; 8193]).unwrap();
+            if source_has_xattrs {
+                xattr::set(lower.join("nested/entry"), "user.test", b"preserved value").unwrap();
+                xattr::set(lower.join("nested/entry"), "user.empty", b"").unwrap();
+            }
+            let upper_entry = match operation {
+                "whiteout" => "nested/.wh.entry",
+                "replace" => "nested/entry",
+                "opaque" => "nested/.wh..wh..opq",
+                _ => "unrelated",
+            };
+            fs::write(upper.join(upper_entry), b"").unwrap();
+            let mut sources = Vec::new();
+            for (index, source) in [lower, upper].into_iter().enumerate() {
+                let blob = directory.path().join(format!("layer-{index}"));
+                let image = build_image(
+                    &BuildImageOptions::new(
+                        source,
+                        EROFS_BLOCK_SIZE,
+                        1 << 20,
+                        BlobMetadataCompressor::None,
+                        HashSet::new(),
+                        true,
+                    )
+                    .unwrap(),
+                    fs::File::create(&blob).unwrap(),
+                )
+                .unwrap();
+                let standalone = directory.path().join(format!("bootstrap-{index}"));
+                fs::write(&standalone, image.standalone_bootstrap.unwrap()).unwrap();
+                for path in [&blob, &standalone] {
+                    let reader = ErofsReader::open_metadata_only(path).unwrap();
+                    let root_nid = reader.superblock().root_nid();
+                    let root = reader.inode(root_nid).unwrap();
+                    assert_eq!(
+                        reader
+                            .read_xattrs(root_nid, &root)
+                            .unwrap()
+                            .iter()
+                            .any(|(name, value)| {
+                                name == b"trusted.nydus.no_xattr" && value == b"1"
+                            }),
+                        index == 1 || !source_has_xattrs
+                    );
+                }
+                let source = directory.path().join(hex_string(&image.full_blob_digest));
+                fs::rename(blob, &source).unwrap();
+                sources.push(source);
+            }
+            let merged = directory.path().join("merged");
+            fs::write(
+                &merged,
+                merge_sources_to_bootstrap_bytes(&sources, WhiteoutSpec::Oci).unwrap(),
+            )
+            .unwrap();
+            let optimized = directory.path().join("optimized");
+            fs::write(
+                &optimized,
+                rewrite_bootstrap_with_ondemand_blob(&merged, &[0x55; 32], 1).unwrap(),
+            )
+            .unwrap();
+            for path in [&merged, &optimized] {
+                let reader = ErofsReader::open_metadata_only(path).unwrap();
+                let root_nid = reader.superblock().root_nid();
+                let root = reader.inode(root_nid).unwrap();
+                assert_eq!(
+                    reader
+                        .read_xattrs(root_nid, &root)
+                        .unwrap()
+                        .iter()
+                        .any(|(name, value)| {
+                            name == b"trusted.nydus.no_xattr" && value == b"1"
+                        }),
+                    expected_no_xattr,
+                    "{operation}: {}",
+                    path.display()
+                );
+
+                let mut visible_xattrs = BTreeMap::new();
+                let mut pending = vec![(Vec::new(), root_nid)];
+                while let Some((relative_path, nid)) = pending.pop() {
+                    let inode = reader.inode(nid).unwrap();
+                    let mut xattrs = reader.read_xattrs(nid, &inode).unwrap();
+                    if nid == root_nid {
+                        xattrs.retain(|(name, _)| !is_nydus_xattr(name));
+                    }
+                    if !xattrs.is_empty() {
+                        xattrs.sort();
+                        visible_xattrs.insert(relative_path.clone(), xattrs);
+                    }
+                    if mode_to_erofs_file_type(inode.mode()) == EROFS_FT_DIR {
+                        for entry in reader.read_dir(nid, &inode).unwrap() {
+                            if entry.name == b"." || entry.name == b".." {
+                                continue;
+                            }
+                            let mut child_path = relative_path.clone();
+                            if !child_path.is_empty() {
+                                child_path.push(b'/');
+                            }
+                            child_path.extend_from_slice(&entry.name);
+                            pending.push((child_path, entry.nid));
+                        }
+                    }
+                }
+                let expected_xattrs = if expected_no_xattr {
+                    BTreeMap::new()
+                } else {
+                    BTreeMap::from([(
+                        b"nested/entry".to_vec(),
+                        vec![
+                            (b"user.empty".to_vec(), Vec::new()),
+                            (b"user.test".to_vec(), b"preserved value".to_vec()),
+                        ],
+                    )])
+                };
+                assert_eq!(
+                    visible_xattrs,
+                    expected_xattrs,
+                    "{operation}: {}",
+                    path.display()
+                );
+            }
+        }
+    }
+
+    #[test]
     fn whiteout_semantics_follow_the_oci_rules() {
         type Layers = &'static [&'static [(&'static str, u8)]];
         let cases: [(&str, Layers, &[&str]); 4] = [

--- a/nydus/src/fuse/fs.rs
+++ b/nydus/src/fuse/fs.rs
@@ -15,9 +15,9 @@ use fuser::{
 };
 
 use nydus_format::erofs::{
-    is_nydus_xattr, ErofsInode, EROFS_FEATURE_COMPAT_NYDUS_NO_XATTR, EROFS_FT_BLKDEV,
-    EROFS_FT_CHRDEV, EROFS_FT_DIR, EROFS_FT_FIFO, EROFS_FT_REG_FILE, EROFS_FT_SOCK,
-    EROFS_FT_SYMLINK,
+    erofs_xattr_name_split, is_nydus_xattr, ErofsInode, EROFS_FT_BLKDEV, EROFS_FT_CHRDEV,
+    EROFS_FT_DIR, EROFS_FT_FIFO, EROFS_FT_REG_FILE, EROFS_FT_SOCK, EROFS_FT_SYMLINK,
+    EROFS_XATTR_INDEX_TRUSTED, NYDUS_XATTR_SUFFIX_NO_XATTR,
 };
 use nydus_telemetry::metrics;
 
@@ -42,8 +42,6 @@ pub struct ErofsFs {
     /// handles keep the page cache (KEEP_CACHE, and CACHE_DIR for dirs).
     no_open: AtomicBool,
     no_opendir: AtomicBool,
-    /// Image-wide "no inode has xattrs" declaration from the builder: xattr
-    /// requests answer ENOSYS so the kernel stops sending them entirely.
     no_xattr: bool,
 }
 
@@ -70,17 +68,25 @@ impl DirHandle {
 }
 
 impl ErofsFs {
-    pub fn new(reader: Arc<ErofsReader>) -> Self {
-        let no_xattr =
-            reader.superblock().feature_compat() & EROFS_FEATURE_COMPAT_NYDUS_NO_XATTR != 0;
-        Self {
+    pub fn new(reader: Arc<ErofsReader>) -> io::Result<Self> {
+        let root_nid = reader.superblock().root_nid();
+        let root = reader.inode(root_nid)?;
+        let no_xattr = reader
+            .read_xattrs(root_nid, &root)?
+            .iter()
+            .any(|(name, value)| {
+                erofs_xattr_name_split(name)
+                    == Some((EROFS_XATTR_INDEX_TRUSTED, NYDUS_XATTR_SUFFIX_NO_XATTR))
+                    && value == b"1"
+            });
+        Ok(Self {
             reader,
             dir_handles: Mutex::new(HashMap::new()),
             next_dir_handle: AtomicU64::new(1),
             no_open: AtomicBool::new(false),
             no_opendir: AtomicBool::new(false),
             no_xattr,
-        }
+        })
     }
 
     fn ino_to_nid(&self, ino: u64) -> u64 {
@@ -735,5 +741,82 @@ impl Filesystem for ErofsFs {
             return;
         }
         reply.data(&names_buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::build::blob_chunk::BlobWriter;
+    use crate::build::bootstrap::render_bootstrap;
+    use crate::build::inode::build_tree;
+    use nydus_format::erofs::{XattrEntry, EROFS_BLOCK_SIZE, EROFS_XATTR_INDEX_USER};
+    use std::collections::HashSet;
+    use std::fs;
+
+    #[test]
+    fn no_xattr_is_derived_from_root_marker() {
+        let directory = tempfile::tempdir().unwrap();
+        let source = directory.path().join("source");
+        fs::create_dir(&source).unwrap();
+        fs::write(source.join("child"), b"").unwrap();
+        let mut writer = BlobWriter::new(&directory.path().join("data"), EROFS_BLOCK_SIZE).unwrap();
+        let mut inodes =
+            build_tree(&source, &mut writer, EROFS_BLOCK_SIZE, &HashSet::new()).unwrap();
+        let bootstrap = directory.path().join("bootstrap");
+
+        for (name_index, suffix, value, expected) in [
+            (
+                EROFS_XATTR_INDEX_TRUSTED,
+                NYDUS_XATTR_SUFFIX_NO_XATTR,
+                b"1".as_slice(),
+                true,
+            ),
+            (
+                EROFS_XATTR_INDEX_TRUSTED,
+                NYDUS_XATTR_SUFFIX_NO_XATTR,
+                b"0".as_slice(),
+                false,
+            ),
+            (
+                EROFS_XATTR_INDEX_TRUSTED,
+                NYDUS_XATTR_SUFFIX_NO_XATTR,
+                b"".as_slice(),
+                false,
+            ),
+            (
+                EROFS_XATTR_INDEX_USER,
+                NYDUS_XATTR_SUFFIX_NO_XATTR,
+                b"1".as_slice(),
+                false,
+            ),
+            (
+                EROFS_XATTR_INDEX_TRUSTED,
+                b"nydus.other".as_slice(),
+                b"1".as_slice(),
+                false,
+            ),
+        ] {
+            inodes[0].xattrs = vec![XattrEntry {
+                name_index,
+                suffix: suffix.to_vec(),
+                value: value.to_vec(),
+            }];
+            inodes[1].xattrs = vec![XattrEntry {
+                name_index: EROFS_XATTR_INDEX_TRUSTED,
+                suffix: NYDUS_XATTR_SUFFIX_NO_XATTR.to_vec(),
+                value: b"1".to_vec(),
+            }];
+            let bytes = render_bootstrap(&mut inodes, 0, &[], &[0; 16]).unwrap();
+            fs::write(&bootstrap, bytes).unwrap();
+            let reader = ErofsReader::open_metadata_only(&bootstrap).unwrap();
+            let filesystem = ErofsFs::new(Arc::new(reader)).unwrap();
+            assert_eq!(filesystem.no_xattr, expected);
+        }
+        assert!(should_hide_xattr(FUSE_ROOT_ID, b"trusted.nydus.no_xattr"));
+        assert!(!should_hide_xattr(
+            FUSE_ROOT_ID + 1,
+            b"trusted.nydus.no_xattr"
+        ));
     }
 }

--- a/tests/e2e/no_xattr_test.go
+++ b/tests/e2e/no_xattr_test.go
@@ -1,0 +1,96 @@
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestAutomaticNoXattr(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("requires root for FUSE and trusted xattr fixtures")
+	}
+	nydusBin := mustLookupExecutable(t, "nydus")
+
+	t.Run("RemovedOption", func(t *testing.T) {
+		output, err := exec.Command(nydusBin, "fuse", "--mountpoint", t.TempDir(), "--no-xattr").CombinedOutput()
+		require.Error(t, err)
+		require.Contains(t, string(output), "unexpected argument '--no-xattr'")
+		output, err = exec.Command(nydusBin, "fuse", "--help").CombinedOutput()
+		require.NoError(t, err)
+		require.NotContains(t, string(output), "--no-xattr")
+		require.NotContains(t, string(output), "NYDUS_FUSE_NO_XATTR")
+	})
+
+	for _, fixture := range []struct {
+		name  string
+		path  string
+		key   string
+		value []byte
+	}{
+		{name: "None"},
+		{name: "File", path: "file", key: "user.test", value: []byte("value")},
+		{name: "EmptyValue", path: "file", key: "user.empty", value: []byte{}},
+		{name: "Root", path: ".", key: "user.root", value: []byte("root")},
+		{name: "Directory", path: "nested", key: "user.dir", value: []byte("directory")},
+		{name: "NonRootInternalName", path: "file", key: "trusted.nydus.no_xattr", value: []byte("1")},
+	} {
+		t.Run(fixture.name, func(t *testing.T) {
+			t.Setenv("NYDUS_FUSE_NO_XATTR", "true")
+			root := t.TempDir()
+			source := filepath.Join(root, "source")
+			require.NoError(t, os.MkdirAll(filepath.Join(source, "nested"), 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(source, "file"), []byte("payload"), 0o644))
+			if fixture.key != "" {
+				require.NoError(t, unix.Setxattr(filepath.Join(source, fixture.path), fixture.key, fixture.value, 0))
+			}
+			require.NoError(t, unix.Setxattr(source, "trusted.nydus.no_xattr", []byte("stale"), 0))
+			blobDir := filepath.Join(root, "blobs")
+			bootstrap := filepath.Join(root, "bootstrap")
+			output, err := exec.Command(nydusBin, "build", "--blob-dir", blobDir, "--bootstrap", bootstrap, source).CombinedOutput()
+			require.NoError(t, err, "%s", output)
+			entries, err := os.ReadDir(blobDir)
+			require.NoError(t, err)
+			var blob string
+			for _, entry := range entries {
+				if sha256FilenamePattern.MatchString(entry.Name()) {
+					require.Empty(t, blob)
+					blob = filepath.Join(blobDir, entry.Name())
+				}
+			}
+			require.NotEmpty(t, blob)
+
+			for _, layout := range []string{"blob", "bootstrap"} {
+				t.Run(layout, func(t *testing.T) {
+					mnt := filepath.Join(root, "mnt-"+layout)
+					if layout == "blob" {
+						t.Cleanup(mountNydus(t, nydusBin, "", blob, mnt))
+					} else {
+						t.Cleanup(mountNydusBootstrap(t, nydusBin, bootstrap, blobDir, mnt))
+					}
+					data, err := os.ReadFile(filepath.Join(mnt, "file"))
+					require.NoError(t, err)
+					require.Equal(t, []byte("payload"), data)
+					for attempt := 0; attempt < 2; attempt++ {
+						if fixture.key == "" {
+							_, err = unix.Getxattr(filepath.Join(mnt, "file"), "user.absent", nil)
+							require.ErrorIs(t, err, unix.EOPNOTSUPP)
+							_, err = unix.Listxattr(mnt, nil)
+							require.ErrorIs(t, err, unix.EOPNOTSUPP)
+						} else {
+							require.Equal(t, fixture.value, roGetXattr(t, filepath.Join(mnt, fixture.path), fixture.key))
+							require.Contains(t, roListXattr(t, filepath.Join(mnt, fixture.path)), fixture.key)
+							_, err = unix.Getxattr(mnt, "trusted.nydus.no_xattr", nil)
+							require.ErrorIs(t, err, unix.ENODATA)
+							require.NotContains(t, roListXattr(t, mnt), "trusted.nydus.no_xattr")
+						}
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
    layout: remove EROFS_FEATURE_COMPAT_NYDUS_NO_XATTR and add automatic no-xattr marker tracking

    This commit introduces automatic tracking of the no-xattr marker during image
    building and merging operations. The marker is now properly maintained when
    flattening inode trees, rendering bootstraps, and performing layer merges.

    The implementation ensures that the trusted.nydus.no_xattr xattr is correctly
    set on the root inode based on whether any visible xattrs exist in the
    filesystem tree. This marker is preserved through all build operations
    including bootstrap rendering, layer merging, and optimization.

    EROFS_FEATURE_COMPAT_NYDUS_NO_XATTR is dropped so that we do not
    introduce unnecessary EROFS feature bits that might conflict with EROFS
    upstream some day.

    Key changes:
    - Remove EROFS_FEATURE_COMPAT_NYDUS_NO_XATTR feature bit from superblock
    - Add set_root_no_xattr_marker function to manage the marker xattr
    - Update flatten_tree to track no-xattr state during tree traversal
    - Modify bootstrap rendering to preserve the marker through all operations
    - Add comprehensive tests covering marker behavior in various scenarios
    - Update FUSE filesystem to derive no-xattr state from root marker