### PR TITLE
[v3] tests: strengthen EROFS mount coverage and replace erofsfuse dependency with kernel erofs

### DIFF
--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -24,28 +24,7 @@ var blobMetaFilenamePattern = regexp.MustCompile(`^[0-9a-f]{64}\.blob\.meta$`)
 
 const (
 	erofsCFuseEnv = "EROFS_C_FUSE"
-	erofsMkfsEnv  = "EROFS_MKFS"
 )
-
-// setupCErofsFuse checks if erofsfuse is available. An explicit EROFS_C_FUSE
-// path wins and skips the setup script.
-func setupCErofsFuse(t *testing.T) {
-	if _, err := lookupCErofsFuseExecutable(); err == nil {
-		if os.Getenv(erofsMkfsEnv) != "" {
-			_, err := lookupCErofsMkfsExecutable()
-			require.NoError(t, err)
-		}
-		return
-	} else if os.Getenv(erofsCFuseEnv) != "" {
-		require.NoError(t, err)
-	}
-
-	script, err := filepath.Abs(filepath.Join("..", "scripts", "setup_erofsfuse.sh"))
-	require.NoError(t, err)
-
-	out, err := exec.Command("bash", script).CombinedOutput()
-	require.NoError(t, err, "setup_erofsfuse.sh failed:\n%s", out)
-}
 
 // mustLookupExecutable is a test helper that wraps lookupExecutable and fails the test if the executable is not found.
 func mustLookupExecutable(t *testing.T, name string) string {
@@ -126,21 +105,6 @@ func lookupCErofsFuseExecutable() (string, error) {
 	}
 
 	return "", fmt.Errorf("erofsfuse not found, set %s=path to enable comparison", erofsCFuseEnv)
-}
-
-func lookupCErofsMkfsExecutable() (string, error) {
-	if p := os.Getenv(erofsMkfsEnv); p != "" {
-		if err := validateExecutablePath(p, erofsMkfsEnv); err != nil {
-			return "", err
-		}
-		return p, nil
-	}
-
-	if p, err := exec.LookPath("mkfs.erofs"); err == nil {
-		return p, nil
-	}
-
-	return "", fmt.Errorf("mkfs.erofs not found, set %s=path if a test requires it", erofsMkfsEnv)
 }
 
 // fsckErofsImage validates a freshly built bootstrap with erofs-utils. A nydus

--- a/tests/e2e/roundtrip_test.go
+++ b/tests/e2e/roundtrip_test.go
@@ -24,8 +24,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const nydusRunErofsCompatEnv = "NYDUSFS_RUN_EROFS_COMPAT"
-
 func erofsKernelCompatibilitySkipReason(release, filesystems string) (string, error) {
 	var major, minor int
 	if _, err := fmt.Sscanf(release, "%d.%d", &major, &minor); err != nil {
@@ -170,6 +168,16 @@ func verifyNativeErofsTree(t *testing.T, bootstrap, decodedDir, expected string)
 	fsckErofsImage(t, bootstrap, decodedDir)
 	deviceArgs, err := erofsDeviceArgs(bootstrap, decodedDir)
 	require.NoError(t, err)
+	devicePaths := make([]string, 0, len(deviceArgs))
+	for _, arg := range deviceArgs {
+		devicePaths = append(devicePaths, strings.TrimPrefix(arg, "--device="))
+	}
+	mountpoint := mountNativeErofs(t, bootstrap, devicePaths...)
+	roDiffTree(t, expected, mountpoint, true)
+}
+
+func mountNativeErofs(t *testing.T, bootstrap string, devicePaths ...string) string {
+	t.Helper()
 	mountpoint := filepath.Join(t.TempDir(), "mnt")
 	require.NoError(t, os.Mkdir(mountpoint, 0755))
 	mounted := false
@@ -189,8 +197,8 @@ func verifyNativeErofsTree(t *testing.T, bootstrap, decodedDir, expected string)
 	}
 	primary := attach(bootstrap)
 	options := []string{"ro"}
-	for _, arg := range deviceArgs {
-		options = append(options, "device="+attach(strings.TrimPrefix(arg, "--device=")))
+	for _, path := range devicePaths {
+		options = append(options, "device="+attach(path))
 	}
 	out, err := exec.Command("mount", "-t", "erofs", "-o", strings.Join(options, ","), primary, mountpoint).CombinedOutput()
 	require.NoError(t, err, "native EROFS mount: %s", out)
@@ -202,7 +210,7 @@ func verifyNativeErofsTree(t *testing.T, bootstrap, decodedDir, expected string)
 		}
 		mounted = false
 	})
-	roDiffTree(t, expected, mountpoint, true)
+	return mountpoint
 }
 
 func TestBlobMount(t *testing.T) {
@@ -303,42 +311,79 @@ func TestMergedMount(t *testing.T) {
 		roDiffTree(t, expectedDir, mountpoint, true)
 		verifyWhiteoutResults(t, mountpoint)
 		verifyBlobCacheArtifacts(t, cacheDir, layer1Blob, layer2Blob, layer3Blob)
-		verifyMergedMountMatchesErofsFuseWhenEnabled(
-			t,
-			mergedBootstrap,
-			mountpoint,
-			cachedBlobDataDevicesForBlobs(t, cacheDir, layer1Blob, layer2Blob, layer3Blob)...,
-		)
 		pauseMergeDebugIfRequested(t, mountpoint)
 	}()
 }
 
