### PR TITLE
[v3] release: bump version to 3.0.0-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2877,7 +2877,7 @@ dependencies = [
 
 [[package]]
 name = "nydus"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-backend"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 dependencies = [
  "arc-swap",
  "blake3",
@@ -2945,7 +2945,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-config"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 dependencies = [
  "clap",
  "humantime-serde",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-core"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 dependencies = [
  "libc",
  "memmap2",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-error"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 dependencies = [
  "libc",
  "nydus-format",
@@ -2985,7 +2985,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-format"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 dependencies = [
  "bitflags 2.11.0",
  "blake3",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-storage"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 dependencies = [
  "blake3",
  "crc32c",
@@ -3021,7 +3021,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-telemetry"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 dependencies = [
  "prometheus",
  "rolling-file",

--- a/nydus-backend/Cargo.toml
+++ b/nydus-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus-backend"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"
@@ -30,9 +30,9 @@ arc-swap = { version = "1", optional = true }
 dragonfly-client-request = { version = "=1.4.0", optional = true }
 futures = { version = "0.3", optional = true }
 libc = { workspace = true }
-nydus-config = { version = "3.0.0-alpha.1", path = "../nydus-config" }
-nydus-format = { version = "3.0.0-alpha.1", path = "../nydus-format" }
-nydus-telemetry = { version = "3.0.0-alpha.1", path = "../nydus-telemetry" }
+nydus-config = { version = "3.0.0-alpha.2", path = "../nydus-config" }
+nydus-format = { version = "3.0.0-alpha.2", path = "../nydus-format" }
+nydus-telemetry = { version = "3.0.0-alpha.2", path = "../nydus-telemetry" }
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls",
   "stream",

--- a/nydus-config/Cargo.toml
+++ b/nydus-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus-config"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 clap = { workspace = true }
 humantime-serde = "1"
-nydus-error = { version = "3.0.0-alpha.1", path = "../nydus-error" }
+nydus-error = { version = "3.0.0-alpha.2", path = "../nydus-error" }
 rustls-pki-types = { version = "1", features = ["std"] }
 serde = { workspace = true }
 serde_yaml = "0.9"

--- a/nydus-core/Cargo.toml
+++ b/nydus-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus-core"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"
@@ -12,11 +12,11 @@ readme = "README.md"
 zstd = "0.13"
 libc = { workspace = true }
 memmap2 = { workspace = true }
-nydus-backend = { version = "3.0.0-alpha.1", path = "../nydus-backend" }
-nydus-config = { version = "3.0.0-alpha.1", path = "../nydus-config" }
-nydus-error = { version = "3.0.0-alpha.1", path = "../nydus-error" }
-nydus-format = { version = "3.0.0-alpha.1", path = "../nydus-format" }
-nydus-storage = { version = "3.0.0-alpha.1", path = "../nydus-storage" }
+nydus-backend = { version = "3.0.0-alpha.2", path = "../nydus-backend" }
+nydus-config = { version = "3.0.0-alpha.2", path = "../nydus-config" }
+nydus-error = { version = "3.0.0-alpha.2", path = "../nydus-error" }
+nydus-format = { version = "3.0.0-alpha.2", path = "../nydus-format" }
+nydus-storage = { version = "3.0.0-alpha.2", path = "../nydus-storage" }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/nydus-error/Cargo.toml
+++ b/nydus-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus-error"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ readme = "README.md"
 default = []
 
 [dependencies]
-nydus-format = { version = "3.0.0-alpha.1", path = "../nydus-format" }
+nydus-format = { version = "3.0.0-alpha.2", path = "../nydus-format" }
 serde_json = { workspace = true }
 serde_yaml = "0.9"
 thiserror = { workspace = true }

--- a/nydus-format/Cargo.toml
+++ b/nydus-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus-format"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"

--- a/nydus-storage/Cargo.toml
+++ b/nydus-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus-storage"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"
@@ -12,10 +12,10 @@ readme = "README.md"
 crc32c = "0.6"
 libc = { workspace = true }
 memmap2 = { workspace = true }
-nydus-backend = { version = "3.0.0-alpha.1", path = "../nydus-backend" }
-nydus-config = { version = "3.0.0-alpha.1", path = "../nydus-config" }
-nydus-format = { version = "3.0.0-alpha.1", path = "../nydus-format" }
-nydus-telemetry = { version = "3.0.0-alpha.1", path = "../nydus-telemetry" }
+nydus-backend = { version = "3.0.0-alpha.2", path = "../nydus-backend" }
+nydus-config = { version = "3.0.0-alpha.2", path = "../nydus-config" }
+nydus-format = { version = "3.0.0-alpha.2", path = "../nydus-format" }
+nydus-telemetry = { version = "3.0.0-alpha.2", path = "../nydus-telemetry" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/nydus-telemetry/Cargo.toml
+++ b/nydus-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus-telemetry"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"

--- a/nydus/Cargo.toml
+++ b/nydus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "EROFS-oriented image tooling and runtime core APIs for Nydus images."
@@ -68,13 +68,13 @@ hyper-util = { version = "0.1", features = ["tokio"], optional = true }
 libc = { workspace = true }
 libublk = { version = "0.4", default-features = false, optional = true }
 memmap2 = { workspace = true }
-nydus-backend = { version = "3.0.0-alpha.1", path = "../nydus-backend" }
-nydus-config = { version = "3.0.0-alpha.1", path = "../nydus-config" }
-nydus-error = { version = "3.0.0-alpha.1", path = "../nydus-error" }
-nydus-format = { version = "3.0.0-alpha.1", path = "../nydus-format" }
-nydus-core = { version = "3.0.0-alpha.1", path = "../nydus-core" }
-nydus-storage = { version = "3.0.0-alpha.1", path = "../nydus-storage" }
-nydus-telemetry = { version = "3.0.0-alpha.1", path = "../nydus-telemetry", features = [
+nydus-backend = { version = "3.0.0-alpha.2", path = "../nydus-backend" }
+nydus-config = { version = "3.0.0-alpha.2", path = "../nydus-config" }
+nydus-error = { version = "3.0.0-alpha.2", path = "../nydus-error" }
+nydus-format = { version = "3.0.0-alpha.2", path = "../nydus-format" }
+nydus-core = { version = "3.0.0-alpha.2", path = "../nydus-core" }
+nydus-storage = { version = "3.0.0-alpha.2", path = "../nydus-storage" }
+nydus-telemetry = { version = "3.0.0-alpha.2", path = "../nydus-telemetry", features = [
   "logging",
 ] }
 serde = { workspace = true }


### PR DESCRIPTION
Update all workspace crates from version 3.0.0-alpha.1 to 3.0.0-alpha.2 in preparation for the next alpha release. This includes updating version fields in Cargo.toml files and corresponding dependency references across all nydus components.
