### PR TITLE
[v3] scripts: remove nydus crate from publish list

### DIFF
--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -23,7 +23,6 @@ CRATES=(
     nydus-backend
     nydus-storage
     nydus-core
-    nydus
 )
 
 DRY_RUN=0


### PR DESCRIPTION
The nydus crate is for nydus binary. There is no need to publish it.