-func verifyMergedMountMatchesErofsFuseWhenEnabled(
-	t *testing.T,
-	mergedBootstrap string,
-	nydusMountpoint string,
-	blobs ...string,
-) {
-	t.Helper()
-	if os.Getenv(nydusRunErofsCompatEnv) != "1" {
-		t.Logf("Skipping erofsfuse compatibility step; set %s=1 to enable", nydusRunErofsCompatEnv)
-		return
+func TestMergedMountKernelErofsMatchesNydusFuse(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("requires root")
+	}
+	kernel, err := exec.Command("uname", "-r").Output()
+	require.NoError(t, err)
+	release := strings.TrimSpace(string(kernel))
+	filesystems, err := os.ReadFile("/proc/filesystems")
+	require.NoError(t, err)
+	reason, err := erofsKernelCompatibilitySkipReason(release, string(filesystems))
+	require.NoError(t, err)
+	if reason != "" {
+		t.Skip(reason)
+	}
+	for _, tool := range []string{"losetup", "mount"} {
+		_, err := exec.LookPath(tool)
+		require.NoError(t, err, "required native validation tool: %s", tool)
 	}
 
-	setupCErofsFuse(t)
-	cErofsFuseBin := mustLookupCErofsFuse(t)
-	erofsMountpoint := filepath.Join(t.TempDir(), "erofsfuse-mnt")
-	unmount := mountCErofsFuse(t, cErofsFuseBin, mergedBootstrap, erofsMountpoint, blobs...)
-	defer unmount()
+	tmpDir := t.TempDir()
+	layer1Dir := filepath.Join(tmpDir, "layer1")
+	layer2Dir := filepath.Join(tmpDir, "layer2")
+	layer3Dir := filepath.Join(tmpDir, "layer3")
+	expectedDir := filepath.Join(tmpDir, "expected")
+	nydusMountpoint := filepath.Join(tmpDir, "nydus-mnt")
+	prepareMergedE2ECorpora(t, layer1Dir, layer2Dir, layer3Dir, expectedDir)
 
-	roDiffTree(t, erofsMountpoint, nydusMountpoint, false)
+	nydusBin := mustLookupExecutable(t, "nydus")
+	blobDir := filepath.Join(tmpDir, "blobs")
+	layer1Bootstrap := filepath.Join(tmpDir, "layer1.bootstrap")
+	layer2Bootstrap := filepath.Join(tmpDir, "layer2.bootstrap")
+	layer3Bootstrap := filepath.Join(tmpDir, "layer3.bootstrap")
+	mergedBootstrap := filepath.Join(tmpDir, "merged.bootstrap")
+	cacheDir := filepath.Join(tmpDir, "cache")
+
+	layer1Blob := buildNydusFSImageToDir(t, nydusBin, layer1Bootstrap, blobDir, layer1Dir, 4096)
+	layer2Blob := buildNydusFSImageToDir(t, nydusBin, layer2Bootstrap, blobDir, layer2Dir, 4096)
+	layer3Blob := buildNydusFSImageToDir(t, nydusBin, layer3Bootstrap, blobDir, layer3Dir, 4096)
+	mergeNydusBootstrap(
+		t,
+		nydusBin,
+		mergedBootstrap,
+		layer1Blob,
+		layer2Blob,
+		layer3Blob,
+	)
+
+	unmountNydus := mountNydusBootstrapWithCache(t, nydusBin, mergedBootstrap, blobDir, cacheDir, nydusMountpoint)
+	defer unmountNydus()
+
+	// Full-tree walk against the expected merge prewarms cache data so the
+	// cached .blob.data devices can back a native kernel mount.
+	roDiffTree(t, expectedDir, nydusMountpoint, true)
+	verifyBlobCacheArtifacts(t, cacheDir, layer1Blob, layer2Blob, layer3Blob)
+
+	nativeMountpoint := mountNativeErofs(
+		t,
+		mergedBootstrap,
+		cachedBlobDataDevicesForBlobs(t, cacheDir, layer1Blob, layer2Blob, layer3Blob)...,
+	)
+	roDiffTree(t, nativeMountpoint, nydusMountpoint, true)
 }
 
 func cachedBlobDataDevicesForBlobs(t *testing.T, cacheDir string, blobs ...string) []string {
 	t.Helper()
 
-	// erofsfuse consumes plain external devices. Nydus builds zstd-compressed
-	// full blobs, so compat mode must use the cache files populated by nydus fuse.
+	// The kernel EROFS mount consumes plain external devices. Nydus builds
+	// zstd-compressed full blobs, so this path uses cache files populated by
+	// nydus fuse as decoded .blob.data devices.
 	devices := make([]string, 0, len(blobs))
 	for _, blob := range blobs {
 		blobID := fullBlobDigest(t, blob)


### PR DESCRIPTION
This commit removes the erofsfuse compatibility layer and replaces it with direct kernel EROFS mount validation. The changes eliminate the need for the external erofsfuse tool while maintaining comprehensive mount testing.

The key improvements include:
- Removing setupCErofsFuse() and related mkfs lookup functions that were only used for erofsfuse compatibility
- Refactoring verifyNativeErofsTree() to extract mountNativeErofs() as a reusable helper
- Adding TestMergedMountKernelErofsMatchesNydusFuse() that directly mounts EROFS images using the kernel driver
- Updating cachedBlobDataDevicesForBlobs() documentation to reflect the new kernel mount approach

This change simplifies the test infrastructure by relying on the kernel's native EROFS support rather than an external FUSE implementation, making tests more reliable and reducing external dependencies.