### PR TITLE
[v3] config: re-run the build script when the checked-out commit changes

### DIFF
--- a/nydus-config/build.rs
+++ b/nydus-config/build.rs
@@ -1,4 +1,5 @@
-use std::path::Path;
+use std::env;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Represents the git commit information.
@@ -10,11 +11,53 @@ struct Commit {
     date: String,
 }
 
+/// Resolves `path` inside the git directory to an absolute location.
+///
+/// `git rev-parse --git-path` follows `gitdir:` files of submodules and
+/// worktrees, and maps shared entries such as `refs/` and `packed-refs` to the
+/// common directory while `HEAD` stays per-worktree.
+fn git_path(path: &str) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .arg("rev-parse")
+        .arg("--git-path")
+        .arg(path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let path = PathBuf::from(String::from_utf8(output.stdout).ok()?.trim());
+    if path.is_absolute() {
+        Some(path)
+    } else {
+        Some(env::current_dir().ok()?.join(path))
+    }
+}
+
+/// Tells cargo to re-run this script whenever the checked-out commit changes,
+/// so the embedded version does not go stale between builds.
+fn emit_git_rerun_triggers() {
+    // `refs/heads` is declared as a whole directory so a loose ref written after
+    // `git gc` packed the branch is still noticed; `reftable` covers repositories
+    // using that ref backend. Missing paths must not be declared because cargo
+    // treats them as always stale and would re-run on every build.
+    for path in ["HEAD", "refs/heads", "packed-refs", "reftable"] {
+        if let Some(path) = git_path(path).filter(|path| path.exists()) {
+            println!("cargo:rerun-if-changed={}", path.display());
+        }
+    }
+}
+
 /// Returns the git commit information.
 fn get_commit_from_git() -> Option<Commit> {
+    // Only trust git when the crate sits inside the nydus source tree; a
+    // vendored copy inside some other repository must not report that
+    // repository's commit.
     if !Path::new("../.git").exists() {
         return None;
     }
+    emit_git_rerun_triggers();
 
     let output = match Command::new("git")
         .arg("log")


### PR DESCRIPTION
The build script embedded the git commit into GIT_COMMIT_SHORT_HASH and GIT_COMMIT_DATE without declaring any rerun-if-changed inputs, so cargo only re-ran it when a file inside nydus-config changed. Checking out or committing elsewhere in the tree kept the cached environment, and `nydus --version` reported the commit of an earlier build while the rest of the workspace had been recompiled from the new sources.

Declare HEAD, the refs/heads directory, packed-refs and reftable as build-script inputs, resolving each through `git rev-parse --git-path` so the `gitdir:` indirection of submodules and worktrees is followed and shared entries land in the common directory while HEAD stays per-worktree. The refs/heads directory is declared as a whole rather than the single branch file so a loose ref written after `git gc` packed the branch is still noticed. Only existing paths are declared because cargo treats a missing input as always stale and would re-run on every build. Building outside a source checkout still emits nothing and falls back to "unknown".