### PR TITLE
Add incremental blob metadata flag

### DIFF
--- a/nydus-format/src/blob/metadata.rs
+++ b/nydus-format/src/blob/metadata.rs
@@ -87,6 +87,7 @@ bitflags! {
         const COMPRESSOR_LZ4 = 1 << 1;
         const DIGESTER_BLAKE3 = 1 << 2;
         const REDIRECT = 1 << 3;
+        const INCREMENTAL = 1 << 4;
     }
 }
 


### PR DESCRIPTION
## Overview
Add an incremental blob metadata flag and reject non-standalone blob artifacts from standalone blob entry points.

## Related Issues
Related #2080

## Change Details
Introduce an incompatible blob metadata flag for incremental upper blobs so readers can distinguish them from standalone full blobs and redirect blobs.

The new metadata flag is mutually exclusive with redirect metadata. The metadata API now exposes helpers to create and identify incremental blob metadata.

Update `nydus check` and `nydus fuse` blob-mode handling to reject incremental and redirect blob artifacts before opening them as standalone EROFS images, returning a clearer image-layout error instead of falling through to a bad EROFS magic failure.

## Test Results
```text
cargo fmt --all -- --check
cargo check --all --all-targets --all-features
cargo clippy --all --all-targets --all-features -- -D warnings
cargo test -p nydus-format blob::metadata -- --nocapture
cargo test -p nydus reject_non_standalone_blob -- --nocapture
```

## Change Type
- [x] Bug Fix
- [x] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.
